### PR TITLE
fix(#33): stabilize RPC loading and duplicate tool-call cards

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -23,4 +23,7 @@
 ## Notes
 
 - If the `pi` CLI is missing, Pi Desktop now shows onboarding with install instructions.
+- macOS artifacts are currently unsigned/not notarized (Apple Developer signing deferred).
+  - If Gatekeeper blocks launch, run:
+    - `xattr -cr /Applications/Pi\ Desktop.app`
 - See README for setup and docs links.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed
+- Hardened RPC bridge listener initialization to avoid duplicate event subscriptions under concurrent setup.
+- Prevented duplicate tool-call cards by de-duplicating `toolCall` ids in both streaming updates and backend message hydration.
+
+### Changed
+- Composer now shows RPC/binding status inline and blocks send/actions while a session is still loading or reconnecting.
+- Release template/checklists now include the unsigned macOS Gatekeeper workaround command (`xattr -cr /Applications/Pi\ Desktop.app`).
+
 ## [0.1.4] - 2026-03-19
 
 ### Added

--- a/RELEASE_CRITERIA.md
+++ b/RELEASE_CRITERIA.md
@@ -53,6 +53,7 @@ Promote `dev` to `main` only when:
 - [ ] Merge `dev` -> `main`
 - [ ] Tag release candidate (`v0.x.y-rcX`) then stable (`v0.x.y`)
 - [ ] Publish release notes with known limitations
+  - [ ] If macOS build is unsigned, include: `xattr -cr /Applications/Pi\ Desktop.app`
 - [ ] Verify GitHub release artifacts:
   - [ ] macOS (`.dmg` / `.app.tar.gz`)
   - [ ] Windows (`.msi` / `nsis`)

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,13 @@
 # TODO — V1/V1.1 release cleanup plan
 
+## Active issue (current session)
+- [x] #33 RPC reliability: fix duplicate tool cards + loading/reconnect UX
+  - [x] Make RPC bridge listener setup idempotent under concurrent `ensureListeners()` calls
+  - [x] De-dup tool cards by `toolCall.id` (live events + backend hydration)
+  - [x] Disable composer send while RPC binding/reconnecting and surface status inline
+  - [x] Add unsigned macOS workaround command to release template
+  - [x] Validate: `npm run check`, `npm run build:frontend`, `cargo check --manifest-path src-tauri/Cargo.toml`
+
 ## Goal
 Ship Pi Desktop as a **minimal native desktop host for Pi**:
 - strong desktop shell / UX

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -74,3 +74,8 @@ For production distribution, configure platform signing:
 - Linux: optional signature strategy depending on distro/channel
 
 Without macOS signing/notarization, some users may see Gatekeeper warnings (“app is damaged”).
+Include this workaround in release notes while unsigned builds are shipped:
+
+```bash
+xattr -cr /Applications/Pi\ Desktop.app
+```

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -562,7 +562,16 @@ export class ChatView {
 							thinking += p.thinking;
 						}
 						if (type === "toolCall") {
-							const id = typeof p.id === "string" ? p.id : uid("tc");
+							const id = typeof p.id === "string" && p.id.trim().length > 0 ? p.id.trim() : uid("tc");
+							const existing = toolCalls.find((entry) => entry.id === id);
+							if (existing) {
+								existing.name = typeof p.name === "string" ? p.name : existing.name;
+								existing.args = (p.arguments as Record<string, unknown>) ?? existing.args;
+								existing.isRunning = false;
+								existing.isExpanded = false;
+								toolCallMap.set(existing.id, existing);
+								continue;
+							}
 							const tc: ToolCallBlock = {
 								id,
 								name: typeof p.name === "string" ? p.name : "tool",
@@ -1587,13 +1596,23 @@ export class ChatView {
 				} else if (subtype === "toolcall_end") {
 					const tc = assistantEvent.toolCall as Record<string, unknown>;
 					if (tc) {
-						last.toolCalls.push({
-							id: (tc.id as string) || uid("tc"),
-							name: (tc.name as string) || "tool",
-							args: ((tc.arguments ?? {}) as Record<string, unknown>) || {},
-							isRunning: true,
-							isExpanded: false,
-						});
+						const rawId = typeof tc.id === "string" ? tc.id.trim() : "";
+						const id = rawId || uid("tc");
+						const existing = last.toolCalls.find((entry) => entry.id === id);
+						if (existing) {
+							existing.name = typeof tc.name === "string" && tc.name.trim().length > 0 ? tc.name : existing.name;
+							existing.args = ((tc.arguments ?? existing.args) as Record<string, unknown>) || existing.args;
+							existing.isRunning = true;
+							existing.isExpanded = false;
+						} else {
+							last.toolCalls.push({
+								id,
+								name: (tc.name as string) || "tool",
+								args: ((tc.arguments ?? {}) as Record<string, unknown>) || {},
+								isRunning: true,
+								isExpanded: false,
+							});
+						}
 						this.render();
 					}
 				} else if (subtype === "error") {
@@ -1703,6 +1722,22 @@ export class ChatView {
 				this.pushNotice(`Extension error: ${truncate(error, 120)}`, "error");
 				break;
 			}
+
+			case "rpc_connected":
+				this.isConnected = true;
+				this.bindingStatusText = this.projectPath ? "Loading session…" : null;
+				if (this.disconnectNoticeTimer) {
+					clearTimeout(this.disconnectNoticeTimer);
+					this.disconnectNoticeTimer = null;
+				}
+				this.render();
+				if (this.projectPath) {
+					void this.refreshFromBackend();
+					if (!this.loadingModels) {
+						void this.loadAvailableModels();
+					}
+				}
+				break;
 
 			case "rpc_disconnected":
 				this.isConnected = false;
@@ -1981,6 +2016,12 @@ export class ChatView {
 		return Boolean(this.state?.isStreaming) || this.messages.some((m) => m.isStreaming);
 	}
 
+	private isComposerInteractionLocked(): boolean {
+		if (!this.projectPath) return true;
+		if (!this.isConnected) return true;
+		return Boolean(this.bindingStatusText);
+	}
+
 	private toRpcImages(images: PendingImage[]): RpcImageInput[] {
 		return images.map((img) => ({ type: "image", data: img.data, mimeType: img.mimeType }));
 	}
@@ -2027,6 +2068,10 @@ export class ChatView {
 	}
 
 	async sendMessage(mode: DeliveryMode = this.pendingDeliveryMode): Promise<void> {
+		if (this.isComposerInteractionLocked()) {
+			this.pushNotice(this.bindingStatusText || "Session is still loading. Try again in a moment.", "info");
+			return;
+		}
 		const text = this.inputText.trim();
 		const images = [...this.pendingImages];
 		if (!text && images.length === 0) return;
@@ -2692,7 +2737,7 @@ export class ChatView {
 		`;
 	}
 
-	private renderComposerControls(canSend: boolean, isStreaming: boolean): TemplateResult {
+	private renderComposerControls(canSend: boolean, isStreaming: boolean, interactionLocked: boolean): TemplateResult {
 		const currentProvider = normalizeText(this.state?.model?.provider);
 		const currentModelId = normalizeText(this.state?.model?.id);
 		const currentModelValue = currentProvider && currentModelId ? `${currentProvider}::${currentModelId}` : "";
@@ -2706,7 +2751,9 @@ export class ChatView {
 					<button
 						class="composer-icon-btn"
 						title="Attach image"
+						?disabled=${interactionLocked}
 						@click=${() => {
+							if (interactionLocked) return;
 							const input = this.container.querySelector("#file-picker") as HTMLInputElement | null;
 							input?.click();
 						}}
@@ -2718,7 +2765,7 @@ export class ChatView {
 						<select
 							class="composer-select model-select"
 							.value=${currentModelValue}
-							?disabled=${this.loadingModels || this.settingModel}
+							?disabled=${interactionLocked || this.loadingModels || this.settingModel}
 							@pointerdown=${() => {
 								if (!this.loadingModels && this.availableModels.length === 0) {
 									void this.loadAvailableModels();
@@ -2754,7 +2801,7 @@ export class ChatView {
 						<select
 							class="thinking-select-native"
 							.value=${thinkingValue}
-							?disabled=${this.settingThinking}
+							?disabled=${interactionLocked || this.settingThinking}
 							@change=${(e: Event) => void this.setThinkingLevel((e.target as HTMLSelectElement).value as ThinkingLevel)}
 						>
 							<option value="off">Off</option>
@@ -2773,7 +2820,9 @@ export class ChatView {
 						<button
 							class="composer-icon-btn"
 							title="Session actions"
+							?disabled=${interactionLocked}
 							@click=${() => {
+								if (interactionLocked) return;
 								this.quickActionsOpen = !this.quickActionsOpen;
 								this.render();
 							}}
@@ -2828,8 +2877,32 @@ export class ChatView {
 							: nothing}
 					</div>
 					${isStreaming
-						? html`<button class="send-btn stop-btn" title="Stop generation" @click=${() => void this.abortCurrentRun()}>${uiIcon("stop")}</button>`
-						: html`<button class="send-btn primary-send" ?disabled=${!canSend} title="Send" @click=${() => this.sendMessage("prompt")}>${uiIcon("send")}</button>`}
+						? html`
+							<button
+								class="send-btn stop-btn"
+								title="Stop generation"
+								?disabled=${interactionLocked}
+								@click=${() => {
+									if (interactionLocked) return;
+									void this.abortCurrentRun();
+								}}
+							>
+								${uiIcon("stop")}
+							</button>
+						`
+						: html`
+							<button
+								class="send-btn primary-send"
+								?disabled=${interactionLocked || !canSend}
+								title="Send"
+								@click=${() => {
+									if (interactionLocked) return;
+									void this.sendMessage("prompt");
+								}}
+							>
+								${uiIcon("send")}
+							</button>
+						`}
 				</div>
 			</div>
 		`;
@@ -2857,8 +2930,10 @@ export class ChatView {
 
 	private renderComposer(): TemplateResult {
 		const isStreaming = this.currentIsStreaming();
-		const canSend = this.inputText.trim().length > 0 || this.pendingImages.length > 0;
-		const statusText = [this.compactionStatus, this.retryStatus].filter(Boolean).join(" · ");
+		const interactionLocked = this.isComposerInteractionLocked();
+		const canSend = !interactionLocked && (this.inputText.trim().length > 0 || this.pendingImages.length > 0);
+		const connectivityStatus = this.bindingStatusText || (!this.isConnected && this.projectPath ? "RPC disconnected" : "");
+		const statusText = [connectivityStatus, this.compactionStatus, this.retryStatus].filter(Boolean).join(" · ");
 		const ratio = Math.min(1, Math.max(0, this.sessionStats.usageRatio ?? 0));
 		const ratioPercent = `${Math.round(ratio * 100)}%`;
 		const ringRadius = 9;
@@ -2875,16 +2950,22 @@ export class ChatView {
 							<textarea
 								id="chat-input"
 								class="chat-input"
-								placeholder="Ask for follow-up changes"
+								placeholder=${interactionLocked ? (connectivityStatus || "Session not ready…") : "Ask for follow-up changes"}
 								rows="1"
+								?disabled=${interactionLocked}
 								.value=${this.inputText}
 								@input=${(e: Event) => {
+									if (interactionLocked) return;
 									const ta = e.target as HTMLTextAreaElement;
 									this.inputText = ta.value;
 									ta.style.height = "auto";
 									ta.style.height = `${Math.min(ta.scrollHeight, 220)}px`;
 								}}
 								@paste=${(e: ClipboardEvent) => {
+									if (interactionLocked) {
+										e.preventDefault();
+										return;
+									}
 									const items = Array.from(e.clipboardData?.items || []);
 									const files = items
 										.filter((item) => item.type.startsWith("image/"))
@@ -2897,13 +2978,15 @@ export class ChatView {
 								}}
 								@dragover=${(e: DragEvent) => {
 									e.preventDefault();
-									if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+									if (e.dataTransfer) e.dataTransfer.dropEffect = interactionLocked ? "none" : "copy";
 								}}
 								@drop=${(e: DragEvent) => {
 									e.preventDefault();
+									if (interactionLocked) return;
 									this.handleDroppedDataTransfer(e.dataTransfer ?? null);
 								}}
 								@keydown=${(e: KeyboardEvent) => {
+									if (interactionLocked) return;
 									if (e.key === "Enter" && !e.shiftKey) {
 										e.preventDefault();
 										if (e.altKey) {
@@ -2916,7 +2999,7 @@ export class ChatView {
 								}}
 							></textarea>
 						</div>
-						${this.renderComposerControls(canSend, isStreaming)}
+						${this.renderComposerControls(canSend, isStreaming, interactionLocked)}
 						${statusText ? html`<div class="composer-status-inline">${statusText}</div>` : nothing}
 					</div>
 
@@ -2973,6 +3056,10 @@ export class ChatView {
 						multiple
 						style="display:none"
 						@change=${(e: Event) => {
+							if (interactionLocked) {
+								(e.target as HTMLInputElement).value = "";
+								return;
+							}
 							const files = (e.target as HTMLInputElement).files;
 							if (files?.length) void this.prepareImages(files);
 							(e.target as HTMLInputElement).value = "";

--- a/src/rpc/bridge.ts
+++ b/src/rpc/bridge.ts
@@ -166,6 +166,7 @@ export class RpcBridge {
 	private unlistenClosed: UnlistenFn | null = null;
 	private unlistenStderr: UnlistenFn | null = null;
 	private listenersReady = false;
+	private listenersReadyPromise: Promise<void> | null = null;
 	private _isConnected = false;
 	private currentGeneration: number | null = null;
 	private pendingGeneration: number | null = null;
@@ -214,6 +215,7 @@ export class RpcBridge {
 			this.lastStartOptions = { ...options };
 			this.lastDiscoveryInfo = result.discovery;
 			traceBridge(`started instance=${this.instanceId} generation=${this.currentGeneration ?? -1} discovery=${result.discovery}`);
+			this.emitToListeners({ type: "rpc_connected", discovery: result.discovery });
 			return result.discovery;
 		} catch (err) {
 			this.pendingGeneration = null;
@@ -243,7 +245,9 @@ export class RpcBridge {
 	}
 
 	onEvent(callback: RpcEventCallback): () => void {
-		void this.ensureListeners();
+		void this.ensureListeners().catch((err) => {
+			traceBridge(`listener-init-failed instance=${this.instanceId}: ${err instanceof Error ? err.message : String(err)}`);
+		});
 		this.eventListeners.push(callback);
 		return () => {
 			const idx = this.eventListeners.indexOf(callback);
@@ -484,40 +488,71 @@ export class RpcBridge {
 		return generation === this.currentGeneration;
 	}
 
+	private emitToListeners(event: Record<string, unknown>): void {
+		for (const listener of this.eventListeners) {
+			try {
+				listener(event);
+			} catch (err) {
+				traceBridge(`listener-error instance=${this.instanceId}: ${err instanceof Error ? err.message : String(err)}`);
+			}
+		}
+	}
+
 	private async ensureListeners(): Promise<void> {
 		if (this.listenersReady) return;
+		if (this.listenersReadyPromise) {
+			await this.listenersReadyPromise;
+			return;
+		}
 
-		this.unlistenEvent = await listen<RpcLineEventPayload>("rpc-event", (event) => {
-			const payload = event.payload;
-			if (payloadInstanceId(payload) !== this.instanceId) return;
-			if (!this.matchesPayloadGeneration(payload)) return;
-			const line = typeof payload.line === "string" ? payload.line : "";
-			if (!line) return;
-			this.handleLine(line);
-		});
+		this.listenersReadyPromise = (async () => {
+			let unlistenEventLocal: UnlistenFn | null = null;
+			let unlistenClosedLocal: UnlistenFn | null = null;
+			let unlistenStderrLocal: UnlistenFn | null = null;
+			try {
+				unlistenEventLocal = await listen<RpcLineEventPayload>("rpc-event", (event) => {
+					const payload = event.payload;
+					if (payloadInstanceId(payload) !== this.instanceId) return;
+					if (!this.matchesPayloadGeneration(payload)) return;
+					const line = typeof payload.line === "string" ? payload.line : "";
+					if (!line) return;
+					this.handleLine(line);
+				});
 
-		this.unlistenClosed = await listen<RpcClosedEventPayload>("rpc-closed", (event) => {
-			const payload = event.payload;
-			if (payloadInstanceId(payload) !== this.instanceId) return;
-			if (!this.matchesPayloadGeneration(payload)) return;
-			this._isConnected = false;
-			traceBridge(`closed instance=${this.instanceId} generation=${payload.generation ?? -1} reason=${typeof payload.reason === "string" ? payload.reason : "RPC process closed"}`);
-			this.rejectAllPending(typeof payload.reason === "string" ? payload.reason : "RPC process closed");
-			for (const listener of this.eventListeners) {
-				listener({ type: "rpc_disconnected" });
+				unlistenClosedLocal = await listen<RpcClosedEventPayload>("rpc-closed", (event) => {
+					const payload = event.payload;
+					if (payloadInstanceId(payload) !== this.instanceId) return;
+					if (!this.matchesPayloadGeneration(payload)) return;
+					this._isConnected = false;
+					traceBridge(`closed instance=${this.instanceId} generation=${payload.generation ?? -1} reason=${typeof payload.reason === "string" ? payload.reason : "RPC process closed"}`);
+					this.rejectAllPending(typeof payload.reason === "string" ? payload.reason : "RPC process closed");
+					this.emitToListeners({ type: "rpc_disconnected" });
+				});
+
+				unlistenStderrLocal = await listen<RpcLineEventPayload>("rpc-stderr", (event) => {
+					const payload = event.payload;
+					if (payloadInstanceId(payload) !== this.instanceId) return;
+					if (!this.matchesPayloadGeneration(payload)) return;
+					const line = typeof payload.line === "string" ? payload.line : "";
+					if (!line) return;
+					console.debug(`[pi stderr:${this.instanceId}]`, line);
+				});
+
+				this.unlistenEvent = unlistenEventLocal;
+				this.unlistenClosed = unlistenClosedLocal;
+				this.unlistenStderr = unlistenStderrLocal;
+				this.listenersReady = true;
+			} catch (err) {
+				unlistenEventLocal?.();
+				unlistenClosedLocal?.();
+				unlistenStderrLocal?.();
+				throw err;
+			} finally {
+				this.listenersReadyPromise = null;
 			}
-		});
+		})();
 
-		this.unlistenStderr = await listen<RpcLineEventPayload>("rpc-stderr", (event) => {
-			const payload = event.payload;
-			if (payloadInstanceId(payload) !== this.instanceId) return;
-			if (!this.matchesPayloadGeneration(payload)) return;
-			const line = typeof payload.line === "string" ? payload.line : "";
-			if (!line) return;
-			console.debug(`[pi stderr:${this.instanceId}]`, line);
-		});
-
-		this.listenersReady = true;
+		await this.listenersReadyPromise;
 	}
 
 	private handleLine(line: string): void {
@@ -543,7 +578,7 @@ export class RpcBridge {
 			return;
 		}
 
-		for (const listener of this.eventListeners) listener(data);
+		this.emitToListeners(data);
 	}
 
 	private async send(command: Record<string, unknown>): Promise<Record<string, unknown>> {
@@ -597,6 +632,11 @@ export class RpcBridge {
 	}
 
 	async teardownListeners(): Promise<void> {
+		if (this.listenersReadyPromise) {
+			await this.listenersReadyPromise.catch(() => {
+				// ignore listener initialization races during teardown
+			});
+		}
 		this.unlistenEvent?.();
 		this.unlistenClosed?.();
 		this.unlistenStderr?.();
@@ -604,6 +644,7 @@ export class RpcBridge {
 		this.unlistenClosed = null;
 		this.unlistenStderr = null;
 		this.listenersReady = false;
+		this.listenersReadyPromise = null;
 	}
 }
 


### PR DESCRIPTION
## Summary
Implements #33 to harden JSON-RPC event reliability and improve chat loading/tool-call UX.

### What changed
- **RPC bridge listener race fix** (`src/rpc/bridge.ts`)
  - Made `ensureListeners()` concurrency-safe with an in-flight promise guard.
  - Prevented duplicate Tauri listener registrations during concurrent `onEvent()` / `start()` calls.
  - Added cleanup on partial listener setup failures.
  - Added `rpc_connected` frontend event emission on successful start.

- **Tool call de-duplication** (`src/components/chat-view.ts`)
  - De-dups tool calls by `toolCall.id` in:
    - backend hydration (`mapBackendMessages`)
    - live streaming (`message_update` + `toolcall_end`)

- **Chat loading/reconnect UX hardening** (`src/components/chat-view.ts`)
  - Composer actions now lock while session is binding/reconnecting.
  - Inline composer status now includes connectivity/loading state.
  - Added handling for `rpc_connected` to refresh chat/model state after reconnect.

- **Release notes safety for unsigned macOS**
  - `.github/RELEASE_TEMPLATE.md`
  - `docs/RELEASES.md`
  - `RELEASE_CRITERIA.md`
  - Ensures release notes include:
    - `xattr -cr /Applications/Pi\ Desktop.app`

- **Project tracking updates**
  - `CHANGELOG.md` (Unreleased)
  - `TODO.md` active issue checklist synced to #33

## Validation
- `npm run check`
- `npm run build:frontend`
- `cargo check --manifest-path src-tauri/Cargo.toml`
