### PR TITLE
feat(#30): add in-app desktop updater flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Added
+- In-app desktop update flow: checks latest GitHub release, surfaces update availability in sidebar/settings, and opens matching installer download from Settings.
+
+### Changed
+- Release documentation now includes in-app desktop update behavior and fallback logic.
+
 ## [0.1.3] - 2026-03-19
 
 ### Fixed

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -54,6 +54,16 @@ You can run `release.yml` manually from the Actions tab and provide a tag input.
 
 ---
 
+## In-app desktop update behavior
+
+Pi Desktop now checks for new desktop releases in-app (startup + periodic check).
+
+- Update detection source: GitHub `releases/latest`
+- Update entry points: Sidebar update banner and Settings → Desktop updates
+- Update action: opens the best-matching installer asset for the current platform (or release page fallback)
+
+This reduces manual steps for users (no need to browse releases manually each time).
+
 ## Notes about signing
 
 Current workflow produces unsigned artifacts unless signing secrets/certificates are configured.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -999,6 +999,13 @@ struct GitCommandResult {
     exit_code: i32,
 }
 
+#[derive(Debug, Serialize)]
+struct DesktopRuntimeInfo {
+    platform: String,
+    arch: String,
+    version: String,
+}
+
 fn npm_executable() -> &'static str {
     if cfg!(target_os = "windows") {
         "npm.cmd"
@@ -1346,6 +1353,15 @@ async fn run_git_command(options: GitCommandOptions) -> Result<GitCommandResult,
 }
 
 #[tauri::command]
+async fn get_desktop_runtime_info(app: AppHandle) -> Result<DesktopRuntimeInfo, String> {
+    Ok(DesktopRuntimeInfo {
+        platform: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        version: app.package_info().version.to_string(),
+    })
+}
+
+#[tauri::command]
 async fn open_path_in_default_app(path: String) -> Result<(), String> {
     let trimmed = path.trim();
     if trimmed.is_empty() {
@@ -1467,6 +1483,7 @@ pub fn run() {
             get_cli_update_status,
             update_cli_via_npm,
             run_git_command,
+            get_desktop_runtime_info,
             open_path_in_default_app,
         ])
         .run(tauri::generate_context!())

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -3,6 +3,7 @@
  */
 
 import { html, render, type TemplateResult } from "lit";
+import { fetchDesktopUpdateStatus, openDesktopUpdate, type DesktopUpdateStatus } from "../desktop-updates.js";
 import {
 	type CliUpdateStatus,
 	type PiAuthStatus,
@@ -33,6 +34,11 @@ export class SettingsPanel {
 	private saving = false;
 	private authStatus: PiAuthStatus | null = null;
 	private authLoading = false;
+	private desktopStatus: DesktopUpdateStatus | null = null;
+	private desktopLoading = false;
+	private desktopOpening = false;
+	private desktopActionMessage = "";
+	private onDesktopStatusChange: ((status: DesktopUpdateStatus | null) => void) | null = null;
 	private cliStatus: CliUpdateStatus | null = null;
 	private cliLoading = false;
 	private cliUpdating = false;
@@ -48,6 +54,10 @@ export class SettingsPanel {
 
 	setOnClose(callback: () => void): void {
 		this.onClose = callback;
+	}
+
+	setOnDesktopStatusChange(callback: (status: DesktopUpdateStatus | null) => void): void {
+		this.onDesktopStatusChange = callback;
 	}
 
 	setOnCliStatusChange(callback: (status: CliUpdateStatus | null) => void): void {
@@ -114,6 +124,7 @@ export class SettingsPanel {
 
 		await Promise.all([
 			this.refreshAuthStatus(),
+			this.refreshDesktopStatus(),
 			this.refreshCliStatus(),
 			this.refreshCompatibilityStatus(),
 		]);
@@ -128,6 +139,39 @@ export class SettingsPanel {
 			this.authStatus = null;
 		} finally {
 			this.authLoading = false;
+			this.render();
+		}
+	}
+
+	private async refreshDesktopStatus(): Promise<void> {
+		this.desktopLoading = true;
+		this.render();
+		try {
+			this.desktopStatus = await fetchDesktopUpdateStatus();
+		} catch {
+			this.desktopStatus = null;
+		} finally {
+			this.desktopLoading = false;
+			this.render();
+			this.onDesktopStatusChange?.(this.desktopStatus);
+		}
+	}
+
+	private async openDesktopUpdateNow(): Promise<void> {
+		if (this.desktopOpening) return;
+		if (!this.desktopStatus?.updateAvailable) return;
+		this.desktopOpening = true;
+		this.desktopActionMessage = this.desktopStatus.assetUrl ? "Opening desktop installer…" : "Opening release page…";
+		this.render();
+		try {
+			await openDesktopUpdate(this.desktopStatus);
+			this.desktopActionMessage = this.desktopStatus.assetName
+				? `Opened ${this.desktopStatus.assetName} for download.`
+				: "Opened release page.";
+		} catch (err) {
+			this.desktopActionMessage = err instanceof Error ? err.message : "Failed to open desktop update.";
+		} finally {
+			this.desktopOpening = false;
 			this.render();
 		}
 	}
@@ -374,6 +418,42 @@ export class SettingsPanel {
 									`
 									: null}
 							`}
+					</div>
+
+					<div class="settings-section">
+						<div class="settings-section-title">Desktop updates</div>
+						${this.desktopLoading
+							? html`<div class="settings-desc">Checking desktop release…</div>`
+							: html`
+								<div class="settings-desc">
+									Current: <code>${this.desktopStatus?.currentVersion || "unknown"}</code>
+									 · Latest: <code>${this.desktopStatus?.latestVersion || "unknown"}</code>
+								</div>
+								${this.desktopStatus
+									? this.desktopStatus.updateAvailable
+										? html`<div class="settings-desc">A newer Pi Desktop release is available.</div>`
+										: html`<div class="settings-desc">No desktop update available right now.</div>`
+									: html`<div class="settings-desc">Desktop update status unavailable. Check your network and try again.</div>`}
+								${this.desktopStatus?.assetName
+									? html`<div class="settings-desc">Recommended installer: <code>${this.desktopStatus.assetName}</code></div>`
+									: null}
+								${this.desktopStatus?.note ? html`<div class="settings-desc">${this.desktopStatus.note}</div>` : null}
+							`}
+						<div class="settings-actions">
+							<button class="ghost-btn" ?disabled=${this.desktopLoading} @click=${() => this.refreshDesktopStatus()}>Refresh desktop status</button>
+							<button
+								class="ghost-btn"
+								?disabled=${this.desktopOpening || !this.desktopStatus?.updateAvailable}
+								@click=${() => this.openDesktopUpdateNow()}
+							>
+								${this.desktopOpening
+									? "Opening…"
+									: this.desktopStatus?.assetUrl
+										? "Download desktop update"
+										: "Open release page"}
+							</button>
+						</div>
+						${this.desktopActionMessage ? html`<div class="settings-desc">${this.desktopActionMessage}</div>` : null}
 					</div>
 
 					<div class="settings-section">

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -212,6 +212,8 @@ export class Sidebar {
 	private packagesOpen = false;
 	private openProjectMenuId: string | null = null;
 	private modeFilterMenuOpen = false;
+	private desktopUpdateAvailable = false;
+	private desktopUpdateLatestVersion: string | null = null;
 	private cliUpdateAvailable = false;
 	private cliUpdateLatestVersion: string | null = null;
 	private sessionOrganize: "byProject" | "chronological" = "byProject";
@@ -402,6 +404,14 @@ export class Sidebar {
 	setPackagesOpen(open: boolean): void {
 		if (this.packagesOpen === open) return;
 		this.packagesOpen = open;
+		this.render();
+	}
+
+	setDesktopUpdateStatus(updateAvailable: boolean, latestVersion: string | null = null): void {
+		const normalizedLatest = latestVersion && latestVersion.trim().length > 0 ? latestVersion.trim() : null;
+		if (this.desktopUpdateAvailable === updateAvailable && this.desktopUpdateLatestVersion === normalizedLatest) return;
+		this.desktopUpdateAvailable = updateAvailable;
+		this.desktopUpdateLatestVersion = normalizedLatest;
 		this.render();
 	}
 
@@ -3142,6 +3152,16 @@ export class Sidebar {
 				${this.renderWorkspaceSwitcher()}
 
 				<div class="sidebar-topbar" data-tauri-drag-region>
+					${this.desktopUpdateAvailable
+						? html`
+							<button class="sidebar-cli-update-banner sidebar-desktop-update-banner" @click=${() => this.onOpenSettings?.()}>
+								<span>
+									Desktop update available${this.desktopUpdateLatestVersion ? ` · v${this.desktopUpdateLatestVersion}` : ""}
+								</span>
+								<span class="sidebar-cli-update-cta">Open settings</span>
+							</button>
+						`
+						: nothing}
 					${this.cliUpdateAvailable
 						? html`
 							<button class="sidebar-cli-update-banner" @click=${() => this.onOpenSettings?.()}>

--- a/src/desktop-updates.ts
+++ b/src/desktop-updates.ts
@@ -1,0 +1,248 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export type DesktopPlatform = "macos" | "windows" | "linux" | "unknown";
+export type DesktopArch = "x64" | "arm64" | "unknown";
+
+interface GitHubReleaseAsset {
+	name?: string;
+	browser_download_url?: string;
+}
+
+interface GitHubReleasePayload {
+	tag_name?: string;
+	html_url?: string;
+	assets?: GitHubReleaseAsset[];
+}
+
+interface RawDesktopRuntimeInfo {
+	platform?: string;
+	arch?: string;
+	version?: string;
+}
+
+export interface DesktopRuntimeInfo {
+	platform: DesktopPlatform;
+	arch: DesktopArch;
+	version: string;
+}
+
+export interface DesktopUpdateStatus {
+	checkedAt: number;
+	platform: DesktopPlatform;
+	arch: DesktopArch;
+	currentVersion: string;
+	latestVersion: string | null;
+	updateAvailable: boolean;
+	releaseUrl: string;
+	assetName: string | null;
+	assetUrl: string | null;
+	note: string | null;
+}
+
+const REPO_OWNER = "gustavonline";
+const REPO_NAME = "pi-desktop";
+const RELEASES_BASE_URL = `https://github.com/${REPO_OWNER}/${REPO_NAME}/releases`;
+const RELEASES_LATEST_API_URL = `https://api.github.com/repos/${REPO_OWNER}/${REPO_NAME}/releases/latest`;
+
+function sanitizeVersion(raw: string | null | undefined): string {
+	const trimmed = (raw ?? "").trim();
+	if (!trimmed) return "0.0.0";
+	return trimmed.replace(/^v/i, "").trim() || "0.0.0";
+}
+
+function parseSemver(version: string): [number, number, number] | null {
+	const normalized = sanitizeVersion(version).split("-")[0] ?? "";
+	const parts = normalized.split(".");
+	if (parts.length < 2) return null;
+	const major = Number(parts[0] ?? 0);
+	const minor = Number(parts[1] ?? 0);
+	const patch = Number(parts[2] ?? 0);
+	if (!Number.isFinite(major) || !Number.isFinite(minor) || !Number.isFinite(patch)) return null;
+	if (major < 0 || minor < 0 || patch < 0) return null;
+	return [major, minor, patch];
+}
+
+function isNewerVersion(latest: string, current: string): boolean {
+	const latestTuple = parseSemver(latest);
+	const currentTuple = parseSemver(current);
+	if (latestTuple && currentTuple) {
+		const [lMaj, lMin, lPatch] = latestTuple;
+		const [cMaj, cMin, cPatch] = currentTuple;
+		if (lMaj !== cMaj) return lMaj > cMaj;
+		if (lMin !== cMin) return lMin > cMin;
+		return lPatch > cPatch;
+	}
+	return sanitizeVersion(latest) !== sanitizeVersion(current);
+}
+
+function normalizePlatform(raw: string | null | undefined): DesktopPlatform {
+	const value = (raw ?? "").toLowerCase();
+	if (value.includes("mac") || value.includes("darwin")) return "macos";
+	if (value.includes("win")) return "windows";
+	if (value.includes("linux")) return "linux";
+	return "unknown";
+}
+
+function normalizeArch(raw: string | null | undefined): DesktopArch {
+	const value = (raw ?? "").toLowerCase();
+	if (value.includes("aarch64") || value.includes("arm64")) return "arm64";
+	if (value.includes("x86_64") || value.includes("amd64") || value.includes("x64") || value.includes("x86")) return "x64";
+	return "unknown";
+}
+
+function inferRuntimeFromNavigator(): DesktopRuntimeInfo {
+	const ua = (navigator.userAgent || "").toLowerCase();
+	const platform = normalizePlatform([navigator.platform, ua].join(" "));
+	const arch = normalizeArch(ua);
+	return {
+		platform,
+		arch,
+		version: "0.0.0",
+	};
+}
+
+async function getRuntimeInfo(): Promise<DesktopRuntimeInfo> {
+	try {
+		const raw = await invoke<RawDesktopRuntimeInfo>("get_desktop_runtime_info");
+		return {
+			platform: normalizePlatform(raw.platform),
+			arch: normalizeArch(raw.arch),
+			version: sanitizeVersion(raw.version),
+		};
+	} catch {
+		return inferRuntimeFromNavigator();
+	}
+}
+
+function archHints(name: string): { mentionsArm64: boolean; mentionsX64: boolean } {
+	const lower = name.toLowerCase();
+	return {
+		mentionsArm64: /(aarch64|arm64)/.test(lower),
+		mentionsX64: /(x64|x86_64|amd64|win64|intel)/.test(lower),
+	};
+}
+
+function scoreAsset(name: string, platform: DesktopPlatform, arch: DesktopArch): number {
+	const lower = name.toLowerCase();
+	const hints = archHints(lower);
+	let score = -10_000;
+
+	if (platform === "macos") {
+		if (lower.endsWith(".dmg")) score = 500;
+		else if (lower.endsWith(".app.tar.gz")) score = 380;
+		else return score;
+	}
+
+	if (platform === "windows") {
+		if (lower.endsWith(".msi")) score = 500;
+		else if (lower.endsWith(".exe")) score = 470;
+		else return score;
+	}
+
+	if (platform === "linux") {
+		if (lower.endsWith(".appimage")) score = 500;
+		else if (lower.endsWith(".deb")) score = 470;
+		else return score;
+	}
+
+	if (platform === "unknown") {
+		if (lower.endsWith(".dmg")) score = 300;
+		else if (lower.endsWith(".msi")) score = 300;
+		else if (lower.endsWith(".exe")) score = 290;
+		else if (lower.endsWith(".appimage")) score = 280;
+		else if (lower.endsWith(".deb")) score = 260;
+		else return score;
+	}
+
+	if (arch === "arm64") {
+		if (hints.mentionsArm64) score += 40;
+		if (hints.mentionsX64) score -= 30;
+	} else if (arch === "x64") {
+		if (hints.mentionsX64) score += 40;
+		if (hints.mentionsArm64) score -= 30;
+	}
+
+	return score;
+}
+
+function selectBestAsset(
+	assets: GitHubReleaseAsset[],
+	platform: DesktopPlatform,
+	arch: DesktopArch,
+): { name: string; url: string } | null {
+	const normalizedAssets = assets
+		.map((asset) => ({
+			name: (asset.name ?? "").trim(),
+			url: (asset.browser_download_url ?? "").trim(),
+		}))
+		.filter((asset) => asset.name.length > 0 && asset.url.length > 0);
+
+	if (normalizedAssets.length === 0) return null;
+
+	const scored = normalizedAssets
+		.map((asset) => ({
+			...asset,
+			score: scoreAsset(asset.name, platform, arch),
+		}))
+		.sort((a, b) => b.score - a.score);
+
+	const winner = scored[0];
+	if (!winner || winner.score <= -10_000) return null;
+	return { name: winner.name, url: winner.url };
+}
+
+export async function fetchDesktopUpdateStatus(): Promise<DesktopUpdateStatus> {
+	const runtime = await getRuntimeInfo();
+	const response = await fetch(RELEASES_LATEST_API_URL, {
+		headers: {
+			Accept: "application/vnd.github+json",
+		},
+	});
+
+	if (!response.ok) {
+		throw new Error(`Desktop release check failed (HTTP ${response.status})`);
+	}
+
+	const release = (await response.json()) as GitHubReleasePayload;
+	const latestVersionRaw = (release.tag_name ?? "").trim();
+	const latestVersion = latestVersionRaw ? sanitizeVersion(latestVersionRaw) : null;
+	const currentVersion = sanitizeVersion(runtime.version);
+	const releaseUrl = typeof release.html_url === "string" && release.html_url.trim().length > 0
+		? release.html_url.trim()
+		: RELEASES_BASE_URL;
+
+	const updateAvailable = Boolean(latestVersion && isNewerVersion(latestVersion, currentVersion));
+	const asset = selectBestAsset(release.assets ?? [], runtime.platform, runtime.arch);
+
+	let note: string | null = null;
+	if (updateAvailable && !asset) {
+		note = "No installer matched this platform automatically. Open the release page to choose an asset manually.";
+	} else if (runtime.platform === "unknown") {
+		note = "Could not detect desktop platform reliably; using generic asset matching.";
+	}
+
+	return {
+		checkedAt: Date.now(),
+		platform: runtime.platform,
+		arch: runtime.arch,
+		currentVersion,
+		latestVersion,
+		updateAvailable,
+		releaseUrl,
+		assetName: asset?.name ?? null,
+		assetUrl: asset?.url ?? null,
+		note,
+	};
+}
+
+export async function openDesktopUpdate(status: DesktopUpdateStatus): Promise<void> {
+	const target = status.assetUrl ?? status.releaseUrl;
+	if (!target) throw new Error("No desktop update URL available");
+
+	try {
+		const { open } = await import("@tauri-apps/plugin-shell");
+		await open(target);
+	} catch {
+		window.open(target, "_blank", "noopener,noreferrer");
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import { ShortcutsPanel } from "./components/shortcuts-panel.js";
 import { Sidebar, type SidebarMode, type SidebarWorkspaceItem } from "./components/sidebar.js";
 import { TerminalPanel } from "./components/terminal-panel.js";
 import type { WorkspaceTabs } from "./components/workspace-tabs.js";
+import { fetchDesktopUpdateStatus, type DesktopUpdateStatus } from "./desktop-updates.js";
 import { type CliUpdateStatus, RpcBridge, type RpcSessionState, rpcBridge, setActiveRpcBridge } from "./rpc/bridge.js";
 import "./styles/app.css";
 
@@ -85,7 +86,8 @@ const NEW_SESSION_TAB_TITLE = "New session";
 const NEW_FILE_TAB_TITLE = "New file";
 const DEBUG_OVERLAY_STORAGE_KEY = "pi-desktop.debug-overlay.v1";
 const CLI_UPDATE_NOTICE_STORAGE_KEY = "pi-desktop.cli-update-notice-at.v1";
-const CLI_UPDATE_NOTICE_INTERVAL_MS = 24 * 60 * 60 * 1000;
+const DESKTOP_UPDATE_NOTICE_STORAGE_KEY = "pi-desktop.desktop-update-notice-at.v1";
+const UPDATE_NOTICE_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const CLI_INSTALL_COMMAND = "npm install -g @mariozechner/pi-coding-agent";
 const SESSION_ATTENTION_MESSAGES = [
 	"I’m waiting for you — Pi",
@@ -110,8 +112,11 @@ let shortcutsPanel: ShortcutsPanel | null = null;
 let extensionUiHandler: ExtensionUiHandler | null = null;
 
 let cliUpdateStatus: CliUpdateStatus | null = null;
+let desktopUpdateStatus: DesktopUpdateStatus | null = null;
 let cliUpdatePollingTimer: ReturnType<typeof setInterval> | null = null;
+let desktopUpdatePollingTimer: ReturnType<typeof setInterval> | null = null;
 let cliUpdateChecking = false;
+let desktopUpdateChecking = false;
 
 let projectSwitchTask: Promise<void> = Promise.resolve();
 let projectSwitchVersion = 0;
@@ -194,9 +199,9 @@ async function copyCliInstallCommand(): Promise<void> {
 	}
 }
 
-function readLastCliUpdateNoticeAt(): number {
+function readLastUpdateNoticeAt(storageKey: string): number {
 	try {
-		const raw = localStorage.getItem(CLI_UPDATE_NOTICE_STORAGE_KEY);
+		const raw = localStorage.getItem(storageKey);
 		const parsed = raw ? Number(raw) : 0;
 		return Number.isFinite(parsed) ? parsed : 0;
 	} catch {
@@ -204,16 +209,32 @@ function readLastCliUpdateNoticeAt(): number {
 	}
 }
 
-function shouldNotifyCliUpdate(now = Date.now()): boolean {
-	return now - readLastCliUpdateNoticeAt() >= CLI_UPDATE_NOTICE_INTERVAL_MS;
+function shouldNotifyUpdate(storageKey: string, now = Date.now()): boolean {
+	return now - readLastUpdateNoticeAt(storageKey) >= UPDATE_NOTICE_INTERVAL_MS;
 }
 
-function markCliUpdateNotified(now = Date.now()): void {
+function markUpdateNotified(storageKey: string, now = Date.now()): void {
 	try {
-		localStorage.setItem(CLI_UPDATE_NOTICE_STORAGE_KEY, String(now));
+		localStorage.setItem(storageKey, String(now));
 	} catch {
 		// ignore
 	}
+}
+
+function shouldNotifyCliUpdate(now = Date.now()): boolean {
+	return shouldNotifyUpdate(CLI_UPDATE_NOTICE_STORAGE_KEY, now);
+}
+
+function markCliUpdateNotified(now = Date.now()): void {
+	markUpdateNotified(CLI_UPDATE_NOTICE_STORAGE_KEY, now);
+}
+
+function shouldNotifyDesktopUpdate(now = Date.now()): boolean {
+	return shouldNotifyUpdate(DESKTOP_UPDATE_NOTICE_STORAGE_KEY, now);
+}
+
+function markDesktopUpdateNotified(now = Date.now()): void {
+	markUpdateNotified(DESKTOP_UPDATE_NOTICE_STORAGE_KEY, now);
 }
 
 function normalizeProjectPath(path: string | null | undefined): string {
@@ -1472,6 +1493,10 @@ function syncCliUpdateUiHint(): void {
 	sidebar?.setCliUpdateStatus(Boolean(cliUpdateStatus?.update_available), cliUpdateStatus?.latest_version ?? null);
 }
 
+function syncDesktopUpdateUiHint(): void {
+	sidebar?.setDesktopUpdateStatus(Boolean(desktopUpdateStatus?.updateAvailable), desktopUpdateStatus?.latestVersion ?? null);
+}
+
 function syncDebugOverlay(): void {
 	const el = document.getElementById("runtime-debug-overlay");
 	if (!el) return;
@@ -2061,13 +2086,43 @@ async function refreshCliUpdateStatus(): Promise<void> {
 	}
 }
 
+async function refreshDesktopUpdateStatus(): Promise<void> {
+	if (desktopUpdateChecking) return;
+	desktopUpdateChecking = true;
+	try {
+		desktopUpdateStatus = await fetchDesktopUpdateStatus();
+		if (desktopUpdateStatus.updateAvailable && shouldNotifyDesktopUpdate()) {
+			chatView?.notify(
+				`A Pi Desktop update is available${desktopUpdateStatus.latestVersion ? ` (v${desktopUpdateStatus.latestVersion})` : ""}. Open Settings → Desktop updates to install it.`,
+				"info",
+			);
+			markDesktopUpdateNotified();
+		}
+	} catch (err) {
+		console.warn("Failed to refresh desktop update status:", err);
+		desktopUpdateStatus = null;
+	} finally {
+		desktopUpdateChecking = false;
+		syncDesktopUpdateUiHint();
+	}
+}
+
 function startCliUpdatePolling(): void {
 	if (cliUpdatePollingTimer) {
 		clearInterval(cliUpdatePollingTimer);
 	}
 	cliUpdatePollingTimer = setInterval(() => {
 		void refreshCliUpdateStatus();
-	}, CLI_UPDATE_NOTICE_INTERVAL_MS);
+	}, UPDATE_NOTICE_INTERVAL_MS);
+}
+
+function startDesktopUpdatePolling(): void {
+	if (desktopUpdatePollingTimer) {
+		clearInterval(desktopUpdatePollingTimer);
+	}
+	desktopUpdatePollingTimer = setInterval(() => {
+		void refreshDesktopUpdateStatus();
+	}, UPDATE_NOTICE_INTERVAL_MS);
 }
 
 async function initialize(): Promise<void> {
@@ -2235,7 +2290,9 @@ async function initialize(): Promise<void> {
 
 		await runStartupCompatibilityCheck();
 		await refreshCliUpdateStatus();
+		await refreshDesktopUpdateStatus();
 		startCliUpdatePolling();
+		startDesktopUpdatePolling();
 	} catch (err) {
 		connectionError = err instanceof Error ? err.message : String(err);
 		recordDebugTrace(`initialize-fatal: ${connectionError}`);
@@ -2252,6 +2309,10 @@ function mountSettingsPanel(): SettingsPanel {
 	settingsContainer.id = "settings-container";
 	document.body.appendChild(settingsContainer);
 	const panel = new SettingsPanel(settingsContainer);
+	panel.setOnDesktopStatusChange((status) => {
+		desktopUpdateStatus = status;
+		syncDesktopUpdateUiHint();
+	});
 	panel.setOnCliStatusChange((status) => {
 		cliUpdateStatus = status;
 		syncCliUpdateUiHint();
@@ -2937,6 +2998,7 @@ function renderApp(): void {
 	});
 	syncSidebarCollapseToggleButton();
 	syncCliUpdateUiHint();
+	syncDesktopUpdateUiHint();
 
 	sidebar.setOnWorkspaceSelect((workspaceId) => {
 		void queueProjectTask(

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2270,6 +2270,10 @@ body.sidebar-resizing {
 	background: color-mix(in srgb, var(--accent) 22%, var(--bg-soft));
 }
 
+.sidebar-desktop-update-banner {
+	background: color-mix(in srgb, var(--accent) 18%, var(--bg-soft));
+}
+
 .sidebar-cli-update-cta {
 	font-size: 10px;
 	color: var(--muted);


### PR DESCRIPTION
## Summary
Implements issue #30 by adding an in-app desktop update flow so users no longer need to manually browse releases for each app update.

### What’s included
- New desktop update service (`src/desktop-updates.ts`)
  - Checks GitHub `releases/latest`
  - Detects runtime platform/arch/version
  - Picks best-matching installer asset
  - Opens installer/release URL via shell
- New backend command (`get_desktop_runtime_info`) to expose host OS/arch/version from Tauri.
- Main app polling + notification integration
  - Startup check + periodic check
  - Sidebar update badge state sync
  - Chat notification when desktop update is available
- Settings UI
  - New **Desktop updates** section
  - Refresh status
  - One-click **Download desktop update** / release-page fallback
- Sidebar UX
  - Desktop update banner alongside existing CLI update banner
- Docs/changelog updates
  - `docs/RELEASES.md` + `CHANGELOG.md`

## Validation
- `npm run check`
- `npm run build:frontend`

## Issue
Closes #30
