### PR TITLE
refactor: migrate titlebar/sidebar/settings surfaces to React (#9)

### DIFF
--- a/FEATURE_MAPPING.md
+++ b/FEATURE_MAPPING.md
@@ -9,7 +9,7 @@ This document maps `pi-mono/packages/coding-agent` capabilities to this Tauri de
 | `pi --mode rpc` JSON protocol | ✅ Core transport used by app (`src/rpc/bridge.ts` + Rust process manager) |
 | Cross-platform binary/process execution | ✅ Tauri Rust backend discovers `pi` via dev path → bundled sidecar → PATH |
 | Native-like custom frame | ✅ Custom draggable titlebar + native window controls |
-| Frontend architecture for OSS scaling | ✅ React entrypoint (`src/main.tsx`) with legacy Lit host bridge during migration (`src/legacy-bootstrap.ts`) |
+| Frontend architecture for OSS scaling | ✅ React entrypoint (`src/main.tsx`) + React-rendered core surfaces (`titlebar`, `sidebar`, `settings-panel`) with remaining Lit bridge (`src/legacy-bootstrap.ts`) |
 | Session files in `~/.pi/agent/sessions` | ✅ Indexed via Rust backend (`list_sessions`) for sidebar/session browser |
 
 ## 2) Chat + Agent Loop

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pi Desktop
 
-A native-feeling, cross-platform desktop client for the **pi coding agent** CLI, built with **Tauri 2 + Rust + React** (with legacy Lit components during migration).
+A native-feeling, cross-platform desktop client for the **pi coding agent** CLI, built with **Tauri 2 + Rust + React** (with remaining Lit surfaces during migration).
 
 Pi Desktop uses `pi --mode rpc` under the hood and maps core CLI capabilities into a desktop UI.
 
@@ -69,7 +69,7 @@ App bundles land in:
 ## Architecture
 
 - **Frontend**: React (entrypoint/app shell) + Tailwind CSS utilities + custom CSS
-- **UI migration state**: legacy Lit component surfaces are currently hosted via a React bridge and being migrated incrementally
+- **UI migration state**: React-first entrypoint + incremental Lit-to-React surface migration (titlebar/sidebar/settings already React-rendered)
 - **Backend**: Rust (Tauri command bridge + package command runner)
 - **Protocol**: JSON-lines RPC over stdin/stdout to `pi --mode rpc`
 
@@ -91,8 +91,9 @@ The project is now **React-first at the entrypoint level** (`src/main.tsx`) to s
 
 Current status:
 - React hosts the desktop shell mount point
-- Existing Lit components are still active through `src/legacy-bootstrap.ts`
-- Active migration tracking issue: **#7**
+- `titlebar`, `sidebar`, and `settings-panel` are React-rendered surfaces
+- `chat-view` and legacy app orchestration are still Lit-based through `src/legacy-bootstrap.ts`
+- Active migration tracking issues: **#7**, **#9**, **#10**
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,18 +1,18 @@
 # TODO (Issue Mirror)
 
 ## Active issue
-- Issue: #7 — [P0] React-first frontend migration foundation (Lit -> React)
-- Branch: feat/7-react-foundation
-- Scope summary: Prioritized execution of React-first frontend foundation before deeper feature work.
+- Issue: #9 — [P0] Migrate core UI surfaces from Lit to React (chat/sidebar/settings/titlebar)
+- Branch: feat/9-react-core-surfaces
+- Scope summary: Migrate high-change core surfaces to React while preserving parity.
 
 ## Acceptance criteria (from issue)
-- [x] Frontend boots through React entrypoint
-- [x] Existing functionality still works in tauri dev smoke flow
-- [x] Docs clearly describe transition status and next migration steps
-- [x] Follow-up migration tasks tracked in issues/PRs
+- [ ] Core migrated surfaces are React-based
+- [ ] Feature parity with existing behavior is preserved
+- [x] `npm run check`, `npm run build:frontend`, `cargo check` pass
+- [x] tauri dev startup smoke pass for migrated flows
 
 ## Session checklist
-- [x] Implementation done
+- [x] Implementation done (partial: titlebar/sidebar/settings migrated)
 - [x] `npm run check` passed
 - [x] `npm run build:frontend` passed
 - [x] `cargo check` passed
@@ -21,6 +21,6 @@
 - [ ] PR opened/updated
 
 ## Session notes
-- Added React + ReactDOM + Vite React plugin and switched entrypoint to `src/main.tsx`.
-- Moved previous Lit bootstrap to `src/legacy-bootstrap.ts` and mounted it from React host.
-- Updated roadmap/release/docs to reflect React-first transition and migration guardrails.
+- Migrated `titlebar`, `sidebar`, and `settings-panel` components from Lit rendering to React rendering while preserving class APIs.
+- Added `.tsx` React implementations and removed legacy `.ts` Lit versions for those surfaces.
+- `chat-view` remains Lit-based and is still pending under this issue scope.

--- a/src/components/settings-panel.tsx
+++ b/src/components/settings-panel.tsx
@@ -2,7 +2,8 @@
  * Settings Panel - runtime controls for RPC session + app preferences
  */
 
-import { html, render, type TemplateResult } from "lit";
+import { type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import {
 	type CliUpdateStatus,
 	type PiAuthStatus,
@@ -21,6 +22,7 @@ interface SettingsState {
 
 export class SettingsPanel {
 	private container: HTMLElement;
+	private root: Root;
 	private isOpen = false;
 	private state: SettingsState = {
 		theme: "dark",
@@ -43,6 +45,7 @@ export class SettingsPanel {
 
 	constructor(container: HTMLElement) {
 		this.container = container;
+		this.root = createRoot(container);
 		this.loadTheme();
 	}
 
@@ -102,11 +105,7 @@ export class SettingsPanel {
 			// ignore missing persisted settings
 		}
 
-		await Promise.all([
-			this.refreshAuthStatus(),
-			this.refreshCliStatus(),
-			this.refreshCompatibilityStatus(),
-		]);
+		await Promise.all([this.refreshAuthStatus(), this.refreshCliStatus(), this.refreshCompatibilityStatus()]);
 	}
 
 	private async refreshAuthStatus(): Promise<void> {
@@ -274,188 +273,233 @@ export class SettingsPanel {
 		description: string,
 		checked: boolean,
 		onChange: (checked: boolean) => void,
-	): TemplateResult {
-		return html`
-			<div class="settings-row">
+	): ReactElement {
+		return (
+			<div className="settings-row">
 				<div>
-					<div class="settings-label">${label}</div>
-					<div class="settings-desc">${description}</div>
+					<div className="settings-label">{label}</div>
+					<div className="settings-desc">{description}</div>
 				</div>
-				<button class="toggle ${checked ? "on" : "off"}" @click=${() => onChange(!checked)}>
+				<button className={`toggle ${checked ? "on" : "off"}`} onClick={() => onChange(!checked)} type="button">
 					<span></span>
 				</button>
 			</div>
-		`;
+		);
 	}
 
 	render(): void {
 		if (!this.isOpen) {
-			this.container.innerHTML = "";
+			this.root.render(<></>);
 			return;
 		}
 
-		const template = html`
-			<div class="overlay" @click=${(e: Event) => e.target === e.currentTarget && this.close()}>
-				<div class="settings-card">
-					<div class="settings-header">
+		this.root.render(
+			<div
+				className="overlay"
+				onClick={(e) => {
+					if (e.target === e.currentTarget) this.close();
+				}}
+			>
+				<div className="settings-card">
+					<div className="settings-header">
 						<h2>Settings</h2>
-						<button @click=${() => this.close()}>✕</button>
+						<button onClick={() => this.close()} type="button">
+							✕
+						</button>
 					</div>
 
-					<div class="settings-section">
-						<div class="settings-section-title">Appearance</div>
-						<div class="theme-grid">
-							<button class="theme-btn ${this.state.theme === "dark" ? "active" : ""}" @click=${() => this.setTheme("dark")}>Dark</button>
-							<button class="theme-btn ${this.state.theme === "light" ? "active" : ""}" @click=${() => this.setTheme("light")}>Light</button>
+					<div className="settings-section">
+						<div className="settings-section-title">Appearance</div>
+						<div className="theme-grid">
+							<button
+								className={`theme-btn ${this.state.theme === "dark" ? "active" : ""}`}
+								onClick={() => void this.setTheme("dark")}
+								type="button"
+							>
+								Dark
+							</button>
+							<button
+								className={`theme-btn ${this.state.theme === "light" ? "active" : ""}`}
+								onClick={() => void this.setTheme("light")}
+								type="button"
+							>
+								Light
+							</button>
 						</div>
 					</div>
 
-					<div class="settings-section">
-						<div class="settings-section-title">Agent Behavior</div>
-						${this.renderToggle(
+					<div className="settings-section">
+						<div className="settings-section-title">Agent Behavior</div>
+						{this.renderToggle(
 							"Auto-compaction",
 							"Automatically summarize older context before hitting context limits.",
 							this.state.autoCompactionEnabled,
-							(v) => this.setAutoCompaction(v),
+							(v) => void this.setAutoCompaction(v),
 						)}
-						${this.renderToggle(
+						{this.renderToggle(
 							"Auto-retry",
 							"Retry transient provider errors with exponential backoff.",
 							this.state.autoRetryEnabled,
-							(v) => this.setAutoRetry(v),
+							(v) => void this.setAutoRetry(v),
 						)}
 					</div>
 
-					<div class="settings-section">
-						<div class="settings-section-title">Queue Modes</div>
-						<div class="settings-row">
+					<div className="settings-section">
+						<div className="settings-section-title">Queue Modes</div>
+						<div className="settings-row">
 							<div>
-								<div class="settings-label">Steering messages</div>
-								<div class="settings-desc">How queued steer messages are delivered while streaming.</div>
+								<div className="settings-label">Steering messages</div>
+								<div className="settings-desc">How queued steer messages are delivered while streaming.</div>
 							</div>
-							<select class="settings-select" .value=${this.state.steeringMode} @change=${(e: Event) => this.setSteeringMode((e.target as HTMLSelectElement).value as QueueMode)}>
+							<select
+								className="settings-select"
+								value={this.state.steeringMode}
+								onChange={(e) => void this.setSteeringMode(e.target.value as QueueMode)}
+							>
 								<option value="one-at-a-time">one-at-a-time</option>
 								<option value="all">all</option>
 							</select>
 						</div>
-						<div class="settings-row">
+						<div className="settings-row">
 							<div>
-								<div class="settings-label">Follow-up messages</div>
-								<div class="settings-desc">How queued follow-up messages are delivered after runs.</div>
+								<div className="settings-label">Follow-up messages</div>
+								<div className="settings-desc">How queued follow-up messages are delivered after runs.</div>
 							</div>
-							<select class="settings-select" .value=${this.state.followUpMode} @change=${(e: Event) => this.setFollowUpMode((e.target as HTMLSelectElement).value as QueueMode)}>
+							<select
+								className="settings-select"
+								value={this.state.followUpMode}
+								onChange={(e) => void this.setFollowUpMode(e.target.value as QueueMode)}
+							>
 								<option value="one-at-a-time">one-at-a-time</option>
 								<option value="all">all</option>
 							</select>
 						</div>
 					</div>
 
-					<div class="settings-section">
-						<div class="settings-section-title">Account & Resources</div>
-						${this.authLoading
-							? html`<div class="settings-desc">Checking auth status…</div>`
-							: html`
-								<div class="settings-desc">
-									${this.authStatus && this.authStatus.configured_providers.length > 0
+					<div className="settings-section">
+						<div className="settings-section-title">Account &amp; Resources</div>
+						{this.authLoading ? <div className="settings-desc">Checking auth status…</div> : null}
+						{!this.authLoading ? (
+							<>
+								<div className="settings-desc">
+									{this.authStatus && this.authStatus.configured_providers.length > 0
 										? `Configured providers: ${this.authStatus.configured_providers.length}`
 										: "No providers configured yet."}
 								</div>
-								<div class="settings-actions">
-									<button class="ghost-btn" @click=${() => this.refreshAuthStatus()}>Refresh auth status</button>
+								<div className="settings-actions">
+									<button className="ghost-btn" onClick={() => void this.refreshAuthStatus()} type="button">
+										Refresh auth status
+									</button>
 								</div>
-								${this.authStatus && this.authStatus.configured_providers.length > 0
-									? html`
-										<div class="account-chips">
-											${this.authStatus.configured_providers.map(
-												(p) => html`<span class="account-chip">${p.provider} · ${p.source === "environment" ? "env" : p.kind}</span>`,
-											)}
-										</div>
-									`
-									: null}
-								<div class="settings-desc">
-									OAuth <code>/login</code> is interactive-only in TUI mode. Configure auth once in terminal
-									(or set API keys) then restart desktop.
+								{this.authStatus && this.authStatus.configured_providers.length > 0 ? (
+									<div className="account-chips">
+										{this.authStatus.configured_providers.map((p) => (
+											<span className="account-chip" key={`${p.provider}-${p.source}-${p.kind}`}>
+												{p.provider} · {p.source === "environment" ? "env" : p.kind}
+											</span>
+										))}
+									</div>
+								) : null}
+								<div className="settings-desc">
+									OAuth <code>/login</code> is interactive-only in TUI mode. Configure auth once in terminal (or set API keys)
+									then restart desktop.
 								</div>
-								${this.authStatus?.auth_file
-									? html`<div class="settings-desc">Auth file: <code>${this.authStatus.auth_file}</code></div>`
-									: null}
-							`}
+								{this.authStatus?.auth_file ? (
+									<div className="settings-desc">
+										Auth file: <code>{this.authStatus.auth_file}</code>
+									</div>
+								) : null}
+							</>
+						) : null}
 					</div>
 
-					<div class="settings-section">
-						<div class="settings-section-title">CLI Runtime</div>
-						${this.cliLoading
-							? html`<div class="settings-desc">Checking CLI versions…</div>`
-							: html`
-								<div class="settings-desc">
-									Discovery: <code>${this.cliStatus?.discovery || rpcBridge.discoveryInfo || "unknown"}</code>
+					<div className="settings-section">
+						<div className="settings-section-title">CLI Runtime</div>
+						{this.cliLoading ? <div className="settings-desc">Checking CLI versions…</div> : null}
+						{!this.cliLoading ? (
+							<>
+								<div className="settings-desc">
+									Discovery: <code>{this.cliStatus?.discovery || rpcBridge.discoveryInfo || "unknown"}</code>
 								</div>
-								<div class="settings-desc">
-									Current: <code>${this.cliStatus?.current_version || "unknown"}</code>
-									 · Latest: <code>${this.cliStatus?.latest_version || "unknown"}</code>
+								<div className="settings-desc">
+									Current: <code>{this.cliStatus?.current_version || "unknown"}</code> · Latest: <code>{this.cliStatus?.latest_version || "unknown"}</code>
 								</div>
-								${this.cliStatus?.update_available
-									? html`<div class="settings-desc">A newer CLI version is available.</div>`
-									: html`<div class="settings-desc">CLI is up to date or latest version could not be determined.</div>`}
-								${this.cliStatus?.note ? html`<div class="settings-desc">${this.cliStatus.note}</div>` : null}
-							`}
-						<div class="settings-actions">
-							<button class="ghost-btn" ?disabled=${this.cliLoading} @click=${() => this.refreshCliStatus()}>Refresh CLI status</button>
+								{this.cliStatus?.update_available ? (
+									<div className="settings-desc">A newer CLI version is available.</div>
+								) : (
+									<div className="settings-desc">CLI is up to date or latest version could not be determined.</div>
+								)}
+								{this.cliStatus?.note ? <div className="settings-desc">{this.cliStatus.note}</div> : null}
+							</>
+						) : null}
+
+						<div className="settings-actions">
+							<button className="ghost-btn" disabled={this.cliLoading} onClick={() => void this.refreshCliStatus()} type="button">
+								Refresh CLI status
+							</button>
 							<button
-								class="ghost-btn"
-								?disabled=${
+								className="ghost-btn"
+								disabled={
 									this.cliUpdating ||
 									!this.cliStatus?.can_update_in_app ||
 									!this.cliStatus?.npm_available ||
 									!this.cliStatus?.update_available
 								}
-								@click=${() => this.updateCliNow()}
+								onClick={() => void this.updateCliNow()}
+								type="button"
 							>
-								${this.cliUpdating ? "Updating…" : "Update CLI"}
+								{this.cliUpdating ? "Updating…" : "Update CLI"}
 							</button>
 						</div>
-						${this.cliActionMessage ? html`<div class="settings-desc">${this.cliActionMessage}</div>` : null}
-						${this.cliStatus?.update_command
-							? html`<div class="settings-desc">Manual update: <code>${this.cliStatus.update_command}</code></div>`
-							: null}
-						<div class="settings-actions">
-							<button class="ghost-btn" ?disabled=${this.compatibilityLoading} @click=${() => this.refreshCompatibilityStatus()}>
-								${this.compatibilityLoading ? "Checking RPC…" : "Run RPC compatibility check"}
+						{this.cliActionMessage ? <div className="settings-desc">{this.cliActionMessage}</div> : null}
+						{this.cliStatus?.update_command ? (
+							<div className="settings-desc">
+								Manual update: <code>{this.cliStatus.update_command}</code>
+							</div>
+						) : null}
+
+						<div className="settings-actions">
+							<button
+								className="ghost-btn"
+								disabled={this.compatibilityLoading}
+								onClick={() => void this.refreshCompatibilityStatus()}
+								type="button"
+							>
+								{this.compatibilityLoading ? "Checking RPC…" : "Run RPC compatibility check"}
 							</button>
 						</div>
-						${this.compatibilityReport
-							? html`
-								<div class="settings-desc">RPC compatibility: ${this.compatibilityReport.ok ? "OK" : "Failed"}</div>
-								${this.compatibilityReport.checks.length > 0
-									? html`<div class="settings-desc">Required checks passed: ${this.compatibilityReport.checks.join(", ")}</div>`
-									: null}
-								${this.compatibilityReport.failedChecks.length > 0
-									? html`<div class="settings-desc">Required checks failed: ${this.compatibilityReport.failedChecks.join(", ")}</div>`
-									: null}
-								${this.compatibilityReport.optionalWarnings.length > 0
-									? html`
-										<div class="settings-desc">Optional capability warnings:</div>
-										<div class="settings-desc">
-											${this.compatibilityReport.optionalWarnings.map((w) => html`<div>• ${w}</div>`)}
+
+						{this.compatibilityReport ? (
+							<>
+								<div className="settings-desc">RPC compatibility: {this.compatibilityReport.ok ? "OK" : "Failed"}</div>
+								{this.compatibilityReport.checks.length > 0 ? (
+									<div className="settings-desc">Required checks passed: {this.compatibilityReport.checks.join(", ")}</div>
+								) : null}
+								{this.compatibilityReport.failedChecks.length > 0 ? (
+									<div className="settings-desc">Required checks failed: {this.compatibilityReport.failedChecks.join(", ")}</div>
+								) : null}
+								{this.compatibilityReport.optionalWarnings.length > 0 ? (
+									<>
+										<div className="settings-desc">Optional capability warnings:</div>
+										<div className="settings-desc">
+											{this.compatibilityReport.optionalWarnings.map((w) => (
+												<div key={w}>• {w}</div>
+											))}
 										</div>
-									`
-									: null}
-								${this.compatibilityReport.error
-									? html`<div class="settings-desc">${this.compatibilityReport.error}</div>`
-									: null}
-							`
-							: null}
+									</>
+								) : null}
+								{this.compatibilityReport.error ? <div className="settings-desc">{this.compatibilityReport.error}</div> : null}
+							</>
+						) : null}
 					</div>
 
-					${this.statusMessage ? html`<div class="settings-desc">${this.statusMessage}</div>` : null}
+					{this.statusMessage ? <div className="settings-desc">{this.statusMessage}</div> : null}
 				</div>
-			</div>
-		`;
-
-		render(template, this.container);
+			</div>,
+		);
 	}
 
 	destroy(): void {
-		this.container.innerHTML = "";
+		this.root.unmount();
 	}
 }

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -2,7 +2,8 @@
  * Sidebar - Codex-inspired project navigator
  */
 
-import { html, nothing, render } from "lit";
+import { type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
 
 interface SidebarSession {
 	id: string;
@@ -67,8 +68,142 @@ function formatCost(cost: number): string {
 	return `$${cost.toFixed(2)}`;
 }
 
+interface SidebarViewProps {
+	projects: Project[];
+	activeId: string | null;
+	onOpenExtensions: () => void;
+	onOpenSettings: () => void;
+	onOpenFolder: () => void;
+	onSelectProject: (projectId: string) => void;
+	onToggleProject: (projectId: string) => void;
+	onNewSessionInProject: (projectId: string) => void;
+	onRemoveProject: (projectId: string) => void;
+	onSelectSession: (projectId: string, sessionPath: string) => void;
+}
+
+function SidebarView(props: SidebarViewProps): ReactElement {
+	return (
+		<div className="h-full bg-[#171717] border-r border-[#262626] flex flex-col w-64">
+			<div className="p-2 border-b border-[#262626] space-y-1">
+				<button
+					className="w-full flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-[#262626] transition-colors text-left"
+					onClick={props.onOpenExtensions}
+					type="button"
+				>
+					<span className="text-amber-400">⚡</span>
+					<span className="text-sm text-gray-200">Resources</span>
+				</button>
+			</div>
+
+			<div className="flex-1 overflow-y-auto p-2">
+				<div className="flex items-center justify-between px-2 mb-2">
+					<span className="text-[11px] uppercase tracking-wide text-gray-500">Projects</span>
+					<button className="text-gray-500 hover:text-gray-300 text-xs" onClick={props.onOpenFolder} title="Open project" type="button">
+						+
+					</button>
+				</div>
+
+				{props.projects.length === 0 ? (
+					<div className="px-2 py-2 text-xs text-gray-500">No projects</div>
+				) : (
+					props.projects.map((project) => (
+						<div className="mb-1" key={project.id}>
+							<div className="group flex items-center gap-1">
+								<button
+									className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-lg transition-colors ${
+										props.activeId === project.id ? "bg-[#262626]" : "hover:bg-[#222]"
+									}`}
+									onClick={() => {
+										props.onSelectProject(project.id);
+										props.onToggleProject(project.id);
+									}}
+									type="button"
+								>
+									<span className="w-2 h-2 rounded-full shrink-0" style={{ background: project.color }}></span>
+									<span className="text-sm text-gray-200 truncate flex-1 text-left">{project.name}</span>
+									<span className="text-gray-500 text-xs">{project.expanded ? "▾" : "▸"}</span>
+								</button>
+								<button
+									className="opacity-0 group-hover:opacity-100 text-gray-500 hover:text-blue-400 text-xs px-1.5"
+									onClick={(e) => {
+										e.stopPropagation();
+										props.onNewSessionInProject(project.id);
+									}}
+									title="New session in project"
+									type="button"
+								>
+									+
+								</button>
+								<button
+									className="opacity-0 group-hover:opacity-100 text-gray-500 hover:text-red-400 text-xs px-1.5"
+									onClick={(e) => {
+										e.stopPropagation();
+										props.onRemoveProject(project.id);
+									}}
+									title="Remove project"
+									type="button"
+								>
+									✕
+								</button>
+							</div>
+
+							{project.expanded ? (
+								<div className="ml-4 mt-1 space-y-0.5">
+									{project.loadingSessions ? (
+										<div className="px-2 py-1 text-[11px] text-gray-500">Loading sessions...</div>
+									) : project.sessions.length === 0 ? (
+										<div className="px-2 py-1 text-[11px] text-gray-500">No sessions</div>
+									) : (
+										project.sessions.map((session) => (
+											<button
+												className="w-full flex items-center justify-between px-2 py-1 rounded hover:bg-[#222] text-left"
+												onClick={() => props.onSelectSession(project.id, session.path)}
+												title={session.path}
+												type="button"
+												key={session.id}
+											>
+												<div className="min-w-0">
+													<div className="text-[11px] text-gray-400 truncate">{session.name}</div>
+													<div className="text-[10px] text-gray-600">
+														{formatTokens(session.tokens)} · {formatCost(session.cost)}
+													</div>
+												</div>
+												<span className="text-[10px] text-gray-600 ml-2">{formatRelativeDate(session.modifiedAt)}</span>
+											</button>
+										))
+									)}
+								</div>
+							) : null}
+						</div>
+					))
+				)}
+			</div>
+
+			<div className="p-2 border-t border-[#262626] space-y-1">
+				<button
+					className="w-full flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-[#262626] transition-colors text-left"
+					onClick={props.onOpenFolder}
+					type="button"
+				>
+					<span className="text-gray-400">📁</span>
+					<span className="text-sm text-gray-300">Open Folder</span>
+				</button>
+				<button
+					className="w-full flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-[#262626] transition-colors text-left"
+					onClick={props.onOpenSettings}
+					type="button"
+				>
+					<span className="text-gray-400">⚙️</span>
+					<span className="text-sm text-gray-300">Settings</span>
+				</button>
+			</div>
+		</div>
+	);
+}
+
 export class Sidebar {
 	private container: HTMLElement;
+	private root: Root;
 	private projects: Project[] = [];
 	private activeProjectId: string | null = null;
 
@@ -80,6 +215,7 @@ export class Sidebar {
 
 	constructor(container: HTMLElement) {
 		this.container = container;
+		this.root = createRoot(container);
 		this.loadPersistedProjects();
 		this.render();
 	}
@@ -167,7 +303,7 @@ export class Sidebar {
 		if (!project) return;
 		project.expanded = !project.expanded;
 		if (project.expanded && project.sessions.length === 0) {
-			this.loadSessionsForProject(projectId);
+			void this.loadSessionsForProject(projectId);
 		}
 		this.render();
 	}
@@ -180,15 +316,17 @@ export class Sidebar {
 
 		try {
 			const { invoke } = await import("@tauri-apps/api/core");
-			const sessions = await invoke<Array<{
-				id: string;
-				name: string | null;
-				path: string;
-				cwd: string | null;
-				modified_at: number;
-				tokens: number;
-				cost: number;
-			}>>("list_sessions");
+			const sessions = await invoke<
+				Array<{
+					id: string;
+					name: string | null;
+					path: string;
+					cwd: string | null;
+					modified_at: number;
+					tokens: number;
+					cost: number;
+				}>
+			>("list_sessions");
 
 			const projectPath = normalizePath(project.path);
 			const byProject = sessions.filter((s) => {
@@ -221,8 +359,7 @@ export class Sidebar {
 		this.onSessionSelect?.(projectId, sessionPath);
 	}
 
-	private newSessionInProject(projectId: string, e: Event): void {
-		e.stopPropagation();
+	private newSessionInProject(projectId: string): void {
 		const project = this.projects.find((p) => p.id === projectId);
 		if (!project) return;
 		this.activeProjectId = project.id;
@@ -234,8 +371,7 @@ export class Sidebar {
 		}, 900);
 	}
 
-	private removeProject(projectId: string, e: Event): void {
-		e.stopPropagation();
+	private removeProject(projectId: string): void {
 		this.projects = this.projects.filter((p) => p.id !== projectId);
 		if (this.activeProjectId === projectId) {
 			this.activeProjectId = this.projects[0]?.id ?? null;
@@ -277,122 +413,23 @@ export class Sidebar {
 	}
 
 	render(): void {
-		const activeId = this.activeProjectId;
+		this.root.render(
+			<SidebarView
+				projects={this.projects}
+				activeId={this.activeProjectId}
+				onOpenExtensions={() => this.onOpenExtensions?.()}
+				onOpenSettings={() => this.onOpenSettings?.()}
+				onOpenFolder={() => void this.openFolder()}
+				onSelectProject={(projectId) => this.selectProject(projectId)}
+				onToggleProject={(projectId) => this.toggleProject(projectId)}
+				onNewSessionInProject={(projectId) => this.newSessionInProject(projectId)}
+				onRemoveProject={(projectId) => this.removeProject(projectId)}
+				onSelectSession={(projectId, sessionPath) => this.selectSession(projectId, sessionPath)}
+			/>,
+		);
+	}
 
-		const template = html`
-			<div class="h-full bg-[#171717] border-r border-[#262626] flex flex-col w-64">
-				<!-- Top Actions -->
-				<div class="p-2 border-b border-[#262626] space-y-1">
-					<button
-						class="w-full flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-[#262626] transition-colors text-left"
-						@click=${() => this.onOpenExtensions?.()}
-					>
-						<span class="text-amber-400">⚡</span>
-						<span class="text-sm text-gray-200">Resources</span>
-					</button>
-				</div>
-
-				<!-- Projects -->
-				<div class="flex-1 overflow-y-auto p-2">
-					<div class="flex items-center justify-between px-2 mb-2">
-						<span class="text-[11px] uppercase tracking-wide text-gray-500">Projects</span>
-						<button
-							class="text-gray-500 hover:text-gray-300 text-xs"
-							@click=${() => this.openFolder()}
-							title="Open project"
-						>
-							+
-						</button>
-					</div>
-
-					${this.projects.length === 0
-						? html`<div class="px-2 py-2 text-xs text-gray-500">No projects</div>`
-						: this.projects.map(
-								(project) => html`
-									<div class="mb-1">
-										<div class="group flex items-center gap-1">
-											<button
-												class="w-full flex items-center gap-2 px-2 py-1.5 rounded-lg transition-colors ${
-													activeId === project.id ? "bg-[#262626]" : "hover:bg-[#222]"
-												}"
-												@click=${() => {
-													this.selectProject(project.id);
-													this.toggleProject(project.id);
-												}}
-											>
-												<span class="w-2 h-2 rounded-full shrink-0" style="background:${project.color}"></span>
-												<span class="text-sm text-gray-200 truncate flex-1 text-left">${project.name}</span>
-												<span class="text-gray-500 text-xs">${project.expanded ? "▾" : "▸"}</span>
-											</button>
-											<button
-												class="opacity-0 group-hover:opacity-100 text-gray-500 hover:text-blue-400 text-xs px-1.5"
-												@click=${(e: Event) => this.newSessionInProject(project.id, e)}
-												title="New session in project"
-											>
-												+
-											</button>
-											<button
-												class="opacity-0 group-hover:opacity-100 text-gray-500 hover:text-red-400 text-xs px-1.5"
-												@click=${(e: Event) => this.removeProject(project.id, e)}
-												title="Remove project"
-											>
-												✕
-											</button>
-										</div>
-
-										${project.expanded
-											? html`
-												<div class="ml-4 mt-1 space-y-0.5">
-													${project.loadingSessions
-														? html`<div class="px-2 py-1 text-[11px] text-gray-500">Loading sessions...</div>`
-														: project.sessions.length === 0
-															? html`<div class="px-2 py-1 text-[11px] text-gray-500">No sessions</div>`
-															: project.sessions.map(
-																	(session) => html`
-																		<button
-																			class="w-full flex items-center justify-between px-2 py-1 rounded hover:bg-[#222] text-left"
-																			@click=${() => this.selectSession(project.id, session.path)}
-																			title=${session.path}
-																		>
-																			<div class="min-w-0">
-																				<div class="text-[11px] text-gray-400 truncate">${session.name}</div>
-																				<div class="text-[10px] text-gray-600">${formatTokens(session.tokens)} · ${formatCost(session.cost)}</div>
-																			</div>
-																			<span class="text-[10px] text-gray-600 ml-2">${formatRelativeDate(
-																				session.modifiedAt,
-																			)}</span>
-																		</button>
-																	`,
-																)
-													}
-												</div>
-											`
-											: nothing}
-									</div>
-								`,
-							)}
-				</div>
-
-				<!-- Bottom -->
-				<div class="p-2 border-t border-[#262626] space-y-1">
-					<button
-						class="w-full flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-[#262626] transition-colors text-left"
-						@click=${() => this.openFolder()}
-					>
-						<span class="text-gray-400">📁</span>
-						<span class="text-sm text-gray-300">Open Folder</span>
-					</button>
-					<button
-						class="w-full flex items-center gap-2 px-3 py-2 rounded-lg hover:bg-[#262626] transition-colors text-left"
-						@click=${() => this.onOpenSettings?.()}
-					>
-						<span class="text-gray-400">⚙️</span>
-						<span class="text-sm text-gray-300">Settings</span>
-					</button>
-				</div>
-			</div>
-		`;
-
-		render(template, this.container);
+	destroy(): void {
+		this.root.unmount();
 	}
 }

--- a/src/components/titlebar.tsx
+++ b/src/components/titlebar.tsx
@@ -3,7 +3,8 @@
  */
 
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { html, nothing, render } from "lit";
+import { type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
 import { type CliUpdateStatus, type RpcSessionState, rpcBridge } from "../rpc/bridge.js";
 
 interface SessionStats {
@@ -11,8 +12,101 @@ interface SessionStats {
 	cost?: number;
 }
 
+interface TitleBarViewProps {
+	currentProject: string | null;
+	modelId: string;
+	thinkingLevel: string | undefined;
+	tokens: string;
+	cost: string;
+	pending: number;
+	updateAvailable: boolean;
+	canUpdateInApp: boolean;
+	cliUpdating: boolean;
+	updateTitle: string;
+	isMaximized: boolean;
+	onNewSession: () => void;
+	onOpenSessions: () => void;
+	onOpenCommandPalette: () => void;
+	onOpenSettings: () => void;
+	onUpdateCli: () => void;
+	onMinimize: () => void;
+	onToggleMaximize: () => void;
+	onClose: () => void;
+}
+
+function TitleBarView(props: TitleBarViewProps): ReactElement {
+	return (
+		<div className="titlebar" data-tauri-drag-region>
+			<div className="titlebar-left" data-tauri-drag-region>
+				<span className="titlebar-app">pi</span>
+				{props.currentProject ? (
+					<>
+						<span className="titlebar-sep">/</span>
+						<span className="titlebar-project">{props.currentProject}</span>
+					</>
+				) : null}
+			</div>
+
+			<div className="titlebar-center" data-tauri-drag-region>
+				<span className="titlebar-model" title={props.modelId}>
+					{props.modelId}
+				</span>
+				{props.thinkingLevel && props.thinkingLevel !== "off" ? (
+					<span className="titlebar-pill thinking">{props.thinkingLevel}</span>
+				) : null}
+				{props.pending > 0 ? <span className="titlebar-pill queue">{props.pending} queued</span> : null}
+				<span className="titlebar-meta">
+					{props.tokens} tok · {props.cost}
+				</span>
+			</div>
+
+			<div className="titlebar-right">
+				<button className="titlebar-action" onClick={props.onNewSession} title="New session" type="button">
+					New
+				</button>
+				<button className="titlebar-action" onClick={props.onOpenSessions} title="Sessions" type="button">
+					Sessions
+				</button>
+				<button className="titlebar-action" onClick={props.onOpenCommandPalette} title="Commands" type="button">
+					⌘K
+				</button>
+				{props.updateAvailable ? (
+					<button
+						className="titlebar-action update"
+						disabled={props.cliUpdating}
+						onClick={() => (props.canUpdateInApp ? props.onUpdateCli() : props.onOpenSettings())}
+						title={props.updateTitle}
+						type="button"
+					>
+						{props.cliUpdating ? "Updating…" : props.canUpdateInApp ? "Update CLI" : "CLI Update"}
+					</button>
+				) : null}
+				<button className="titlebar-action" onClick={props.onOpenSettings} title="Settings" type="button">
+					⚙
+				</button>
+
+				<button className="titlebar-window" onClick={props.onMinimize} title="Minimize" type="button">
+					—
+				</button>
+				<button
+					className="titlebar-window"
+					onClick={props.onToggleMaximize}
+					title={props.isMaximized ? "Restore" : "Maximize"}
+					type="button"
+				>
+					{props.isMaximized ? "❐" : "□"}
+				</button>
+				<button className="titlebar-window close" onClick={props.onClose} title="Close" type="button">
+					✕
+				</button>
+			</div>
+		</div>
+	);
+}
+
 export class TitleBar {
 	private container: HTMLElement;
+	private root: Root;
 	private state: RpcSessionState | null = null;
 	private currentProject: string | null = null;
 	private isMaximized = false;
@@ -29,6 +123,7 @@ export class TitleBar {
 
 	constructor(container: HTMLElement) {
 		this.container = container;
+		this.root = createRoot(container);
 		void this.checkMaximized();
 		void this.refreshStats();
 		this.startStatsRefresh();
@@ -154,6 +249,7 @@ export class TitleBar {
 
 	destroy(): void {
 		this.stopStatsRefresh();
+		this.root.unmount();
 	}
 
 	render(): void {
@@ -168,51 +264,28 @@ export class TitleBar {
 			? `CLI ${this.cliStatus.current_version || "unknown"} → ${this.cliStatus.latest_version || "latest"}`
 			: "CLI update status";
 
-		const template = html`
-			<div class="titlebar" data-tauri-drag-region>
-				<div class="titlebar-left" data-tauri-drag-region>
-					<span class="titlebar-app">pi</span>
-					${this.currentProject ? html`<span class="titlebar-sep">/</span><span class="titlebar-project">${this.currentProject}</span>` : nothing}
-				</div>
-
-				<div class="titlebar-center" data-tauri-drag-region>
-					<span class="titlebar-model" title=${modelId}>${modelId}</span>
-					${thinkingLevel && thinkingLevel !== "off"
-						? html`<span class="titlebar-pill thinking">${thinkingLevel}</span>`
-						: nothing}
-					${pending > 0 ? html`<span class="titlebar-pill queue">${pending} queued</span>` : nothing}
-					<span class="titlebar-meta">${tokens} tok · ${cost}</span>
-				</div>
-
-				<div class="titlebar-right">
-					<button class="titlebar-action" @click=${() => this.onNewSession?.()} title="New session">New</button>
-					<button class="titlebar-action" @click=${() => this.onOpenSessions?.()} title="Sessions">Sessions</button>
-					<button class="titlebar-action" @click=${() => this.onOpenCommandPalette?.()} title="Commands">⌘K</button>
-					${updateAvailable
-						? html`
-							<button
-								class="titlebar-action update"
-								?disabled=${this.cliUpdating}
-								@click=${() => {
-									if (canUpdateInApp) this.onUpdateCli?.();
-									else this.onOpenSettings?.();
-								}}
-								title=${updateTitle}
-							>
-								${this.cliUpdating ? "Updating…" : canUpdateInApp ? "Update CLI" : "CLI Update"}
-							</button>
-						`
-						: nothing}
-					<button class="titlebar-action" @click=${() => this.onOpenSettings?.()} title="Settings">⚙</button>
-
-					<button class="titlebar-window" @click=${() => this.minimize()} title="Minimize">—</button>
-					<button class="titlebar-window" @click=${() => this.toggleMaximize()} title=${this.isMaximized ? "Restore" : "Maximize"}>
-						${this.isMaximized ? "❐" : "□"}
-					</button>
-					<button class="titlebar-window close" @click=${() => this.close()} title="Close">✕</button>
-				</div>
-			</div>
-		`;
-		render(template, this.container);
+		this.root.render(
+			<TitleBarView
+				currentProject={this.currentProject}
+				modelId={modelId}
+				thinkingLevel={thinkingLevel}
+				tokens={tokens}
+				cost={cost}
+				pending={pending}
+				updateAvailable={updateAvailable}
+				canUpdateInApp={canUpdateInApp}
+				cliUpdating={this.cliUpdating}
+				updateTitle={updateTitle}
+				isMaximized={this.isMaximized}
+				onNewSession={() => this.onNewSession?.()}
+				onOpenSessions={() => this.onOpenSessions?.()}
+				onOpenCommandPalette={() => this.onOpenCommandPalette?.()}
+				onOpenSettings={() => this.onOpenSettings?.()}
+				onUpdateCli={() => this.onUpdateCli?.()}
+				onMinimize={() => void this.minimize()}
+				onToggleMaximize={() => void this.toggleMaximize()}
+				onClose={() => void this.close()}
+			/>,
+		);
 	}
 }


### PR DESCRIPTION
## Summary
- migrate titlebar, sidebar, and settings-panel component rendering from Lit to React
- keep existing class APIs stable so the rest of app flow remains compatible
- rename these components to .tsx
- update migration docs/status and TODO issue mirror

## What remains in #9
- chat-view is still Lit-based and remains to be migrated under issue #9 scope

## Validation
- [x] npm run check
- [x] npm run build:frontend
- [x] cargo check
- [x] tauri dev startup smoke

Partially addresses #9
