### PR TITLE
Packages UX polish + creatorskill-first defaults + config persistence fixes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -90,12 +90,12 @@ These should be packages/extensions/skills unless there is a very strong reason 
 - [x] Add first-class “recommended packages” section
 - [x] Make recommended packages external-sourced (`npm` / `git` / `url`) instead of bundling behavior packages into the app
 - [x] Keep global install as the default in the UI, with project install as an explicit/manual choice
-- [ ] Add richer package metadata in the pane:
+- [x] Add richer package metadata in the pane:
   - [x] source badges (`npm`, `git`, `local`)
   - [x] better project/global scoping cues
   - [x] simplify the Packages pane into a more minimalist list/row layout with less repeated chrome/text
   - [x] remove manual source install bar from the top-level flow; keep install action on package rows
-  - [ ] diagnostics/load errors where possible
+  - [x] diagnostics/load errors where possible
 - [ ] Add proper per-resource enable/disable UX
   - [ ] do **not** shell users into the interactive `pi config` TUI
   - [ ] prefer direct config/settings-driven desktop UX

--- a/assets/skills/creatorskill/SKILL.md
+++ b/assets/skills/creatorskill/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: creatorskill
+description: Create or update Pi prompt templates and Agent skills from a short user brief. Produces minimal, well-structured SKILL.md or prompt files that follow Agent Skills best practices.
+metadata:
+  short-description: Create or update a skill or prompt from a brief
+---
+
+# creatorskill
+
+Purpose
+
+This skill creates a lightweight, production-ready Pi resource (prompt template or Agent skill) from a short user brief. It favors concise, actionable files that follow the Agent Skills conventions and progressive disclosure: only the minimal metadata is kept in immediate context and larger references are stored separately.
+
+When to use
+
+- You want a new prompt template or skill scaffolded quickly from a short description.
+- You want a small, standards-compliant SKILL.md written for immediate use by Pi or other Agent Skill runtimes.
+- You prefer a single, reviewable change staged in chat (nothing is executed automatically).
+
+Input contract
+
+The skill expects a JSON payload (appended to the command) or equivalent user message with these fields:
+- kind: "auto" | "prompt" | "skill"        # preferred resource type or "auto" to infer
+- scope: "global" | "project"               # target location (global preferred)
+- brief: string                                # one-paragraph description of what the resource should do
+- name: string?                                # optional slug hint (will be normalized)
+
+Behavior
+
+1. Validate the brief. If essential details are missing, ask one concise clarification question.
+2. If kind == "auto", infer whether a prompt template or skill fits the brief.
+3. Determine a safe slug:
+   - Prefer an explicit `name` if provided after normalization.
+   - Otherwise derive a short, verb-led slug from the brief (lowercase, letters/numbers/hyphens, ≤64 chars).
+4. Create the resource under the chosen scope using Pi conventions:
+   - Prompt template: ~/.pi/agent/prompts/<slug>.md
+   - Skill: ~/.pi/agent/skills/<slug>/SKILL.md
+5. SKILL.md structure for skills:
+   - YAML frontmatter with `name` and `description` (these are the trigger fields)
+   - Body: short Purpose, Setup (one-time steps), Workflow (ordered steps), Examples (if helpful)
+   - Keep body concise; move large examples or references to `references/` files.
+6. For prompt templates:
+   - Create a markdown file with frontmatter `description` and a short reusable prompt body and usage notes.
+7. Never execute external commands or run the created scripts—always stage the operation and summarize the created files for user review.
+
+Naming rules
+
+- 1–64 chars, lowercase a-z, digits, hyphens only
+- No leading/trailing hyphens, no consecutive hyphens
+- Must match parent directory for SKILL.md (skill folder name)
+
+Examples
+
+Prepare a skill in chat (staged command):
+
+/skill:creatorskill {"kind":"skill","scope":"global","brief":"Create a skill that reviews staged git changes for security issues and outputs a short remediation plan."}
+
+Prepare a prompt template in chat (staged command):
+
+/skill:creatorskill {"kind":"prompt","scope":"global","brief":"Template for reviewing staged git changes with a strict security checklist."}
+
+Sample SKILL.md created for a security-review skill:
+
+```markdown
+---
+name: security-review
+description: Review staged git changes for security issues and suggest concise remediation steps. Use when you want an automated checklist and file-level recommendations for changed files.
+---
+
+# Security Review
+
+## Purpose
+Quickly identify security-relevant changes in staged files and provide prioritized remediation suggestions.
+
+## Setup
+No one-time setup required. (If helper scripts are included, document how to run them.)
+
+## Workflow
+1. List staged files and their diffs.
+2. For each file, check for secrets, insecure patterns, and risky configuration changes.
+3. Produce a short summary and per-file remediation steps.
+
+## Examples
+- `./scripts/check_secrets.sh` (run locally after review)
+```
+
+Validation & Best Practices
+
+- Keep SKILL.md focused: put large references under `references/` and link from SKILL.md.
+- Frontmatter MUST contain `name` and `description` (description should include trigger contexts).
+- Prefer short, imperative language and examples instead of long prose.
+- Ask at most one clarifying question if input is ambiguous.
+
+Notes
+
+- This skill only prepares and writes files under the chosen scope. It does not run or install anything.
+- On successful creation, summarize exactly which files were written and their absolute paths so the user can review and run them manually.

--- a/docs/ISSUE_IMPLEMENTATION_LOG_2026-03-22.md
+++ b/docs/ISSUE_IMPLEMENTATION_LOG_2026-03-22.md
@@ -114,6 +114,36 @@ Implemented:
 Relevant commits:
 - `9a3b994`, `4663f74`, `2bca6ae`
 
+## #25 — Resources/prompts/skills UX + default creatorskill policy
+
+Status: **Closed**
+
+Implemented:
+- Removed forced package/setup nudges and “recommended auto-install” behavior.
+- Kept only `creatorskill` as first-run default resource.
+- Bundled `creatorskill` in app assets and install/copy flow on first native run.
+- Reworked Packages pane IA and visuals toward minimal list layout (skills + extensions in unified installed view).
+- Improved skill/extension details modal UX, including cleaner content rendering and lower visual noise.
+- Added explicit initial loading state (`Loading packages…`) to reduce flicker/jump during async RPC/package discovery.
+
+Notes:
+- Creatorskill remains uninstallable by users.
+- No additional default package auto-install was introduced.
+
+## #40 — Package settings/config UX follow-up (model picker persistence)
+
+Status: **Closed**
+
+Implemented follow-up:
+- Fixed extension config hydration from disk for model-picker commands.
+- Added robust JSON discovery for extension/package config files (including canonical `~/.pi/agent/extensions/<package>.json`).
+- Added provider/id-to-`provider/model` normalization for extension configs such as `pi-session-auto-rename`.
+- Fixed select binding edge cases where UI could still show “Use package default” despite loaded config.
+- Preserved runtime command execution while persisting config updates back to disk.
+
+Notes:
+- Extension-specific config formats vary; generalized support will continue incrementally as more packages land.
+
 ## Next queued issues
 
 After this cycle, planned follow-up targets:

--- a/docs/PACKAGES.md
+++ b/docs/PACKAGES.md
@@ -20,12 +20,28 @@ Pi Desktop should expose capabilities that extensions can consume (UI primitives
 ## What Pi Desktop surfaces
 
 Pi Desktop includes a Packages pane that supports:
-- listing installed packages
-- install/remove/update flows
-- global vs project scope
-- recommended packages
+- extension package install/remove/update flows
+- skills + extensions surfaced as first-class package capabilities
+- curated recommendations (skills + extensions)
 
 It also renders extension-driven UI signals through the extension UI host boundary.
+
+### Skills + extensions in Desktop
+
+In the Packages pane:
+- **Installed** lists all installed skills + extensions in one view.
+- **Recommended** blends curated skills/extensions (Brave Search, Browser Tools, YouTube Transcript) with top extension picks and search results.
+- list rows keep minimal controls (`+` to install, `✓` when installed)
+- clicking an item opens a details modal for richer actions:
+  - extension settings/config commands
+  - install / uninstall
+  - open folder / open page
+  - skill setup + “try in chat”
+- model-picker settings hydrate from extension config JSON when available (e.g. `~/.pi/agent/extensions/<package>.json`)
+- **Create skill** stages `/skill:creatorskill` in chat for manual Enter
+
+If runtime discovery fails, Desktop shows explicit error banners and keeps diagnostics available in the Packages pane.
+The pane also shows an explicit initial loading state (`Loading packages…`) to avoid confusing partial renders while RPC/package discovery is still in progress.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "pi-desktop",
 			"version": "0.1.8",
+			"license": "MIT",
 			"dependencies": {
 				"@mariozechner/mini-lit": "^0.2.0",
 				"@tailwindcss/vite": "^4.1.17",
@@ -19,12 +20,832 @@
 				"@xterm/addon-webgl": "^0.19.0",
 				"@xterm/xterm": "^6.0.0",
 				"lit": "^3.3.1",
-				"lucide": "^0.544.0"
+				"lucide": "^0.544.0",
+				"pi-cursor-agent": "^0.4.2"
 			},
 			"devDependencies": {
 				"@tauri-apps/cli": "^2.0.0",
 				"typescript": "^5.7.3",
 				"vite": "^7.1.6"
+			}
+		},
+		"node_modules/@anthropic-ai/sdk": {
+			"version": "0.73.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.73.0.tgz",
+			"integrity": "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1018.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1018.0.tgz",
+			"integrity": "sha512-uJYVPDn+5n63hISPg/Q0YXITuqdWeC+wssIWKKvnX2Tgn+rPo5piAhvyCE2YzxGoBdBVHIUfu/KyGzUc7OgBYA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/credential-provider-node": "^3.972.26",
+				"@aws-sdk/eventstream-handler-node": "^3.972.12",
+				"@aws-sdk/middleware-eventstream": "^3.972.8",
+				"@aws-sdk/middleware-host-header": "^3.972.8",
+				"@aws-sdk/middleware-logger": "^3.972.8",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.9",
+				"@aws-sdk/middleware-user-agent": "^3.972.26",
+				"@aws-sdk/middleware-websocket": "^3.972.14",
+				"@aws-sdk/region-config-resolver": "^3.972.10",
+				"@aws-sdk/token-providers": "3.1018.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@aws-sdk/util-user-agent-browser": "^3.972.8",
+				"@aws-sdk/util-user-agent-node": "^3.973.12",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/core": "^3.23.12",
+				"@smithy/eventstream-serde-browser": "^4.2.12",
+				"@smithy/eventstream-serde-config-resolver": "^4.3.12",
+				"@smithy/eventstream-serde-node": "^4.2.12",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/hash-node": "^4.2.12",
+				"@smithy/invalid-dependency": "^4.2.12",
+				"@smithy/middleware-content-length": "^4.2.12",
+				"@smithy/middleware-endpoint": "^4.4.27",
+				"@smithy/middleware-retry": "^4.4.44",
+				"@smithy/middleware-serde": "^4.2.15",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/node-http-handler": "^4.5.0",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.7",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.43",
+				"@smithy/util-defaults-mode-node": "^4.2.47",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.12",
+				"@smithy/util-stream": "^4.5.20",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/core": {
+			"version": "3.973.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.25.tgz",
+			"integrity": "sha512-TNrx7eq6nKNOO62HWPqoBqPLXEkW6nLZQGwjL6lq1jZtigWYbK1NbCnT7mKDzbLMHZfuOECUt3n6CzxjUW9HWQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/xml-builder": "^3.972.16",
+				"@smithy/core": "^3.23.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/signature-v4": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.7",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.23",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.23.tgz",
+			"integrity": "sha512-EamaclJcCEaPHp6wiVknNMM2RlsPMjAHSsYSFLNENBM8Wz92QPc6cOn3dif6vPDQt0Oo4IEghDy3NMDCzY/IvA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.25.tgz",
+			"integrity": "sha512-qPymamdPcLp6ugoVocG1y5r69ScNiRzb0hogX25/ij+Wz7c7WnsgjLTaz7+eB5BfRxeyUwuw5hgULMuwOGOpcw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/node-http-handler": "^4.5.0",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.7",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-stream": "^4.5.20",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.25.tgz",
+			"integrity": "sha512-G/v/PicYn4qs7xCv4vT6I4QKdvMyRvsgIFNBkUueCGlbLo7/PuKcNKgUozmLSsaYnE7jIl6UrfkP07EUubr48w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/credential-provider-env": "^3.972.23",
+				"@aws-sdk/credential-provider-http": "^3.972.25",
+				"@aws-sdk/credential-provider-login": "^3.972.25",
+				"@aws-sdk/credential-provider-process": "^3.972.23",
+				"@aws-sdk/credential-provider-sso": "^3.972.25",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.25",
+				"@aws-sdk/nested-clients": "^3.996.15",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.25.tgz",
+			"integrity": "sha512-bUdmyJeVua7SmD+g2a65x2/0YqsGn4K2k4GawI43js0odaNaIzpIhLtHehUnPnfLuyhPWbJR1NyuIO4iMVfM0w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/nested-clients": "^3.996.15",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.26",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.26.tgz",
+			"integrity": "sha512-5XSK74rCXxCNj+UWv5bjq1EccYkiyW4XOHFU9NXnsCcQF8dJuHdua1qFg0m/LIwVOWklbKsrcnMtfxIXwgvwzQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.23",
+				"@aws-sdk/credential-provider-http": "^3.972.25",
+				"@aws-sdk/credential-provider-ini": "^3.972.25",
+				"@aws-sdk/credential-provider-process": "^3.972.23",
+				"@aws-sdk/credential-provider-sso": "^3.972.25",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.25",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.23",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.23.tgz",
+			"integrity": "sha512-IL/TFW59++b7MpHserjUblGrdP5UXy5Ekqqx1XQkERXBFJcZr74I7VaSrQT5dxdRMU16xGK4L0RQ5fQG1pMgnA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.25.tgz",
+			"integrity": "sha512-r4OGAfHmlEa1QBInHWz+/dOD4tRljcjVNQe9wJ/AJNXEj1d2WdsRLppvRFImRV6FIs+bTpjtL0a23V5ELQpRPw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/nested-clients": "^3.996.15",
+				"@aws-sdk/token-providers": "3.1018.0",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.25.tgz",
+			"integrity": "sha512-uM1OtoJgj+yK3MlAmda8uR9WJJCdm5HB25JyCeFL5a5q1Fbafalf4uKidFO3/L0Pgd+Fsflkb4cM6jHIswi3QQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/nested-clients": "^3.996.15",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.12.tgz",
+			"integrity": "sha512-ruyc/MNR6e+cUrGCth7fLQ12RXBZDy/bV06tgqB9Z5n/0SN/C0m6bsQEV8FF9zPI6VSAOaRd0rNgmpYVnGawrQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.8.tgz",
+			"integrity": "sha512-r+oP+tbCxgqXVC3pu3MUVePgSY0ILMjA+aEwOosS77m3/DRbtvHrHwqvMcw+cjANMeGzJ+i0ar+n77KXpRA8RQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-host-header": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.8.tgz",
+			"integrity": "sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-logger": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.8.tgz",
+			"integrity": "sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-recursion-detection": {
+			"version": "3.972.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.9.tgz",
+			"integrity": "sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-user-agent": {
+			"version": "3.972.26",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.26.tgz",
+			"integrity": "sha512-AilFIh4rI/2hKyyGN6XrB0yN96W2o7e7wyrPWCM6QjZM1mcC/pVkW3IWWRvuBWMpVP8Fg+rMpbzeLQ6dTM4gig==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@smithy/core": "^3.23.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-retry": "^4.2.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.14",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.14.tgz",
+			"integrity": "sha512-qnfDlIHjm6DrTYNvWOUbnZdVKgtoKbO/Qzj+C0Wp5Y7VUrsvBRQtGKxD+hc+mRTS4N0kBJ6iZ3+zxm4N1OSyjg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-format-url": "^3.972.8",
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/eventstream-serde-browser": "^4.2.12",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/signature-v4": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/nested-clients": {
+			"version": "3.996.15",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.15.tgz",
+			"integrity": "sha512-k6WAVNkub5DrU46iPQvH1m0xc1n+0dX79+i287tYJzf5g1yU2rX3uf4xNeL5JvK1NtYgfwMnsxHqhOXFBn367A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/middleware-host-header": "^3.972.8",
+				"@aws-sdk/middleware-logger": "^3.972.8",
+				"@aws-sdk/middleware-recursion-detection": "^3.972.9",
+				"@aws-sdk/middleware-user-agent": "^3.972.26",
+				"@aws-sdk/region-config-resolver": "^3.972.10",
+				"@aws-sdk/types": "^3.973.6",
+				"@aws-sdk/util-endpoints": "^3.996.5",
+				"@aws-sdk/util-user-agent-browser": "^3.972.8",
+				"@aws-sdk/util-user-agent-node": "^3.973.12",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/core": "^3.23.12",
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/hash-node": "^4.2.12",
+				"@smithy/invalid-dependency": "^4.2.12",
+				"@smithy/middleware-content-length": "^4.2.12",
+				"@smithy/middleware-endpoint": "^4.4.27",
+				"@smithy/middleware-retry": "^4.4.44",
+				"@smithy/middleware-serde": "^4.2.15",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/node-http-handler": "^4.5.0",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/smithy-client": "^4.12.7",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-body-length-node": "^4.2.3",
+				"@smithy/util-defaults-mode-browser": "^4.3.43",
+				"@smithy/util-defaults-mode-node": "^4.2.47",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.12",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/region-config-resolver": {
+			"version": "3.972.10",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.10.tgz",
+			"integrity": "sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/token-providers": {
+			"version": "3.1018.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1018.0.tgz",
+			"integrity": "sha512-97OPNJHy37wmGOX44xAcu6E9oSTiqK9uPcy/fWpmN5uB3JuEp1f6x60Xot/jp+FxwhQWIFUsVJFnm3QKqt7T6Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/core": "^3.973.25",
+				"@aws-sdk/nested-clients": "^3.996.15",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/types": {
+			"version": "3.973.6",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.6.tgz",
+			"integrity": "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-endpoints": {
+			"version": "3.996.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.5.tgz",
+			"integrity": "sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-endpoints": "^3.3.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-format-url": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.8.tgz",
+			"integrity": "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/querystring-builder": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-browser": {
+			"version": "3.972.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.8.tgz",
+			"integrity": "sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/types": "^4.13.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@aws-sdk/util-user-agent-node": {
+			"version": "3.973.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.12.tgz",
+			"integrity": "sha512-8phW0TS8ntENJgDcFewYT/Q8dOmarpvSxEjATu2GUBAutiHr++oEGCiBUwxslCMNvwW2cAPZNT53S/ym8zm/gg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-sdk/middleware-user-agent": "^3.972.26",
+				"@aws-sdk/types": "^3.973.6",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-config-provider": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"aws-crt": ">=1.0.0"
+			},
+			"peerDependenciesMeta": {
+				"aws-crt": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.16",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.16.tgz",
+			"integrity": "sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"fast-xml-parser": "5.5.8",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws/lambda-invoke-store": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@borewit/text-codec": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+			"integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@bufbuild/protobuf": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.0.tgz",
+			"integrity": "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag==",
+			"license": "(Apache-2.0 AND BSD-3-Clause)"
+		},
+		"node_modules/@connectrpc/connect": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.7.0.tgz",
+			"integrity": "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w==",
+			"license": "Apache-2.0",
+			"peerDependencies": {
+				"@bufbuild/protobuf": "^1.10.0"
+			}
+		},
+		"node_modules/@connectrpc/connect-node": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.7.0.tgz",
+			"integrity": "sha512-6vaPIkG/NyhxlYgytLoR9KYbPhczEboFB2OYWkA9qvUz1K7efXfeGrlRxoLtpa+r8VxyIOw73w5ktNe743nD+A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"undici": "^5.28.4"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"@bufbuild/protobuf": "^1.10.0",
+				"@connectrpc/connect": "1.7.0"
+			}
+		},
+		"node_modules/@connectrpc/connect-node/node_modules/undici": {
+			"version": "5.29.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+			"integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+			"license": "MIT",
+			"dependencies": {
+				"@fastify/busboy": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.0"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -443,6 +1264,39 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@fastify/busboy": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+			"integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@google/genai": {
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.46.0.tgz",
+			"integrity": "sha512-ewPMN5JkKfgU5/kdco9ZhXBHDPhVqZpMQqIFQhwsHLf8kyZfx1cNpw1pHo1eV6PGEW7EhIBFi3aYZraFndAXqg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -503,6 +1357,210 @@
 				"@lit-labs/ssr-dom-shim": "^1.5.0"
 			}
 		},
+		"node_modules/@mariozechner/clipboard": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.2.tgz",
+			"integrity": "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard-darwin-arm64": "0.3.2",
+				"@mariozechner/clipboard-darwin-universal": "0.3.2",
+				"@mariozechner/clipboard-darwin-x64": "0.3.2",
+				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
+				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
+				"@mariozechner/clipboard-linux-x64-musl": "0.3.2",
+				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
+				"@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-arm64": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.2.tgz",
+			"integrity": "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-universal": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
+			"integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-darwin-x64": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.2.tgz",
+			"integrity": "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.2.tgz",
+			"integrity": "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.2.tgz",
+			"integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.2.tgz",
+			"integrity": "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.2.tgz",
+			"integrity": "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-linux-x64-musl": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.2.tgz",
+			"integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.2.tgz",
+			"integrity": "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.2.tgz",
+			"integrity": "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"peer": true,
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@mariozechner/jiti": {
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/@mariozechner/jiti/-/jiti-2.6.5.tgz",
+			"integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"std-env": "^3.10.0",
+				"yoctocolors": "^2.1.2"
+			},
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
 		"node_modules/@mariozechner/mini-lit": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/@mariozechner/mini-lit/-/mini-lit-0.2.1.tgz",
@@ -524,6 +1582,142 @@
 				"lit": "^3.3.1"
 			}
 		},
+		"node_modules/@mariozechner/pi-agent-core": {
+			"version": "0.63.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-agent-core/-/pi-agent-core-0.63.1.tgz",
+			"integrity": "sha512-h0B20xfs/iEVR2EC4gwiE8hKI1TPeB8REdRJMgV+uXKH7gpeIZ9+s8Dp9nX35ZR0QUjkNey2+ULk2DxQtdg14Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@mariozechner/pi-ai": "^0.63.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@mariozechner/pi-ai": {
+			"version": "0.63.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-ai/-/pi-ai-0.63.1.tgz",
+			"integrity": "sha512-wjgwY+yfrFO6a9QdAfjWpH7iSrDean6GsKDDMohNcLCy6PreMxHOZvNM0NwJARL1tZoZovr7ikAQfLGFZbnjsw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@anthropic-ai/sdk": "^0.73.0",
+				"@aws-sdk/client-bedrock-runtime": "^3.983.0",
+				"@google/genai": "^1.40.0",
+				"@mistralai/mistralai": "1.14.1",
+				"@sinclair/typebox": "^0.34.41",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"chalk": "^5.6.2",
+				"openai": "6.26.0",
+				"partial-json": "^0.1.7",
+				"proxy-agent": "^6.5.0",
+				"undici": "^7.19.1",
+				"zod-to-json-schema": "^3.24.6"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@mariozechner/pi-coding-agent": {
+			"version": "0.63.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.63.1.tgz",
+			"integrity": "sha512-XSoMyLtuMA7ePK1UBWqSJ/BBdtBdJUHY9nbtnNyG6GeW7Gbgd+iqljIuwmAUf8wlYL981UIfYM/WIPQ6t/dIxw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@mariozechner/jiti": "^2.6.2",
+				"@mariozechner/pi-agent-core": "^0.63.1",
+				"@mariozechner/pi-ai": "^0.63.1",
+				"@mariozechner/pi-tui": "^0.63.1",
+				"@silvia-odwyer/photon-node": "^0.3.4",
+				"ajv": "^8.17.1",
+				"chalk": "^5.5.0",
+				"cli-highlight": "^2.1.11",
+				"diff": "^8.0.2",
+				"extract-zip": "^2.0.1",
+				"file-type": "^21.1.1",
+				"glob": "^13.0.1",
+				"hosted-git-info": "^9.0.2",
+				"ignore": "^7.0.5",
+				"marked": "^15.0.12",
+				"minimatch": "^10.2.3",
+				"proper-lockfile": "^4.1.2",
+				"strip-ansi": "^7.1.0",
+				"undici": "^7.19.1",
+				"yaml": "^2.8.2"
+			},
+			"bin": {
+				"pi": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=20.6.0"
+			},
+			"optionalDependencies": {
+				"@mariozechner/clipboard": "^0.3.2"
+			}
+		},
+		"node_modules/@mariozechner/pi-coding-agent/node_modules/marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@mariozechner/pi-tui": {
+			"version": "0.63.1",
+			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.63.1.tgz",
+			"integrity": "sha512-G5p+eh1EPkFCNaaggX6vRrqttnDscK6npgmEOknoCQXZtch8XNgh9Lf3VJ0A2lZXSgR7IntG5dfXHPH/Ki64wA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/mime-types": "^2.1.4",
+				"chalk": "^5.5.0",
+				"get-east-asian-width": "^1.3.0",
+				"marked": "^15.0.12",
+				"mime-types": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"optionalDependencies": {
+				"koffi": "^2.9.0"
+			}
+		},
+		"node_modules/@mariozechner/pi-tui/node_modules/marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@mistralai/mistralai": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.14.1.tgz",
+			"integrity": "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ==",
+			"peer": true,
+			"dependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.24.1"
+			}
+		},
 		"node_modules/@preact/signals-core": {
 			"version": "1.13.0",
 			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.13.0.tgz",
@@ -533,6 +1727,80 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"
 			}
+		},
+		"node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/codegen": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+			"integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/fetch": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.0"
+			}
+		},
+		"node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/inquire": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+			"integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/@protobufjs/utf8": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+			"integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+			"license": "BSD-3-Clause",
+			"peer": true
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
 			"version": "4.57.1",
@@ -858,6 +2126,716 @@
 			"os": [
 				"win32"
 			]
+		},
+		"node_modules/@silvia-odwyer/photon-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/@sinclair/typebox": {
+			"version": "0.34.48",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+			"integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@smithy/abort-controller": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.12.tgz",
+			"integrity": "sha512-xolrFw6b+2iYGl6EcOL7IJY71vvyZ0DJ3mcKtpykqPe2uscwtzDZJa1uVQXyP7w9Dd+kGwYnPbMsJrGISKiY/Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/config-resolver": {
+			"version": "4.4.13",
+			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.13.tgz",
+			"integrity": "sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-config-provider": "^4.2.2",
+				"@smithy/util-endpoints": "^3.3.3",
+				"@smithy/util-middleware": "^4.2.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/core": {
+			"version": "3.23.12",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.12.tgz",
+			"integrity": "sha512-o9VycsYNtgC+Dy3I0yrwCqv9CWicDnke0L7EVOrZtJpjb2t0EjaEofmMrYc0T1Kn3yk32zm6cspxF9u9Bj7e5w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-body-length-browser": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-stream": "^4.5.20",
+				"@smithy/util-utf8": "^4.2.2",
+				"@smithy/uuid": "^1.1.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/credential-provider-imds": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.12.tgz",
+			"integrity": "sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-codec": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
+			"integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-browser": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.12.tgz",
+			"integrity": "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-config-resolver": {
+			"version": "4.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.12.tgz",
+			"integrity": "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-node": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.12.tgz",
+			"integrity": "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/eventstream-serde-universal": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/eventstream-serde-universal": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.12.tgz",
+			"integrity": "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/eventstream-codec": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/fetch-http-handler": {
+			"version": "5.3.15",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.15.tgz",
+			"integrity": "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/querystring-builder": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/hash-node": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.12.tgz",
+			"integrity": "sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/invalid-dependency": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.12.tgz",
+			"integrity": "sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/is-array-buffer": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+			"integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-content-length": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.12.tgz",
+			"integrity": "sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-endpoint": {
+			"version": "4.4.27",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.27.tgz",
+			"integrity": "sha512-T3TFfUgXQlpcg+UdzcAISdZpj4Z+XECZ/cefgA6wLBd6V4lRi0svN2hBouN/be9dXQ31X4sLWz3fAQDf+nt6BA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.23.12",
+				"@smithy/middleware-serde": "^4.2.15",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"@smithy/url-parser": "^4.2.12",
+				"@smithy/util-middleware": "^4.2.12",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-retry": {
+			"version": "4.4.44",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.44.tgz",
+			"integrity": "sha512-Y1Rav7m5CFRPQyM4CI0koD/bXjyjJu3EQxZZhtLGD88WIrBrQ7kqXM96ncd6rYnojwOo/u9MXu57JrEvu/nLrA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/service-error-classification": "^4.2.12",
+				"@smithy/smithy-client": "^4.12.7",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-retry": "^4.2.12",
+				"@smithy/uuid": "^1.1.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-serde": {
+			"version": "4.2.15",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.15.tgz",
+			"integrity": "sha512-ExYhcltZSli0pgAKOpQQe1DLFBLryeZ22605y/YS+mQpdNWekum9Ujb/jMKfJKgjtz1AZldtwA/wCYuKJgjjlg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.23.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/middleware-stack": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.12.tgz",
+			"integrity": "sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-config-provider": {
+			"version": "4.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.12.tgz",
+			"integrity": "sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/shared-ini-file-loader": "^4.4.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/node-http-handler": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.5.0.tgz",
+			"integrity": "sha512-Rnq9vQWiR1+/I6NZZMNzJHV6pZYyEHt2ZnuV3MG8z2NNenC4i/8Kzttz7CjZiHSmsN5frhXhg17z3Zqjjhmz1A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/abort-controller": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/querystring-builder": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/property-provider": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.12.tgz",
+			"integrity": "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/protocol-http": {
+			"version": "5.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.12.tgz",
+			"integrity": "sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-builder": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.12.tgz",
+			"integrity": "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-uri-escape": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/querystring-parser": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.12.tgz",
+			"integrity": "sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/service-error-classification": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.12.tgz",
+			"integrity": "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/shared-ini-file-loader": {
+			"version": "4.4.7",
+			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.7.tgz",
+			"integrity": "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/signature-v4": {
+			"version": "5.3.12",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.12.tgz",
+			"integrity": "sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.2.2",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-middleware": "^4.2.12",
+				"@smithy/util-uri-escape": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/smithy-client": {
+			"version": "4.12.7",
+			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.7.tgz",
+			"integrity": "sha512-q3gqnwml60G44FECaEEsdQMplYhDMZYCtYhMCzadCnRnnHIobZJjegmdoUo6ieLQlPUzvrMdIJUpx6DoPmzANQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/core": "^3.23.12",
+				"@smithy/middleware-endpoint": "^4.4.27",
+				"@smithy/middleware-stack": "^4.2.12",
+				"@smithy/protocol-http": "^5.3.12",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-stream": "^4.5.20",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/types": {
+			"version": "4.13.1",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
+			"integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/url-parser": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.12.tgz",
+			"integrity": "sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/querystring-parser": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-base64": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-browser": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+			"integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-body-length-node": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+			"integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-buffer-from": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+			"integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/is-array-buffer": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-config-provider": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+			"integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-browser": {
+			"version": "4.3.43",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.43.tgz",
+			"integrity": "sha512-Qd/0wCKMaXxev/z00TvNzGCH2jlKKKxXP1aDxB6oKwSQthe3Og2dMhSayGCnsma1bK/kQX1+X7SMP99t6FgiiQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/smithy-client": "^4.12.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-defaults-mode-node": {
+			"version": "4.2.47",
+			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.47.tgz",
+			"integrity": "sha512-qSRbYp1EQ7th+sPFuVcVO05AE0QH635hycdEXlpzIahqHHf2Fyd/Zl+8v0XYMJ3cgDVPa0lkMefU7oNUjAP+DQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/config-resolver": "^4.4.13",
+				"@smithy/credential-provider-imds": "^4.2.12",
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/property-provider": "^4.2.12",
+				"@smithy/smithy-client": "^4.12.7",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-endpoints": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.3.tgz",
+			"integrity": "sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/node-config-provider": "^4.3.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-hex-encoding": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+			"integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-middleware": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.12.tgz",
+			"integrity": "sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-retry": {
+			"version": "4.2.12",
+			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.12.tgz",
+			"integrity": "sha512-1zopLDUEOwumjcHdJ1mwBHddubYF8GMQvstVCLC54Y46rqoHwlIU+8ZzUeaBcD+WCJHyDGSeZ2ml9YSe9aqcoQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/service-error-classification": "^4.2.12",
+				"@smithy/types": "^4.13.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-stream": {
+			"version": "4.5.20",
+			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.20.tgz",
+			"integrity": "sha512-4yXLm5n/B5SRBR2p8cZ90Sbv4zL4NKsgxdzCzp/83cXw2KxLEumt5p+GAVyRNZgQOSrzXn9ARpO0lUe8XSlSDw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/fetch-http-handler": "^5.3.15",
+				"@smithy/node-http-handler": "^4.5.0",
+				"@smithy/types": "^4.13.1",
+				"@smithy/util-base64": "^4.3.2",
+				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-hex-encoding": "^4.2.2",
+				"@smithy/util-utf8": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-uri-escape": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/util-utf8": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"@smithy/util-buffer-from": "^4.2.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@smithy/uuid": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
 		},
 		"node_modules/@tailwindcss/node": {
 			"version": "4.1.18",
@@ -1379,17 +3357,84 @@
 				"@tauri-apps/api": "^2.10.1"
 			}
 		},
+		"node_modules/@tokenizer/inflate": {
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+			"integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.4.3",
+				"token-types": "^6.1.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@tootallnate/quickjs-emscripten": {
+			"version": "0.23.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+			"integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"license": "MIT"
 		},
+		"node_modules/@types/mime-types": {
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
+			"integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@types/node": {
+			"version": "25.5.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+			"integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~7.18.0"
+			}
+		},
+		"node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@types/trusted-types": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
 			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
 			"license": "MIT"
+		},
+		"node_modules/@types/yauzl": {
+			"version": "2.10.3",
+			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@webreflection/alien-signals": {
 			"version": "0.3.2",
@@ -1421,11 +3466,206 @@
 				"addons/*"
 			]
 		},
+		"node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/alien-signals": {
 			"version": "2.0.8",
 			"resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-2.0.8.tgz",
 			"integrity": "sha512-844G1VLkk0Pe2SJjY0J8vp8ADI73IM4KliNu2OGlYzWpO28NexEUvjHTcFjFX3VXoiUtwTbHxLNI9ImkcoBqzA==",
 			"license": "MIT"
+		},
+		"node_modules/ansi-regex": {
+			"version": "6.2.2",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+			"integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/any-promise": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+			"integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/ast-types": {
+			"version": "0.13.4",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+			"integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/basic-ftp": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+			"integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
+		"node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/brace-expansion": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
 		},
 		"node_modules/class-variance-authority": {
 			"version": "0.7.1",
@@ -1439,6 +3679,90 @@
 				"url": "https://polar.sh/cva"
 			}
 		},
+		"node_modules/cli-highlight": {
+			"version": "2.1.11",
+			"resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+			"integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"chalk": "^4.0.0",
+				"highlight.js": "^10.7.1",
+				"mz": "^2.4.0",
+				"parse5": "^5.1.1",
+				"parse5-htmlparser2-tree-adapter": "^6.0.0",
+				"yargs": "^16.0.0"
+			},
+			"bin": {
+				"highlight": "bin/highlight"
+			},
+			"engines": {
+				"node": ">=8.0.0",
+				"npm": ">=5.0.0"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/cli-highlight/node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.0",
+				"wrap-ansi": "^7.0.0"
+			}
+		},
+		"node_modules/cliui/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cliui/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/clsx": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1448,6 +3772,26 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/commander": {
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
@@ -1455,6 +3799,49 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 12"
+			}
+		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/degenerator": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+			"integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ast-types": "^0.13.4",
+				"escodegen": "^2.1.0",
+				"esprima": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 14"
 			}
 		},
 		"node_modules/detect-libc": {
@@ -1473,6 +3860,33 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/end-of-stream": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"once": "^1.4.0"
 			}
 		},
 		"node_modules/enhanced-resolve": {
@@ -1529,6 +3943,171 @@
 				"@esbuild/win32-x64": "0.27.3"
 			}
 		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escodegen": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"esprima": "^4.0.1",
+				"estraverse": "^5.2.0",
+				"esutils": "^2.0.2"
+			},
+			"bin": {
+				"escodegen": "bin/escodegen.js",
+				"esgenerate": "bin/esgenerate.js"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"optionalDependencies": {
+				"source-map": "~0.6.1"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/extract-zip": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+			"license": "BSD-2-Clause",
+			"peer": true,
+			"dependencies": {
+				"debug": "^4.1.1",
+				"get-stream": "^5.1.0",
+				"yauzl": "^2.10.0"
+			},
+			"bin": {
+				"extract-zip": "cli.js"
+			},
+			"engines": {
+				"node": ">= 10.17.0"
+			},
+			"optionalDependencies": {
+				"@types/yauzl": "^2.9.1"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/fast-xml-builder": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
+			"integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"path-expression-matcher": "^1.1.3"
+			}
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.5.8",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.8.tgz",
+			"integrity": "sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fast-xml-builder": "^1.1.4",
+				"path-expression-matcher": "^1.2.0",
+				"strnum": "^2.2.0"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/fd-slicer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"pend": "~1.2.0"
+			}
+		},
 		"node_modules/fdir": {
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1546,6 +4125,62 @@
 				}
 			}
 		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/file-type": {
+			"version": "21.3.4",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+			"integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tokenizer/inflate": "^0.4.1",
+				"strtok3": "^10.3.4",
+				"token-types": "^6.1.1",
+				"uint8array-extras": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1560,11 +4195,161 @@
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
+		"node_modules/gaxios": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-east-asian-width": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-stream": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"pump": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-uri": {
+			"version": "6.0.5",
+			"resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+			"integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"basic-ftp": "^5.0.2",
+				"data-uri-to-buffer": "^6.0.2",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/get-uri/node_modules/data-uri-to-buffer": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+			"integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/google-auth-library": {
+			"version": "10.6.2",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"license": "ISC"
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/highlight.js": {
 			"version": "11.11.1",
@@ -1575,11 +4360,103 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/hosted-git-info": {
+			"version": "9.0.2",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+			"integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/html-parse-string": {
 			"version": "0.0.9",
 			"resolved": "https://registry.npmjs.org/html-parse-string/-/html-parse-string-0.0.9.tgz",
 			"integrity": "sha512-wyGnsOolHbNrcb8N6bdJF4EHyzd3zVGCb9/mBxeNjAYBDOZqD7YkqLBz7kXtdgHwNnV8lN/BpSDpsI1zm8Sd8g==",
 			"license": "MIT"
+		},
+		"node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause",
+			"peer": true
+		},
+		"node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/ip-address": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
 		},
 		"node_modules/jiti": {
 			"version": "2.6.1",
@@ -1588,6 +4465,60 @@
 			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"node_modules/katex": {
@@ -1604,6 +4535,18 @@
 			},
 			"bin": {
 				"katex": "cli.js"
+			}
+		},
+		"node_modules/koffi": {
+			"version": "2.15.2",
+			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.2.tgz",
+			"integrity": "sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"peer": true,
+			"funding": {
+				"url": "https://liberapay.com/Koromix"
 			}
 		},
 		"node_modules/lightningcss": {
@@ -1886,6 +4829,23 @@
 				"@types/trusted-types": "^2.0.2"
 			}
 		},
+		"node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"license": "Apache-2.0",
+			"peer": true
+		},
+		"node_modules/lru-cache": {
+			"version": "11.2.7",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+			"integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/lucide": {
 			"version": "0.544.0",
 			"resolved": "https://registry.npmjs.org/lucide/-/lucide-0.544.0.tgz",
@@ -1913,6 +4873,78 @@
 				"node": ">= 20"
 			}
 		},
+		"node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/minimatch": {
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"brace-expansion": "^5.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/mz": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+			"integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"any-promise": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"thenify-all": "^1.0.0"
+			}
+		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1929,6 +4961,232 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
+		"node_modules/netmask": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"peer": true,
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/pac-proxy-agent": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+			"integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tootallnate/quickjs-emscripten": "^0.23.0",
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"get-uri": "^6.0.1",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.6",
+				"pac-resolver": "^7.0.1",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/pac-resolver": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+			"integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"degenerator": "^5.0.0",
+				"netmask": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/parse5": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+			"integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+			"integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"parse5": "^6.0.1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/path-expression-matcher": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
+			"integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"license": "BlueOak-1.0.0",
+			"peer": true,
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/pend": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/pi-cursor-agent": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/pi-cursor-agent/-/pi-cursor-agent-0.4.2.tgz",
+			"integrity": "sha512-AOHZKMuf2ZpeiS/xNaaanZOQu6JuXaahDNFlJDT3+k8kQ8pfIsS696DQHuBhj7pso1PEVOirJ9+fWbRmOnNgsg==",
+			"license": "MIT",
+			"dependencies": {
+				"@bufbuild/protobuf": "1.10.0",
+				"@connectrpc/connect": "^1.7.0",
+				"@connectrpc/connect-node": "^1.7.0"
+			},
+			"peerDependencies": {
+				"@mariozechner/pi-ai": ">=0.52.10",
+				"@mariozechner/pi-coding-agent": ">=0.52.10"
 			}
 		},
 		"node_modules/picocolors": {
@@ -1977,6 +5235,131 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
+		"node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/proper-lockfile/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/protobufjs": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+			"integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"peer": true,
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.4",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.0",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.0",
+				"@types/node": ">=13.7.0",
+				"long": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/proxy-agent": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+			"integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"http-proxy-agent": "^7.0.1",
+				"https-proxy-agent": "^7.0.6",
+				"lru-cache": "^7.14.1",
+				"pac-proxy-agent": "^7.1.0",
+				"proxy-from-env": "^1.1.0",
+				"socks-proxy-agent": "^8.0.5"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/proxy-agent/node_modules/lru-cache": {
+			"version": "7.18.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+			"integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/pump": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/rollup": {
 			"version": "4.57.1",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -2021,6 +5404,86 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+			"integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks": {
+			"version": "2.8.7",
+			"resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+			"integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ip-address": "^10.0.1",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/socks-proxy-agent": {
+			"version": "8.0.5",
+			"resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+			"integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "^4.3.4",
+				"socks": "^2.8.3"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2028,6 +5491,110 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/std-env": {
+			"version": "3.10.0",
+			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+			"integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/string-width/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+			"integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^6.2.2"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/strnum": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
+			"integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/strtok3": {
+			"version": "10.3.5",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+			"integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/tailwind-merge": {
@@ -2078,6 +5645,29 @@
 				"url": "https://opencollective.com/webpack"
 			}
 		},
+		"node_modules/thenify": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+			"integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"any-promise": "^1.0.0"
+			}
+		},
+		"node_modules/thenify-all": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+			"integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"thenify": ">= 3.1.0 < 4"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
 		"node_modules/tinyglobby": {
 			"version": "0.2.15",
 			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2093,6 +5683,38 @@
 			"funding": {
 				"url": "https://github.com/sponsors/SuperchupuDev"
 			}
+		},
+		"node_modules/token-types": {
+			"version": "6.1.2",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+			"integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@borewit/text-codec": "^0.2.1",
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
 		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
@@ -2116,6 +5738,36 @@
 			"dependencies": {
 				"@webreflection/alien-signals": "^0.3.2"
 			}
+		},
+		"node_modules/uint8array-extras": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+			"integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/undici": {
+			"version": "7.24.6",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+			"integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/vite": {
 			"version": "7.3.1",
@@ -2189,6 +5841,185 @@
 				"yaml": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC",
+			"peer": true
+		},
+		"node_modules/ws": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yaml": {
+			"version": "2.8.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+			"license": "ISC",
+			"peer": true,
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"license": "ISC",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
+			}
+		},
+		"node_modules/yoctocolors": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+			"integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "4.3.6",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"license": "MIT",
+			"peer": true,
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"license": "ISC",
+			"peer": true,
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
 		"@xterm/addon-webgl": "^0.19.0",
 		"@xterm/xterm": "^6.0.0",
 		"lit": "^3.3.1",
-		"lucide": "^0.544.0"
+		"lucide": "^0.544.0",
+		"pi-cursor-agent": "^0.4.2"
 	},
 	"devDependencies": {
 		"@tauri-apps/cli": "^2.0.0",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -150,6 +150,20 @@ fn discover_sidecar(app: &AppHandle) -> Option<PathBuf> {
     None
 }
 
+fn resolve_home_dir() -> Option<PathBuf> {
+    if let Ok(home) = std::env::var("HOME") {
+        if !home.trim().is_empty() {
+            return Some(PathBuf::from(home));
+        }
+    }
+    if let Ok(user_profile) = std::env::var("USERPROFILE") {
+        if !user_profile.trim().is_empty() {
+            return Some(PathBuf::from(user_profile));
+        }
+    }
+    None
+}
+
 fn discover_pi_from_common_locations() -> Option<PathBuf> {
     let mut candidates: Vec<PathBuf> = Vec::new();
 
@@ -206,9 +220,7 @@ fn discover_pi_from_common_locations() -> Option<PathBuf> {
         return candidates.into_iter().find(|candidate| candidate.is_file());
     }
 
-    if let Ok(home) = std::env::var("HOME") {
-        let home_dir = PathBuf::from(home);
-
+    if let Some(home_dir) = resolve_home_dir() {
         // nvm installations (common for npm global installs)
         candidates.push(home_dir.join(".nvm/versions/node/current/bin/pi"));
         let nvm_versions_dir = home_dir.join(".nvm/versions/node");
@@ -230,6 +242,7 @@ fn discover_pi_from_common_locations() -> Option<PathBuf> {
         }
 
         // Other common per-user install locations
+        candidates.push(home_dir.join(".pi/agent/bin/pi"));
         candidates.push(home_dir.join(".volta/bin/pi"));
         candidates.push(home_dir.join(".local/bin/pi"));
     }
@@ -301,20 +314,55 @@ fn discover_npm_path(pi: Option<&PiProcess>) -> Option<PathBuf> {
     candidates.into_iter().find(|candidate| candidate.is_file())
 }
 
+fn discover_pi_from_env_override() -> Option<PathBuf> {
+    for key in ["PI_DESKTOP_PI_PATH", "PI_CLI_PATH"] {
+        if let Ok(raw) = std::env::var(key) {
+            let value = raw.trim();
+            if value.is_empty() {
+                continue;
+            }
+            let candidate = PathBuf::from(value);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+            if let Ok(which_path) = which::which(value) {
+                return Some(which_path);
+            }
+        }
+    }
+    None
+}
+
 /// Discover the pi binary. Strategy:
 /// 1. If cli_path is provided (dev mode), use node + script
-/// 2. Try sidecar discovery (packaged app)
-/// 3. Try finding `pi` on PATH (globally installed CLI or standalone binary)
-/// 4. Try common install locations (for GUI app launches without shell PATH)
-/// 5. Fail with actionable error
+/// 2. Try explicit env override (PI_DESKTOP_PI_PATH / PI_CLI_PATH)
+/// 3. Try sidecar discovery (packaged app)
+/// 4. Try finding `pi` on PATH (globally installed CLI or standalone binary)
+/// 5. Try common install locations (for GUI app launches without shell PATH)
+/// 6. Fail with actionable error
 fn discover_pi(app: &AppHandle, options: &RpcStartOptions) -> Result<PiProcess, String> {
     // Dev mode: cli_path explicitly provided
     if let Some(ref cli_path) = options.cli_path {
-        if !cli_path.is_empty() {
-            return Ok(PiProcess::DevNode {
-                script: cli_path.clone(),
-            });
+        let trimmed = cli_path.trim();
+        if !trimmed.is_empty() {
+            if trimmed.ends_with(".js") || trimmed.ends_with(".mjs") || trimmed.ends_with(".cjs") {
+                return Ok(PiProcess::DevNode {
+                    script: trimmed.to_string(),
+                });
+            }
+            let direct = PathBuf::from(trimmed);
+            if direct.is_file() {
+                return Ok(PiProcess::PathBinary { path: direct });
+            }
+            if let Ok(which_path) = which::which(trimmed) {
+                return Ok(PiProcess::PathBinary { path: which_path });
+            }
         }
+    }
+
+    // Explicit environment override
+    if let Some(path) = discover_pi_from_env_override() {
+        return Ok(PiProcess::PathBinary { path });
     }
 
     // Packaged app: bundled sidecar
@@ -423,6 +471,11 @@ async fn rpc_start(
     } else {
         return Err("Failed to acquire RPC instances lock".to_string());
     };
+
+    let cwd_path = Path::new(&options.cwd);
+    if !cwd_path.is_dir() {
+        return Err(format!("Working directory does not exist: {}", options.cwd));
+    }
 
     let pi = discover_pi(&app, &options)?;
     let discovery_label = format!("{:?}", pi);
@@ -1252,9 +1305,14 @@ async fn run_pi_cli_command(
         return Err("No command arguments provided".to_string());
     }
 
+    let resolved_cwd = options.cwd.clone().unwrap_or_else(|| ".".to_string());
+    if !Path::new(&resolved_cwd).is_dir() {
+        return Err(format!("Working directory does not exist: {}", resolved_cwd));
+    }
+
     let discovery_opts = RpcStartOptions {
         cli_path: options.cli_path.clone(),
-        cwd: options.cwd.clone().unwrap_or_else(|| ".".to_string()),
+        cwd: resolved_cwd,
         provider: None,
         model: None,
         env: options.env.clone(),

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -110,6 +110,20 @@ interface WelcomeDashboardSummary {
 	updatedAt: number;
 }
 
+interface ComposerSkillDraft {
+	name: string;
+	commandText: string;
+	scope: string | null;
+}
+
+interface SlashPaletteItem {
+	id: string;
+	section: "Actions" | "Skills";
+	label: string;
+	hint: string;
+	skillName?: string;
+}
+
 function uid(prefix = "id"): string {
 	return `${prefix}_${Math.random().toString(36).slice(2, 8)}_${Date.now().toString(36)}`;
 }
@@ -295,8 +309,14 @@ export class ChatView {
 	private forkExpandedToolRows = new Set<string>();
 	private historyQuery = "";
 	private historyRoleFilter: UiRole | "all" = "all";
-	private quickActionsOpen = false;
 	private autoFollowChat = true;
+	private selectedSkillDraft: ComposerSkillDraft | null = null;
+	private slashPaletteOpen = false;
+	private slashPaletteQuery = "";
+	private slashPaletteIndex = 0;
+	private slashSkills: string[] = [];
+	private slashSkillsLoading = false;
+	private slashSkillsUpdatedAt = 0;
 	private runHasAssistantText = false;
 	private readonly workingStatusPhrases = [
 		"starting",
@@ -403,8 +423,12 @@ export class ChatView {
 			__PI_DESKTOP_PUSH_TRACE__?: (message: string) => void;
 		}).__PI_DESKTOP_PUSH_TRACE__;
 		push?.(`chat:setProjectPath ${previous ?? "-"} -> ${path ?? "-"}`);
-		this.quickActionsOpen = false;
 		this.gitMenuOpen = false;
+		this.selectedSkillDraft = null;
+		this.slashPaletteOpen = false;
+		this.slashPaletteQuery = "";
+		this.slashPaletteIndex = 0;
+		this.slashSkillsUpdatedAt = 0;
 		if (!path) {
 			this.bindingStatusText = null;
 			this.modelLoadRequestSeq += 1;
@@ -427,6 +451,10 @@ export class ChatView {
 		this.lastBackendSessionFile = null;
 		this.lastBackendRefreshError = null;
 		this.pendingDeliveryMode = "prompt";
+		this.selectedSkillDraft = null;
+		this.slashPaletteOpen = false;
+		this.slashPaletteQuery = "";
+		this.slashPaletteIndex = 0;
 		this.runHasAssistantText = false;
 		this.clearWorkingStatusTimer(true);
 		this.bindingStatusText = projectPath ? (statusText ?? "Loading session…") : null;
@@ -439,6 +467,7 @@ export class ChatView {
 
 	setInputText(text: string): void {
 		this.inputText = text;
+		this.updateSlashPaletteStateFromInput();
 		this.render();
 		requestAnimationFrame(() => {
 			const textarea = this.container.querySelector("#chat-input") as HTMLTextAreaElement | null;
@@ -448,6 +477,242 @@ export class ChatView {
 			textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`;
 			textarea.focus();
 		});
+	}
+
+	stageComposerCommand(commandText: string): void {
+		const draft = this.parseComposerSkillDraftFromCommand(commandText);
+		if (draft) {
+			this.selectedSkillDraft = draft;
+			this.inputText = "";
+			this.updateSlashPaletteStateFromInput();
+			this.render();
+			requestAnimationFrame(() => {
+				const textarea = this.container.querySelector("#chat-input") as HTMLTextAreaElement | null;
+				textarea?.focus();
+			});
+			return;
+		}
+		this.selectedSkillDraft = null;
+		this.inputText = commandText;
+		this.closeSlashPalette();
+		this.render();
+		requestAnimationFrame(() => {
+			const textarea = this.container.querySelector("#chat-input") as HTMLTextAreaElement | null;
+			if (!textarea) return;
+			textarea.value = commandText;
+			textarea.style.height = "auto";
+			textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`;
+			textarea.focus();
+		});
+	}
+
+	private parseComposerSkillDraftFromCommand(commandText: string): ComposerSkillDraft | null {
+		const trimmed = commandText.trim();
+		const match = trimmed.match(/^\/skill:([a-zA-Z0-9._-]+)\b([\s\S]*)$/);
+		if (!match) return null;
+		const name = match[1] || "";
+		const suffix = (match[2] || "").trim();
+		if (!suffix) {
+			return { name, commandText: `/skill:${name}`, scope: null };
+		}
+		if (!suffix.startsWith("{")) {
+			return { name, commandText: `/skill:${name} ${suffix}`, scope: null };
+		}
+		try {
+			const payload = JSON.parse(suffix) as { scope?: unknown };
+			return {
+				name,
+				commandText: `/skill:${name} ${suffix}`,
+				scope: typeof payload.scope === "string" && payload.scope.trim().length > 0 ? payload.scope.trim() : null,
+			};
+		} catch {
+			return { name, commandText: `/skill:${name} ${suffix}`, scope: null };
+		}
+	}
+
+	private removeComposerSkillDraft(): void {
+		this.selectedSkillDraft = null;
+		this.render();
+		requestAnimationFrame(() => {
+			const textarea = this.container.querySelector("#chat-input") as HTMLTextAreaElement | null;
+			textarea?.focus();
+		});
+	}
+
+	private slashQueryFromInput(): string | null {
+		const raw = this.inputText;
+		if (!raw.startsWith("/")) return null;
+		if (raw.includes("\n")) return null;
+		return raw.slice(1).trimStart();
+	}
+
+	private updateSlashPaletteStateFromInput(): void {
+		const query = this.slashQueryFromInput();
+		if (query === null) {
+			this.slashPaletteOpen = false;
+			this.slashPaletteQuery = "";
+			this.slashPaletteIndex = 0;
+			return;
+		}
+		const normalized = query.toLowerCase();
+		if (!this.slashPaletteOpen || normalized !== this.slashPaletteQuery) {
+			this.slashPaletteIndex = 0;
+		}
+		this.slashPaletteOpen = true;
+		this.slashPaletteQuery = normalized;
+		void this.ensureSlashSkillsLoaded();
+	}
+
+	private closeSlashPalette(clearInput = false): void {
+		this.slashPaletteOpen = false;
+		this.slashPaletteQuery = "";
+		this.slashPaletteIndex = 0;
+		if (clearInput) this.inputText = "";
+	}
+
+	private normalizeSkillNameFromCommand(rawName: string): string | null {
+		const trimmed = rawName.trim();
+		if (!trimmed) return null;
+		const fromPrefixed = trimmed.match(/^\/?skill:([a-zA-Z0-9._-]+)\b/i);
+		if (fromPrefixed) return fromPrefixed[1] ?? null;
+		if (/^[a-zA-Z0-9._-]+$/.test(trimmed)) return trimmed;
+		return null;
+	}
+
+	private collectRuntimeSkillNames(commands: Array<Record<string, unknown>>): string[] {
+		const names = new Set<string>();
+		for (const raw of commands) {
+			const source = normalizeText((raw as Record<string, unknown>).source).toLowerCase();
+			if (source !== "skill") continue;
+			const name = this.normalizeSkillNameFromCommand(normalizeText((raw as Record<string, unknown>).name));
+			if (name) names.add(name);
+		}
+		return [...names].sort((a, b) => a.localeCompare(b));
+	}
+
+	private async ensureSlashSkillsLoaded(force = false): Promise<void> {
+		if (this.slashSkillsLoading) return;
+		if (!force && this.slashSkills.length > 0 && Date.now() - this.slashSkillsUpdatedAt < 120_000) return;
+		this.slashSkillsLoading = true;
+		if (this.slashPaletteOpen) this.render();
+		try {
+			const runtimeCommands = await rpcBridge.getCommands().catch(() => []);
+			const runtimeSkills = this.collectRuntimeSkillNames(runtimeCommands as Array<Record<string, unknown>>);
+
+			const { homeDir } = await import("@tauri-apps/api/path");
+			const home = await homeDir();
+			const roots = [joinFsPath(joinFsPath(joinFsPath(home, ".pi"), "agent"), "skills")];
+			const sets = await Promise.all(roots.map((root) => this.collectSkillNames(root)));
+			const merged = new Set<string>(runtimeSkills);
+			for (const list of sets) {
+				for (const name of list) merged.add(name);
+			}
+			this.slashSkills = [...merged].sort((a, b) => a.localeCompare(b));
+			this.slashSkillsUpdatedAt = Date.now();
+		} catch {
+			this.slashSkills = this.slashSkills.slice();
+			this.slashSkillsUpdatedAt = Date.now();
+		} finally {
+			this.slashSkillsLoading = false;
+			if (this.slashPaletteOpen) this.render();
+		}
+	}
+
+	private matchesSlashQuery(query: string, ...values: string[]): boolean {
+		if (!query) return true;
+		const haystack = values.join(" ").toLowerCase();
+		return haystack.includes(query);
+	}
+
+	private getSlashPaletteItems(): SlashPaletteItem[] {
+		if (!this.slashPaletteOpen) return [];
+		const query = this.slashPaletteQuery;
+		const actions: SlashPaletteItem[] = [
+			{ id: "action:new-session", section: "Actions" as const, label: "New session", hint: "Create a fresh session tab" },
+			{ id: "action:rename-session", section: "Actions" as const, label: "Rename session", hint: "Rename current session" },
+			{ id: "action:open-terminal", section: "Actions" as const, label: "Open terminal", hint: "Switch to terminal pane" },
+			{ id: "action:compact", section: "Actions" as const, label: "Compact context", hint: "Run session compaction now" },
+			{ id: "action:fork", section: "Actions" as const, label: "Fork from message", hint: "Create fork from session history" },
+			{ id: "action:history", section: "Actions" as const, label: "Open history", hint: "Browse current session history" },
+			{ id: "action:copy-last", section: "Actions" as const, label: "Copy last answer", hint: "Copy latest assistant response" },
+			{ id: "action:export-html", section: "Actions" as const, label: "Export HTML", hint: "Export conversation to HTML" },
+		].filter((item) => this.matchesSlashQuery(query, item.label, item.hint, item.id));
+
+		const skills = this.slashSkills
+			.filter((name) => this.matchesSlashQuery(query, name, "skill"))
+			.slice(0, 24)
+			.map((name) => ({
+				id: `skill:${name}`,
+				section: "Skills" as const,
+				label: name,
+				hint: "Use skill in composer",
+				skillName: name,
+			}));
+
+		if (query && query.startsWith("skill:") && skills.length === 0) {
+			const raw = query.slice("skill:".length).trim();
+			if (raw) {
+				skills.push({
+					id: `skill:${raw}`,
+					section: "Skills" as const,
+					label: raw,
+					hint: "Use typed skill name",
+					skillName: raw,
+				});
+			}
+		}
+
+		return [...actions, ...skills];
+	}
+
+	private selectSlashPaletteItem(item: SlashPaletteItem): void {
+		if (item.section === "Skills" && item.skillName) {
+			this.selectedSkillDraft = {
+				name: item.skillName,
+				commandText: `/skill:${item.skillName}`,
+				scope: null,
+			};
+			this.inputText = "";
+			this.closeSlashPalette();
+			this.render();
+			requestAnimationFrame(() => {
+				const textarea = this.container.querySelector("#chat-input") as HTMLTextAreaElement | null;
+				textarea?.focus();
+			});
+			return;
+		}
+
+		this.inputText = "";
+		this.closeSlashPalette();
+		this.render();
+		switch (item.id) {
+			case "action:new-session":
+				void this.newSession();
+				return;
+			case "action:rename-session":
+				void this.renameSession();
+				return;
+			case "action:open-terminal":
+				this.onOpenTerminal?.();
+				return;
+			case "action:compact":
+				void this.compactNow();
+				return;
+			case "action:fork":
+				this.openHistoryViewerForFork({ loading: false, sessionName: this.state?.sessionName ?? null });
+				return;
+			case "action:history":
+				this.openHistoryViewer();
+				return;
+			case "action:copy-last":
+				void this.copyLastMessage();
+				return;
+			case "action:export-html":
+				void this.exportToHtml();
+				return;
+			default:
+				return;
+		}
 	}
 
 	private async bindNativeFileDropListener(): Promise<void> {
@@ -2420,6 +2685,8 @@ export class ChatView {
 	private clearComposer(): void {
 		this.inputText = "";
 		this.pendingImages = [];
+		this.selectedSkillDraft = null;
+		this.closeSlashPalette();
 		this.render();
 		const textarea = this.container.querySelector("#chat-input") as HTMLTextAreaElement | null;
 		if (textarea) {
@@ -2433,7 +2700,11 @@ export class ChatView {
 			this.pushNotice(this.bindingStatusText || "Session is still loading. Try again in a moment.", "info");
 			return;
 		}
-		const text = this.inputText.trim();
+		const promptText = this.inputText.trim();
+		const selectedSkillCommand = this.selectedSkillDraft?.commandText?.trim() ?? "";
+		const text = selectedSkillCommand
+			? (promptText ? `${selectedSkillCommand}\n\n${promptText}` : selectedSkillCommand)
+			: promptText;
 		const images = [...this.pendingImages];
 		if (!text && images.length === 0) return;
 
@@ -3448,66 +3719,6 @@ export class ChatView {
 				</div>
 
 				<div class="control-group right">
-					<div class="chat-actions-menu-wrap">
-						<button
-							class="composer-icon-btn"
-							title="Session actions"
-							?disabled=${interactionLocked}
-							@click=${() => {
-								if (interactionLocked) return;
-								this.quickActionsOpen = !this.quickActionsOpen;
-								this.render();
-							}}
-						>
-							${uiIcon("spark")}
-						</button>
-						${this.quickActionsOpen
-							? html`
-								<div class="chat-actions-menu">
-									<button @click=${() => {
-										this.quickActionsOpen = false;
-										this.render();
-										void this.newSession();
-									}}>New session</button>
-									<button @click=${() => {
-										this.quickActionsOpen = false;
-										this.render();
-										void this.renameSession();
-									}}>Rename session</button>
-									<button @click=${() => {
-										this.quickActionsOpen = false;
-										this.render();
-										this.onOpenTerminal?.();
-									}}>Open terminal</button>
-									<button @click=${() => {
-										this.quickActionsOpen = false;
-										this.render();
-										void this.compactNow();
-									}}>Compact context</button>
-									<button @click=${() => {
-										this.quickActionsOpen = false;
-										this.render();
-										this.openHistoryViewerForFork({ loading: false, sessionName: this.state?.sessionName ?? null });
-									}}>Fork from message</button>
-									<button @click=${() => {
-										this.quickActionsOpen = false;
-										this.render();
-										this.openHistoryViewer();
-									}}>Open history</button>
-									<button @click=${() => {
-										this.quickActionsOpen = false;
-										this.render();
-										void this.copyLastMessage();
-									}}>Copy last answer</button>
-									<button @click=${() => {
-										this.quickActionsOpen = false;
-										this.render();
-										void this.exportToHtml();
-									}}>Export HTML</button>
-								</div>
-							`
-							: nothing}
-					</div>
 					${isStreaming
 						? html`
 							<button
@@ -3560,10 +3771,59 @@ export class ChatView {
 		`;
 	}
 
+	private renderComposerSkillDraftPill(): TemplateResult | typeof nothing {
+		const draft = this.selectedSkillDraft;
+		if (!draft) return nothing;
+		return html`
+			<div class="composer-skill-draft-row">
+				<div class="composer-skill-draft-pill">
+					<span class="composer-skill-draft-label">Skill</span>
+					<span class="composer-skill-draft-name">${draft.name}</span>
+					<button class="composer-skill-draft-remove" title="Remove skill" @click=${() => this.removeComposerSkillDraft()}>✕</button>
+				</div>
+			</div>
+		`;
+	}
+
+	private renderSlashPalette(items: SlashPaletteItem[]): TemplateResult | typeof nothing {
+		if (!this.slashPaletteOpen) return nothing;
+		if (this.slashSkillsLoading && items.length === 0) {
+			return html`<div class="composer-slash-menu"><div class="composer-slash-empty">Loading commands…</div></div>`;
+		}
+		if (items.length === 0) {
+			return html`<div class="composer-slash-menu"><div class="composer-slash-empty">No commands match “/${this.slashPaletteQuery}”.</div></div>`;
+		}
+		const activeIndex = Math.max(0, Math.min(this.slashPaletteIndex, items.length - 1));
+		let currentSection: "Actions" | "Skills" | null = null;
+		return html`
+			<div class="composer-slash-menu">
+				${items.map((item, index) => {
+					const sectionChanged = item.section !== currentSection;
+					currentSection = item.section;
+					return html`
+						${sectionChanged ? html`<div class="composer-slash-section">${item.section}</div>` : nothing}
+						<button
+							class="composer-slash-item ${index === activeIndex ? "active" : ""}"
+							@click=${() => this.selectSlashPaletteItem(item)}
+						>
+							<span class="composer-slash-item-label">${item.label}</span>
+							<span class="composer-slash-item-hint">${item.hint}</span>
+						</button>
+					`;
+				})}
+			</div>
+		`;
+	}
+
 	private renderComposer(): TemplateResult {
 		const isStreaming = this.currentIsStreaming();
 		const interactionLocked = this.isComposerInteractionLocked();
-		const canSend = !interactionLocked && (this.inputText.trim().length > 0 || this.pendingImages.length > 0);
+		const slashItems = this.getSlashPaletteItems();
+		const canSendBase = !interactionLocked && (this.inputText.trim().length > 0 || this.pendingImages.length > 0 || Boolean(this.selectedSkillDraft));
+		const canSend = canSendBase && !(this.slashPaletteOpen && slashItems.length > 0);
+		if (slashItems.length > 0 && this.slashPaletteIndex >= slashItems.length) {
+			this.slashPaletteIndex = slashItems.length - 1;
+		}
 		const connectivityStatus = this.bindingStatusText || (!this.isConnected && this.projectPath ? "RPC disconnected" : "");
 		const statusText = [connectivityStatus, this.compactionStatus, this.retryStatus].filter(Boolean).join(" · ");
 		const ratio = Math.min(1, Math.max(0, this.sessionStats.usageRatio ?? 0));
@@ -3578,6 +3838,7 @@ export class ChatView {
 				<div class="composer-inner">
 					<div class="composer-panel">
 						${this.renderPendingImages()}
+						${this.renderComposerSkillDraftPill()}
 						<div class="composer-row">
 							<textarea
 								id="chat-input"
@@ -3589,9 +3850,14 @@ export class ChatView {
 								@input=${(e: Event) => {
 									if (interactionLocked) return;
 									const ta = e.target as HTMLTextAreaElement;
+									const hadSlashPalette = this.slashPaletteOpen;
 									this.inputText = ta.value;
+									this.updateSlashPaletteStateFromInput();
 									ta.style.height = "auto";
 									ta.style.height = `${Math.min(ta.scrollHeight, 220)}px`;
+									if (this.slashPaletteOpen || hadSlashPalette) {
+										this.render();
+									}
 								}}
 								@paste=${(e: ClipboardEvent) => {
 									if (interactionLocked) {
@@ -3619,6 +3885,33 @@ export class ChatView {
 								}}
 								@keydown=${(e: KeyboardEvent) => {
 									if (interactionLocked) return;
+									const liveSlashItems = this.getSlashPaletteItems();
+									if (this.slashPaletteOpen && liveSlashItems.length > 0) {
+										if (e.key === "ArrowDown") {
+											e.preventDefault();
+											this.slashPaletteIndex = (this.slashPaletteIndex + 1) % liveSlashItems.length;
+											this.render();
+											return;
+										}
+										if (e.key === "ArrowUp") {
+											e.preventDefault();
+											this.slashPaletteIndex = (this.slashPaletteIndex - 1 + liveSlashItems.length) % liveSlashItems.length;
+											this.render();
+											return;
+										}
+										if (e.key === "Enter" && !e.shiftKey) {
+											e.preventDefault();
+											const picked = liveSlashItems[Math.max(0, Math.min(this.slashPaletteIndex, liveSlashItems.length - 1))];
+											if (picked) this.selectSlashPaletteItem(picked);
+											return;
+										}
+									}
+									if (this.slashPaletteOpen && e.key === "Escape") {
+										e.preventDefault();
+										this.closeSlashPalette();
+										this.render();
+										return;
+									}
 									if (e.key === "Enter" && !e.shiftKey) {
 										e.preventDefault();
 										if (e.altKey) {
@@ -3631,6 +3924,7 @@ export class ChatView {
 								}}
 							></textarea>
 						</div>
+						${this.renderSlashPalette(slashItems)}
 						${this.renderComposerControls(canSend, isStreaming, interactionLocked)}
 						${statusText ? html`<div class="composer-status-inline">${statusText}</div>` : nothing}
 					</div>
@@ -3988,8 +4282,8 @@ export class ChatView {
 					const target = e.target as HTMLElement;
 					let changed = false;
 
-					if (this.quickActionsOpen && !target.closest(".chat-actions-menu-wrap")) {
-						this.quickActionsOpen = false;
+					if (this.slashPaletteOpen && !target.closest(".composer-slash-menu") && !target.closest("#chat-input")) {
+						this.closeSlashPalette();
 						changed = true;
 					}
 

--- a/src/components/packages-view.ts
+++ b/src/components/packages-view.ts
@@ -4,6 +4,7 @@
 
 import { html, nothing, render, type TemplateResult } from "lit";
 import { normalizeRecommendedSource, RECOMMENDED_PACKAGES, type RecommendedPackageDefinition } from "../recommended-packages.js";
+import { RECOMMENDED_SKILLS, type RecommendedSkillDefinition } from "../recommended-skills.js";
 import { rpcBridge } from "../rpc/bridge.js";
 
 interface CatalogPackageItem {
@@ -37,6 +38,46 @@ interface ModelOption {
 	label: string;
 }
 
+interface DiscoveredResourceItem {
+	id: string;
+	kind: "prompt" | "skill";
+	name: string;
+	description: string;
+	commandText: string;
+	path: string;
+	origin: string | null;
+	loaded: boolean;
+	packageSource: string | null;
+	packageScope: "user" | "project" | null;
+	packageDisplayName: string | null;
+	sourceKind: "npm" | "git" | "url" | "local" | "unknown";
+}
+
+interface ExtensionSurfaceItem {
+	id: string;
+	displayName: string;
+	source: string;
+	description: string;
+	note: string;
+	openUrl: string | null;
+	sourceKind: "npm" | "git" | "url" | "local" | "unknown";
+	installState: { global: boolean; project: boolean };
+	installedItemForScope: InstalledDisplayItem | null;
+}
+
+interface RecommendedSkillSurfaceItem {
+	id: string;
+	definition: RecommendedSkillDefinition;
+	resource: DiscoveredResourceItem | null;
+	installed: boolean;
+	packageInstalled: boolean;
+}
+
+type ActivePackagesModal =
+	| { kind: "extension"; item: ExtensionSurfaceItem }
+	| { kind: "skill"; item: DiscoveredResourceItem }
+	| { kind: "recommended-skill"; item: RecommendedSkillSurfaceItem };
+
 type UiIcon =
 	| "package"
 	| "extension"
@@ -50,6 +91,7 @@ type UiIcon =
 
 const PACKAGES_CATALOG_URL = "https://shittycodingagent.ai/packages";
 const PACKAGES_SEARCH_URL = "https://registry.npmjs.org/-/v1/search?text=keywords:pi-package&size=250";
+const RESOURCE_CREATOR_SKILL_NAME = "creatorskill";
 
 function uniqueBy<T>(items: T[], getKey: (item: T) => string): T[] {
 	const seen = new Set<string>();
@@ -142,6 +184,129 @@ function modelRef(provider: string, id: string): string {
 	return `${provider}/${id}`;
 }
 
+function splitModelRef(value: string): { provider: string; id: string } | null {
+	const input = value.trim();
+	const slash = input.indexOf("/");
+	if (slash <= 0 || slash >= input.length - 1) return null;
+	const provider = input.slice(0, slash).trim();
+	const id = input.slice(slash + 1).trim();
+	if (!provider || !id) return null;
+	return { provider, id };
+}
+
+function readModelRefFromConfigObject(parsed: Record<string, unknown>): string | null {
+	const provider = readString(parsed.provider) || readString(parsed.providerId) || readString(parsed.provider_id);
+	const id = readString(parsed.id) || readString(parsed.modelId) || readString(parsed.model_id);
+	if (provider && id) return modelRef(provider, id);
+	const model = readString(parsed.model);
+	if (model && splitModelRef(model)) return model;
+	return null;
+}
+
+interface ParsedSkillDocSection {
+	heading: string | null;
+	paragraphs: string[];
+}
+
+interface ParsedSkillDoc {
+	title: string;
+	summary: string;
+	sections: ParsedSkillDocSection[];
+}
+
+function parseFrontmatter(content: string): { attributes: Record<string, string>; body: string } {
+	const normalized = content.replace(/^\uFEFF/, "").replace(/\r\n/g, "\n");
+	const lines = normalized.split("\n");
+	if (lines[0]?.trim() !== "---") return { attributes: {}, body: normalized };
+	const endIndex = lines.findIndex((line, index) => index > 0 && line.trim() === "---");
+	if (endIndex <= 0) return { attributes: {}, body: normalized };
+	const attributes: Record<string, string> = {};
+	for (const line of lines.slice(1, endIndex)) {
+		const match = line.match(/^\s*([A-Za-z0-9_-]+)\s*:\s*(.*)$/);
+		if (!match) continue;
+		let value = match[2].trim();
+		if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+			value = value.slice(1, -1);
+		}
+		attributes[match[1].toLowerCase()] = value;
+	}
+	return {
+		attributes,
+		body: lines.slice(endIndex + 1).join("\n").trim(),
+	};
+}
+
+function normalizeDocLine(line: string): string {
+	if (/^---+$/.test(line.trim())) return "";
+	return line
+		.replace(/!\[[^\]]*\]\(([^)]+)\)/g, "image: $1")
+		.replace(/\[([^\]]+)\]\(([^)]+)\)/g, "$1 ($2)")
+		.replace(/`([^`]+)`/g, "$1")
+		.replace(/\*\*([^*]+)\*\*/g, "$1")
+		.replace(/\*([^*]+)\*/g, "$1")
+		.replace(/^[-*+]\s+/, "• ")
+		.replace(/^>\s?/, "")
+		.trim();
+}
+
+function linesToParagraphs(lines: string[]): string[] {
+	const paragraphs: string[] = [];
+	let chunk: string[] = [];
+	for (const raw of lines) {
+		const line = raw.trim();
+		if (!line) {
+			if (chunk.length > 0) {
+				paragraphs.push(chunk.join(" "));
+				chunk = [];
+			}
+			continue;
+		}
+		chunk.push(line);
+	}
+	if (chunk.length > 0) paragraphs.push(chunk.join(" "));
+	return paragraphs;
+}
+
+function parseSkillDoc(content: string): ParsedSkillDoc {
+	const { attributes, body } = parseFrontmatter(content);
+	const sections: ParsedSkillDocSection[] = [];
+	let activeHeading: string | null = null;
+	let activeLines: string[] = [];
+	let title = attributes.name ? toTitleFromSlug(attributes.name) : "Skill details";
+	const summary = attributes.description ?? "";
+
+	const pushSection = () => {
+		const paragraphs = linesToParagraphs(activeLines);
+		if (!activeHeading && paragraphs.length === 0) return;
+		sections.push({ heading: activeHeading, paragraphs });
+		activeLines = [];
+	};
+
+	for (const raw of body.split(/\r?\n/)) {
+		const trimmed = raw.trim();
+		if (!trimmed) {
+			activeLines.push("");
+			continue;
+		}
+		const headingMatch = trimmed.match(/^#{1,6}\s+(.+)$/);
+		if (headingMatch) {
+			pushSection();
+			activeHeading = headingMatch[1].trim();
+			if (!title || title === "Skill details") title = activeHeading;
+			continue;
+		}
+		activeLines.push(normalizeDocLine(trimmed));
+	}
+	pushSection();
+
+	if (sections.length === 0 && body.trim()) {
+		sections.push({ heading: null, paragraphs: [normalizeDocLine(body.trim())] });
+	}
+	if (!title) title = "Skill details";
+
+	return { title, summary, sections };
+}
+
 function icon(name: UiIcon): TemplateResult {
 	switch (name) {
 		case "package":
@@ -149,7 +314,7 @@ function icon(name: UiIcon): TemplateResult {
 		case "extension":
 			return html`<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M6.1 3.2a2.1 2.1 0 1 1 3.8 1.2h1a1.8 1.8 0 0 1 1.8 1.8v1.1H9.8"></path><path d="M9.9 12.8a2.1 2.1 0 1 1-3.8-1.2h-1a1.8 1.8 0 0 1-1.8-1.8V8.7h2.9"></path><path d="M7.9 5.6v4.8"></path></svg>`;
 		case "skill":
-			return html`<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 2.4l1.7 3.6 3.9.5-2.9 2.8.8 3.9L8 11.3l-3.5 1.9.8-3.9-2.9-2.8 3.9-.5z"></path></svg>`;
+			return html`<svg class="filled" viewBox="0 0 20 20" aria-hidden="true"><path d="M9.2 2.3a1.5 1.5 0 0 1 3 0v3.8h.8V3.8a1.5 1.5 0 0 1 3 0v6.4a4.8 4.8 0 0 1-4.8 4.8H9.8A4.8 4.8 0 0 1 5 10.2V7.8a1.5 1.5 0 1 1 3 0v1.4h.8V2.3a1.5 1.5 0 0 1 .4-1z"></path></svg>`;
 		case "theme":
 			return html`<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 2.4a5.6 5.6 0 1 0 0 11.2c1.4 0 1.9-.8 1.9-1.5 0-.5-.2-1 .6-1h1.2a1.9 1.9 0 0 0 1.9-1.9A5.6 5.6 0 0 0 8 2.4z"></path><circle cx="5.3" cy="6.4" r=".8"></circle><circle cx="8" cy="5.4" r=".8"></circle><circle cx="10.6" cy="6.5" r=".8"></circle></svg>`;
 		case "prompt":
@@ -180,13 +345,97 @@ function sourceKindLabel(kind: "npm" | "git" | "url" | "local" | "unknown"): str
 	}
 }
 
+function inferSourceKindFromSource(source: string): "npm" | "git" | "url" | "local" | "unknown" {
+	const value = source.trim();
+	if (!value) return "unknown";
+	if (value.startsWith("npm:") || /^[@a-z0-9][\w./-]*$/i.test(value)) return "npm";
+	if (value.startsWith("git:") || value.startsWith("github:")) return "git";
+	if (/^https?:\/\//i.test(value)) return "url";
+	if (
+		value.startsWith("file:") ||
+		value.startsWith("./") ||
+		value.startsWith("../") ||
+		value.startsWith("/") ||
+		value.startsWith("~/") ||
+		/^[a-zA-Z]:[\\/]/.test(value)
+	) {
+		return "local";
+	}
+	return "unknown";
+}
+
+function readString(value: unknown): string {
+	return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeSourceScope(value: string): "user" | "project" | null {
+	const normalized = value.trim().toLowerCase();
+	if (normalized === "user" || normalized === "global") return "user";
+	if (normalized === "project" || normalized === "local") return "project";
+	return null;
+}
+
+function readCommandSourceInfo(raw: Record<string, unknown>): {
+	path: string;
+	source: string;
+	scope: "user" | "project" | null;
+	origin: string;
+	baseDir: string;
+} {
+	const info = (raw.sourceInfo ?? raw.source_info) as Record<string, unknown> | undefined;
+	const path = readString(raw.path) || readString(raw.location) || readString(info?.path);
+	const source = readString(info?.source);
+	const scope = normalizeSourceScope(readString(info?.scope));
+	const origin = readString(info?.origin);
+	const baseDir = readString(info?.baseDir ?? info?.base_dir);
+	return { path, source, scope, origin, baseDir };
+}
+
+function joinFsPath(base: string, child: string): string {
+	const sep = base.includes("\\") ? "\\" : "/";
+	const normalizedBase = base.replace(/[\\/]+$/, "");
+	return `${normalizedBase}${sep}${child}`;
+}
+
+function pathBaseName(path: string): string {
+	const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
+	const parts = normalized.split("/");
+	return parts[parts.length - 1] || normalized;
+}
+
+function fileStem(path: string): string {
+	const base = pathBaseName(path);
+	const idx = base.lastIndexOf(".");
+	if (idx <= 0) return base;
+	return base.slice(0, idx);
+}
+
+function pathDirName(path: string): string {
+	const normalized = path.replace(/[\\/]+$/, "");
+	const slashIdx = Math.max(normalized.lastIndexOf("/"), normalized.lastIndexOf("\\"));
+	if (slashIdx <= 0) return normalized;
+	return normalized.slice(0, slashIdx);
+}
+
+function toTitleFromSlug(value: string): string {
+	return value
+		.split(/[-_\s]+/)
+		.filter(Boolean)
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(" ");
+}
+
 export class PackagesView {
 	private container: HTMLElement;
 	private catalogItems: CatalogPackageItem[] = [];
 	private installedUser: InstalledPackageItem[] = [];
 	private installedProject: InstalledPackageItem[] = [];
+	private promptTemplateResources: DiscoveredResourceItem[] = [];
+	private skillResources: DiscoveredResourceItem[] = [];
 
 	private loadingCatalog = false;
+	private loadingResources = false;
+	private resourcesError = "";
 	private loadingConfig = false;
 	private runningCommand = false;
 	private catalogError = "";
@@ -197,16 +446,45 @@ export class PackagesView {
 	private query = "";
 	private currentProjectPath: string | null = null;
 	private onBack: (() => void) | null = null;
+	private onInsertPromptTemplate: ((commandText: string) => void | Promise<void>) | null = null;
 	private packageConfigCommands = new Map<string, PackageConfigCommand[]>();
 	private activePackageConfigSource: string | null = null;
 	private activePackageConfigLabel = "";
 	private runningConfigCommand = false;
 	private packageConfigStatus = "";
 	private packageConfigCommandArgs = new Map<string, string>();
+	private packageConfigLoadedModelBySource = new Map<string, string>();
 	private configModels: ModelOption[] = [];
 	private configModelsLoading = false;
 	private configModelsLoaded = false;
 	private configModelsError = "";
+	private homePath: string | null = null;
+	private creatingResource = false;
+	private deletingResource = false;
+	private resourceStatus = "";
+	private resourceEditorOpen = false;
+	private resourceEditorMode: "create" | "edit" = "create";
+	private resourceEditorKind: "prompt" | "skill" = "prompt";
+	private resourceEditorScope: "global" | "project" = "global";
+	private resourceEditorName = "";
+	private resourceEditorDescription = "";
+	private resourceEditorContent = "";
+	private resourceEditorPath: string | null = null;
+	private resourceEditorLoaded = false;
+	private resourceEditorError = "";
+	private resourceCreatorOpen = false;
+	private resourceCreatorKind: "auto" | "prompt" | "skill" = "auto";
+	private resourceCreatorScope: "global" | "project" = "global";
+	private resourceCreatorBrief = "";
+	private resourceCreatorRunning = false;
+	private resourceCreatorError = "";
+	private resourceCreatorKindLocked = false;
+	private activePackagesModal: ActivePackagesModal | null = null;
+	private activeSkillContent = "";
+	private activeSkillContentPath: string | null = null;
+	private activeSkillContentLoading = false;
+	private activeSkillContentError = "";
+	private activeSkillContentNotice = "";
 
 	constructor(container: HTMLElement) {
 		this.container = container;
@@ -215,14 +493,20 @@ export class PackagesView {
 
 	setProjectPath(path: string | null): void {
 		this.currentProjectPath = path;
-		if (!path && this.packageScope === "local") {
-			this.packageScope = "global";
+		this.packageScope = "global";
+		if (!path && this.resourceEditorScope === "project") {
+			this.resourceEditorScope = "global";
 		}
+		this.resourceCreatorScope = "global";
 		this.render();
 	}
 
 	setOnBack(cb: () => void): void {
 		this.onBack = cb;
+	}
+
+	setOnInsertPromptTemplate(cb: ((commandText: string) => void | Promise<void>) | null): void {
+		this.onInsertPromptTemplate = cb;
 	}
 
 	setQuery(query: string): void {
@@ -237,6 +521,7 @@ export class PackagesView {
 
 	async open(): Promise<void> {
 		await Promise.all([this.loadCatalog(this.catalogItems.length === 0), this.loadConfig()]);
+		await this.refreshDiscoveredResources();
 	}
 
 	async openCatalog(): Promise<void> {
@@ -245,6 +530,7 @@ export class PackagesView {
 
 	async refreshPackages(forceCatalog = false): Promise<void> {
 		await Promise.all([this.loadCatalog(forceCatalog), this.loadConfig()]);
+		await this.refreshDiscoveredResources();
 	}
 
 	private async openExternal(url: string): Promise<void> {
@@ -258,6 +544,134 @@ export class PackagesView {
 
 	private normalizeQuery(): string {
 		return this.query.trim().toLowerCase();
+	}
+
+	private normalizeResourceName(name: string): string {
+		const trimmed = name.trim();
+		if (this.resourceEditorKind === "skill") {
+			return trimmed
+				.toLowerCase()
+				.replace(/[^a-z0-9-]/g, "-")
+				.replace(/--+/g, "-")
+				.replace(/^-+|-+$/g, "")
+				.slice(0, 64);
+		}
+		return trimmed
+			.toLowerCase()
+			.replace(/[^a-z0-9_-]/g, "-")
+			.replace(/--+/g, "-")
+			.replace(/^[-_]+|[-_]+$/g, "")
+			.slice(0, 64);
+	}
+
+	private validateResourceName(name: string, kind: "prompt" | "skill"): string | null {
+		const trimmed = name.trim();
+		if (!trimmed) return "Name is required.";
+		if (kind === "skill") {
+			if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(trimmed)) {
+				return "Skill name must use lowercase letters, numbers, and hyphens.";
+			}
+			if (trimmed.length > 64) return "Skill name must be 64 characters or fewer.";
+			return null;
+		}
+		if (!/^[a-z0-9][a-z0-9_-]*$/.test(trimmed)) {
+			return "Prompt name must start with a letter/number and use letters, numbers, hyphens, or underscores.";
+		}
+		if (trimmed.length > 64) return "Prompt name must be 64 characters or fewer.";
+		return null;
+	}
+
+	private async ensureHomePath(): Promise<void> {
+		if (this.homePath) return;
+		try {
+			const { homeDir } = await import("@tauri-apps/api/path");
+			this.homePath = await homeDir();
+		} catch {
+			this.homePath = null;
+		}
+	}
+
+	private resourceRootPath(kind: "prompt" | "skill", scope: "global" | "project"): string | null {
+		const suffix = kind === "prompt" ? "prompts" : "skills";
+		if (scope === "global") {
+			if (!this.homePath) return null;
+			return joinFsPath(joinFsPath(joinFsPath(this.homePath, ".pi"), "agent"), suffix);
+		}
+		if (!this.currentProjectPath) return null;
+		return joinFsPath(joinFsPath(this.currentProjectPath, ".pi"), suffix);
+	}
+
+	private resourceFilePath(kind: "prompt" | "skill", scope: "global" | "project", name: string): string | null {
+		const root = this.resourceRootPath(kind, scope);
+		if (!root) return null;
+		if (kind === "prompt") {
+			return joinFsPath(root, `${name}.md`);
+		}
+		return joinFsPath(joinFsPath(root, name), "SKILL.md");
+	}
+
+	private createPromptTemplateContent(description: string): string {
+		const safeDescription = description.trim() || "Describe when to use this template";
+		return `---\ndescription: ${JSON.stringify(safeDescription)}\n---\nWrite the prompt instructions here.\n\nUse arguments if needed:\n- $1 for first arg\n- $@ for all args\n`;
+	}
+
+	private createSkillTemplateContent(name: string, description: string): string {
+		const safeName = name.trim() || "my-skill";
+		const safeDescription = description.trim() || "What this skill does and when to use it.";
+		const heading = toTitleFromSlug(safeName) || "My Skill";
+		return `---\nname: ${safeName}\ndescription: ${JSON.stringify(safeDescription)}\n---\n\n# ${heading}\n\n## Purpose\nDescribe the task this skill handles and when to use it.\n\n## Setup\nAdd one-time setup steps if needed.\n\n## Workflow\n1. Gather required context.\n2. Execute the core steps for this skill.\n3. Return a concise summary and next actions.\n`;
+	}
+
+	private applyResourceTemplate(): void {
+		if (this.resourceEditorKind === "prompt") {
+			this.resourceEditorContent = this.createPromptTemplateContent(this.resourceEditorDescription);
+		} else {
+			this.resourceEditorContent = this.createSkillTemplateContent(this.resourceEditorName, this.resourceEditorDescription);
+		}
+		this.render();
+	}
+
+	private normalizeLoadedResourceName(item: DiscoveredResourceItem): string {
+		const raw = item.name.trim();
+		if (item.kind === "skill") {
+			if (raw.startsWith("skill:")) return raw.slice("skill:".length);
+			if (raw.startsWith("/skill:")) return raw.slice("/skill:".length);
+		}
+		return raw.startsWith("/") ? raw.slice(1) : raw;
+	}
+
+	private isResourcePathWithin(path: string, root: string | null): boolean {
+		const normalizedPath = normalizeFsPath(path);
+		const normalizedRoot = normalizeFsPath(root ?? "");
+		if (!normalizedPath || !normalizedRoot) return false;
+		return normalizedPath === normalizedRoot || normalizedPath.startsWith(`${normalizedRoot}/`);
+	}
+
+	private canEditResource(item: DiscoveredResourceItem): boolean {
+		if (!item.path) return false;
+		const normalizedPath = normalizeFsPath(item.path);
+		if (!normalizedPath) return false;
+		if (normalizedPath.includes("/node_modules/")) return false;
+		const globalRoot = this.resourceRootPath(item.kind, "global");
+		const projectRoot = this.resourceRootPath(item.kind, "project");
+		return this.isResourcePathWithin(item.path, globalRoot) || this.isResourcePathWithin(item.path, projectRoot);
+	}
+
+	private normalizeResourceListItem(item: DiscoveredResourceItem): DiscoveredResourceItem {
+		if (item.kind === "skill") {
+			const normalizedSkillName = this.normalizeLoadedResourceName(item);
+			return {
+				...item,
+				name: normalizedSkillName,
+				commandText: `/skill:${normalizedSkillName}`,
+			};
+		}
+		const normalizedPromptName = this.normalizeLoadedResourceName(item);
+		return {
+			...item,
+			name: normalizedPromptName,
+			commandText: `/${normalizedPromptName}`,
+		};
 	}
 
 	private async loadCatalog(force = false): Promise<void> {
@@ -316,18 +730,11 @@ export class PackagesView {
 		this.render();
 
 		try {
-			const [userListResult, projectListResult] = await Promise.all([
-				rpcBridge.runPiCliCommand(["list"], { cwd: "/" }),
-				this.currentProjectPath
-					? rpcBridge.runPiCliCommand(["list"], { cwd: this.currentProjectPath }).catch(() => null)
-					: Promise.resolve(null),
-			]);
-
+			const userListResult = await rpcBridge.runPiCliCommand(["list"], { cwd: "/" });
 			const parsedUser = parsePiListOutput(userListResult.stdout ?? "");
-			const parsedProject = projectListResult ? parsePiListOutput(projectListResult.stdout ?? "") : { user: [], project: [] };
 
-			this.installedUser = uniqueBy([...parsedUser.user, ...parsedProject.user], (item) => item.source);
-			this.installedProject = uniqueBy([...parsedUser.project, ...parsedProject.project], (item) => item.source);
+			this.installedUser = uniqueBy([...parsedUser.user], (item) => item.source);
+			this.installedProject = [];
 			await this.refreshPackageConfigCommands();
 			if (this.activePackageConfigSource && !this.isNormalizedSourceInstalled(this.activePackageConfigSource)) {
 				this.closeActivePackageConfig();
@@ -362,32 +769,33 @@ export class PackagesView {
 		}
 
 		for (const raw of commands) {
-			const source = typeof raw.source === "string" ? raw.source : "";
-			const name = typeof raw.name === "string" ? raw.name.trim() : "";
-			const description = typeof raw.description === "string" ? raw.description.trim() : "";
-			const path = typeof raw.path === "string" ? raw.path : "";
-
-			if (source !== "extension" || !name || !path) continue;
+			const source = readString(raw.source).toLowerCase();
+			const name = readString(raw.name);
+			const description = readString(raw.description);
+			const sourceInfo = readCommandSourceInfo(raw);
+			if (source !== "extension" || !name) continue;
 			if (!isLikelyConfigCommand(name, description)) continue;
 
-			const normalizedPath = normalizeFsPath(path);
-			if (!normalizedPath) continue;
+			const matchedPackage = this.findInstalledItemForCommand(
+				{
+					path: sourceInfo.path,
+					sourceHint: sourceInfo.source,
+					baseDir: sourceInfo.baseDir,
+				},
+				installedItems,
+			);
+			if (!matchedPackage) continue;
 
-			for (const item of installedItems) {
-				const normalizedSource = normalizeRecommendedSource(item.source);
-				const list = bySource.get(normalizedSource);
-				if (!list) continue;
+			const normalizedSource = normalizeRecommendedSource(matchedPackage.source);
+			const list = bySource.get(normalizedSource);
+			if (!list) continue;
 
-				const normalizedLocation = normalizeFsPath(item.location);
-				const locationMatches = normalizedLocation
-					? normalizedPath === normalizedLocation || normalizedPath.startsWith(`${normalizedLocation}/`)
-					: false;
-				const npmFallbackMatches = !locationMatches && pathMatchesNpmPackage(normalizedPath, item.source);
-				if (!locationMatches && !npmFallbackMatches) continue;
-
-				if (list.some((command) => command.name === name)) continue;
-				list.push({ name, description, path });
-			}
+			if (list.some((command) => command.name === name)) continue;
+			list.push({
+				name,
+				description,
+				path: sourceInfo.path || sourceInfo.baseDir,
+			});
 		}
 
 		for (const list of bySource.values()) {
@@ -397,22 +805,333 @@ export class PackagesView {
 		this.packageConfigCommands = bySource;
 	}
 
+	private matchesInstalledItemPath(path: string, item: InstalledDisplayItem): boolean {
+		const normalizedPath = normalizeFsPath(path);
+		if (!normalizedPath) return false;
+		const normalizedLocation = normalizeFsPath(item.location);
+		const locationMatches = normalizedLocation
+			? normalizedPath === normalizedLocation || normalizedPath.startsWith(`${normalizedLocation}/`)
+			: false;
+		const npmFallbackMatches = !locationMatches && pathMatchesNpmPackage(normalizedPath, item.source);
+		return locationMatches || npmFallbackMatches;
+	}
+
+	private findInstalledItemForCommand(
+		meta: { path: string; sourceHint: string; baseDir: string },
+		installedItems: InstalledDisplayItem[],
+	): InstalledDisplayItem | null {
+		const normalizedSourceHint = meta.sourceHint && meta.sourceHint.toLowerCase() !== "auto"
+			? normalizeRecommendedSource(meta.sourceHint)
+			: "";
+		if (normalizedSourceHint) {
+			const bySource = installedItems.find((item) => normalizeRecommendedSource(item.source) === normalizedSourceHint) ?? null;
+			if (bySource) return bySource;
+		}
+
+		for (const candidatePath of [meta.path, meta.baseDir]) {
+			if (!candidatePath) continue;
+			for (const item of installedItems) {
+				if (this.matchesInstalledItemPath(candidatePath, item)) return item;
+			}
+		}
+
+		return null;
+	}
+
+	private toDiscoveredResourceItem(raw: Record<string, unknown>, installedItems: InstalledDisplayItem[]): DiscoveredResourceItem | null {
+		const kind = readString(raw.source).toLowerCase();
+		if (kind !== "prompt" && kind !== "skill") return null;
+		const name = readString(raw.name);
+		if (!name) return null;
+		const description = readString(raw.description);
+		const sourceInfo = readCommandSourceInfo(raw);
+		const path = sourceInfo.path || sourceInfo.baseDir;
+		const matchedPackage = this.findInstalledItemForCommand(
+			{
+				path,
+				sourceHint: sourceInfo.source,
+				baseDir: sourceInfo.baseDir,
+			},
+			installedItems,
+		);
+		const sourceInfoSource = sourceInfo.source && sourceInfo.source.toLowerCase() !== "auto" ? sourceInfo.source : "";
+		const packageSource = matchedPackage?.source ?? (sourceInfoSource || null);
+		const packageScope = matchedPackage?.scope ?? sourceInfo.scope;
+		const packageDisplayName = matchedPackage?.displayName ?? (packageSource ? this.getDisplayName(packageSource) : null);
+		const commandText = name.startsWith("/") ? name : `/${name}`;
+		const idBase = `${kind}:${name}:${path || packageSource || sourceInfo.origin || "runtime"}`.toLowerCase();
+		return {
+			id: idBase,
+			kind,
+			name,
+			description,
+			commandText,
+			path,
+			origin: sourceInfo.origin || null,
+			loaded: true,
+			packageSource,
+			packageScope,
+			packageDisplayName,
+			sourceKind: packageSource ? inferSourceKindFromSource(packageSource) : "unknown",
+		};
+	}
+
+	private async listDirSafe(path: string): Promise<Array<{ name: string; isDirectory: boolean; isFile: boolean; isSymlink: boolean }>> {
+		try {
+			const { exists, readDir } = await import("@tauri-apps/plugin-fs");
+			if (!(await exists(path))) return [];
+			return await readDir(path);
+		} catch {
+			return [];
+		}
+	}
+
+	private async scanPromptResources(scope: "global" | "project"): Promise<DiscoveredResourceItem[]> {
+		const root = this.resourceRootPath("prompt", scope);
+		if (!root) return [];
+		const entries = await this.listDirSafe(root);
+		const out: DiscoveredResourceItem[] = [];
+		for (const entry of entries) {
+			if (!entry.isFile) continue;
+			if (!entry.name.toLowerCase().endsWith(".md")) continue;
+			const name = fileStem(entry.name).trim();
+			if (!name) continue;
+			const path = joinFsPath(root, entry.name);
+			out.push({
+				id: `prompt:${name}:${path}`.toLowerCase(),
+				kind: "prompt",
+				name,
+				description: "Local prompt template",
+				commandText: `/${name}`,
+				path,
+				origin: scope === "global" ? "user" : "project",
+				loaded: false,
+				packageSource: null,
+				packageScope: scope === "global" ? "user" : "project",
+				packageDisplayName: null,
+				sourceKind: "local",
+			});
+		}
+		return out;
+	}
+
+	private async scanSkillResources(scope: "global" | "project"): Promise<DiscoveredResourceItem[]> {
+		const root = this.resourceRootPath("skill", scope);
+		if (!root) return [];
+		const out: DiscoveredResourceItem[] = [];
+		const queue: Array<{ path: string; depth: number }> = [{ path: root, depth: 0 }];
+		while (queue.length > 0) {
+			const next = queue.shift()!;
+			if (next.depth > 5) continue;
+			const entries = await this.listDirSafe(next.path);
+			for (const entry of entries) {
+				const fullPath = joinFsPath(next.path, entry.name);
+				if (entry.isDirectory) {
+					queue.push({ path: fullPath, depth: next.depth + 1 });
+					continue;
+				}
+				if (!entry.isFile) continue;
+				const lower = entry.name.toLowerCase();
+				if (lower === "skill.md") {
+					const skillName = pathBaseName(next.path).trim();
+					if (!skillName) continue;
+					out.push({
+						id: `skill:${skillName}:${fullPath}`.toLowerCase(),
+						kind: "skill",
+						name: skillName,
+						description: "Local skill",
+						commandText: `/skill:${skillName}`,
+						path: fullPath,
+						origin: scope === "global" ? "user" : "project",
+						loaded: false,
+						packageSource: null,
+						packageScope: scope === "global" ? "user" : "project",
+						packageDisplayName: null,
+						sourceKind: "local",
+					});
+					continue;
+				}
+				if (next.depth !== 0) continue;
+				if (!lower.endsWith(".md")) continue;
+				const skillName = fileStem(entry.name).trim();
+				if (!skillName) continue;
+				out.push({
+					id: `skill:${skillName}:${fullPath}`.toLowerCase(),
+					kind: "skill",
+					name: skillName,
+					description: "Local skill",
+					commandText: `/skill:${skillName}`,
+					path: fullPath,
+					origin: scope === "global" ? "user" : "project",
+					loaded: false,
+					packageSource: null,
+					packageScope: scope === "global" ? "user" : "project",
+					packageDisplayName: null,
+					sourceKind: "local",
+				});
+			}
+		}
+		return out;
+	}
+
+	private mergeDiscoveredResources(
+		commandResources: DiscoveredResourceItem[],
+		localResources: DiscoveredResourceItem[],
+	): DiscoveredResourceItem[] {
+		const merged = localResources.map((item) => this.normalizeResourceListItem(item));
+		for (const item of commandResources) {
+			const normalized = this.normalizeResourceListItem(item);
+			const normalizedPath = normalizeFsPath(normalized.path);
+			let matchIndex = normalizedPath
+				? merged.findIndex((existing) => normalizeFsPath(existing.path) === normalizedPath)
+				: -1;
+
+			if (matchIndex === -1) {
+				const nameMatches = merged
+					.map((existing, index) => ({ existing, index }))
+					.filter(({ existing }) => existing.kind === normalized.kind && existing.name === normalized.name);
+				if (nameMatches.length === 1) {
+					matchIndex = nameMatches[0].index;
+				}
+			}
+
+			if (matchIndex === -1) {
+				merged.push(normalized);
+				continue;
+			}
+
+			const existing = merged[matchIndex];
+			merged[matchIndex] = {
+				...existing,
+				...normalized,
+				path: normalized.path || existing.path,
+				description: normalized.description || existing.description,
+				loaded: true,
+				sourceKind: normalized.sourceKind === "unknown" ? existing.sourceKind : normalized.sourceKind,
+				packageSource: normalized.packageSource ?? existing.packageSource,
+				packageScope: normalized.packageScope ?? existing.packageScope,
+				packageDisplayName: normalized.packageDisplayName ?? existing.packageDisplayName,
+				origin: normalized.origin ?? existing.origin,
+			};
+		}
+		return merged;
+	}
+
+	private async refreshDiscoveredResources(): Promise<void> {
+		if (this.loadingResources) return;
+		this.loadingResources = true;
+		this.resourcesError = "";
+		this.render();
+
+		try {
+			await this.ensureHomePath();
+			const installedItems = this.getInstalledItems(false);
+
+			let commands: Array<Record<string, unknown>> = [];
+			try {
+				commands = await rpcBridge.getCommands();
+			} catch (err) {
+				this.resourcesError = err instanceof Error ? err.message : String(err);
+			}
+
+			const commandResources = commands
+				.map((raw) => this.toDiscoveredResourceItem(raw, installedItems))
+				.filter((item): item is DiscoveredResourceItem => item !== null)
+				.map((item) => ({ ...item, loaded: true }))
+				.filter((item) => item.packageScope !== "project");
+
+			const [globalPrompts, globalSkills] = await Promise.all([
+				this.scanPromptResources("global"),
+				this.scanSkillResources("global"),
+			]);
+			const localResources = [...globalPrompts, ...globalSkills];
+			const merged = this.mergeDiscoveredResources(commandResources, localResources);
+
+			this.promptTemplateResources = uniqueBy(
+				merged.filter((item) => item.kind === "prompt"),
+				(item) => `${item.kind}:${item.name}:${normalizeFsPath(item.path) || item.packageScope || "runtime"}`.toLowerCase(),
+			).sort((a, b) => a.name.localeCompare(b.name));
+
+			this.skillResources = uniqueBy(
+				merged.filter((item) => item.kind === "skill"),
+				(item) => `${item.kind}:${item.name}:${normalizeFsPath(item.path) || item.packageScope || "runtime"}`.toLowerCase(),
+			).sort((a, b) => a.name.localeCompare(b.name));
+		} catch (err) {
+			this.promptTemplateResources = [];
+			this.skillResources = [];
+			this.resourcesError = err instanceof Error ? err.message : String(err);
+		} finally {
+			this.loadingResources = false;
+			this.render();
+		}
+	}
+
 	private packageConfigCommandKey(source: string, commandName: string): string {
 		return `${normalizeRecommendedSource(source)}::${commandName.trim().toLowerCase()}`;
 	}
 
+	private packageConfigStorageKey(source: string, commandName: string): string {
+		const normalized = normalizeRecommendedSource(source);
+		return `pi.packages.configArg.v1::${normalized}::${commandName.trim().toLowerCase()}`;
+	}
+
 	private getPackageConfigCommandArg(source: string, commandName: string): string {
-		const key = this.packageConfigCommandKey(source, commandName);
-		return this.packageConfigCommandArgs.get(key) ?? "";
+		const normalizedCommand = commandName.trim().toLowerCase();
+		const variants = uniqueBy(
+			[normalizedCommand, normalizedCommand.startsWith("/") ? normalizedCommand.slice(1) : `/${normalizedCommand}`],
+			(value) => value,
+		);
+
+		for (const variant of variants) {
+			const key = this.packageConfigCommandKey(source, variant);
+			if (this.packageConfigCommandArgs.has(key)) return (this.packageConfigCommandArgs.get(key) || "").trim();
+		}
+
+		// Fallback to localStorage for persisted values
+		try {
+			for (const variant of variants) {
+				const storageKey = this.packageConfigStorageKey(source, variant);
+				const stored = localStorage.getItem(storageKey);
+				if (stored && stored.trim()) {
+					const trimmed = stored.trim();
+					for (const syncVariant of variants) {
+						this.packageConfigCommandArgs.set(this.packageConfigCommandKey(source, syncVariant), trimmed);
+					}
+					return trimmed;
+				}
+			}
+		} catch {
+			// ignore storage errors
+		}
+		return "";
 	}
 
 	private setPackageConfigCommandArg(source: string, commandName: string, value: string): void {
-		const key = this.packageConfigCommandKey(source, commandName);
-		if (!value) {
-			this.packageConfigCommandArgs.delete(key);
+		const normalizedCommand = commandName.trim().toLowerCase();
+		const variants = uniqueBy(
+			[normalizedCommand, normalizedCommand.startsWith("/") ? normalizedCommand.slice(1) : `/${normalizedCommand}`],
+			(v) => v,
+		);
+		const trimmed = value.trim();
+		if (!trimmed) {
+			for (const variant of variants) {
+				this.packageConfigCommandArgs.delete(this.packageConfigCommandKey(source, variant));
+				try {
+					localStorage.removeItem(this.packageConfigStorageKey(source, variant));
+				} catch {
+					// ignore
+				}
+			}
 			return;
 		}
-		this.packageConfigCommandArgs.set(key, value);
+		for (const variant of variants) {
+			this.packageConfigCommandArgs.set(this.packageConfigCommandKey(source, variant), trimmed);
+			try {
+				localStorage.setItem(this.packageConfigStorageKey(source, variant), trimmed);
+			} catch {
+				// ignore
+			}
+		}
 	}
 
 	private mapModelOptions(models: Array<Record<string, unknown>>): ModelOption[] {
@@ -449,7 +1168,7 @@ export class PackagesView {
 		const fallback = modelRef(this.configModels[0].provider, this.configModels[0].id);
 		for (const command of commands) {
 			if (!commandLikelyNeedsModelArg(command)) continue;
-			const currentArg = this.getPackageConfigCommandArg(source, command.name);
+			const currentArg = this.getPackageConfigCommandArg(source, command.name); // checks localStorage fallback
 			if (currentArg) continue;
 			this.setPackageConfigCommandArg(source, command.name, fallback);
 		}
@@ -490,7 +1209,7 @@ export class PackagesView {
 		return this.getInstalledItems(false).some((item) => normalizeRecommendedSource(item.source) === normalizedSource);
 	}
 
-	private openPackageConfig(item: InstalledDisplayItem): void {
+	private async openPackageConfig(item: InstalledDisplayItem): Promise<void> {
 		const source = normalizeRecommendedSource(item.source);
 		const commands = this.getConfigCommandsForItem(item);
 		this.activePackageConfigSource = source;
@@ -502,6 +1221,8 @@ export class PackagesView {
 		if (commands.some((command) => commandLikelyNeedsModelArg(command))) {
 			void this.ensureConfigModelsLoaded();
 		}
+		// attempt to read existing package config files and seed args from disk (native only)
+		void this.loadPackageConfigFromPackage(source, commands).catch(() => {});
 		this.render();
 	}
 
@@ -510,6 +1231,132 @@ export class PackagesView {
 		this.activePackageConfigLabel = "";
 		this.packageConfigStatus = "";
 		this.render();
+	}
+
+	private async loadPackageConfigFromPackage(source: string, commands: PackageConfigCommand[]): Promise<void> {
+		if (commands.length === 0) return;
+		try {
+			const installed = this.findInstalledItemForSource(source, "global");
+			await this.ensureHomePath();
+			const { exists, readTextFile, readDir, stat } = await import("@tauri-apps/plugin-fs");
+			const pkgName = this.getDisplayName(source);
+			const npmName = npmPackageNameFromSource(source) || pkgName;
+
+			const roots = uniqueBy(
+				[
+					this.homePath ? joinFsPath(joinFsPath(joinFsPath(this.homePath, ".pi"), "agent"), "extensions") : "",
+					...commands.map((command) => command.path?.trim() || ""),
+					installed?.location?.trim() || "",
+				].filter((value): value is string => Boolean(value)),
+				(value) => normalizeFsPath(value),
+			);
+
+			const candidates: string[] = [];
+			const addCandidate = (path: string) => {
+				if (!path) return;
+				if (!candidates.includes(path)) candidates.push(path);
+			};
+
+			for (const root of roots) {
+				let dir = root;
+				try {
+					if (await exists(root)) {
+						const info = await stat(root).catch(() => null);
+						if (info?.isFile) {
+							if (root.toLowerCase().endsWith(".json")) addCandidate(root);
+							dir = pathDirName(root);
+						} else if (!info?.isDirectory) {
+							continue;
+						}
+					} else if (/\.[a-z0-9]+$/i.test(root)) {
+						dir = pathDirName(root);
+					}
+				} catch {
+					continue;
+				}
+
+				const preferred = [
+					joinFsPath(dir, `${pkgName}.json`),
+					joinFsPath(dir, `${npmName}.json`),
+					joinFsPath(dir, "pi-package-config.json"),
+				];
+				for (const filePath of preferred) {
+					if (await exists(filePath)) addCandidate(filePath);
+				}
+
+				try {
+					const entries = await readDir(dir);
+					for (const entry of entries) {
+						if (entry && typeof entry.name === "string" && entry.name.toLowerCase().endsWith(".json")) {
+							addCandidate(joinFsPath(dir, entry.name));
+						}
+					}
+				} catch {
+					// ignore readDir errors for this root
+				}
+			}
+
+			const seeded = new Set<string>();
+			let loadedFromPath = "";
+			let loadedModelValue = "";
+			for (const filePath of candidates) {
+				try {
+					const txt = await readTextFile(filePath);
+					const parsedUnknown = JSON.parse(txt) as unknown;
+					if (!parsedUnknown || typeof parsedUnknown !== "object" || Array.isArray(parsedUnknown)) continue;
+					const parsed = parsedUnknown as Record<string, unknown>;
+					const modelFromObject = readModelRefFromConfigObject(parsed);
+
+					for (const command of commands) {
+						const commandId = command.name.trim().toLowerCase();
+						if (seeded.has(commandId)) continue;
+						const key = command.name.startsWith("/") ? command.name.slice(1) : command.name;
+						let value = "";
+
+						if (typeof parsed[key] === "string") {
+							value = String(parsed[key]).trim();
+						}
+
+						if (!value && commandLikelyNeedsModelArg(command)) {
+							if (modelFromObject) {
+								value = modelFromObject;
+							} else {
+								for (const k of Object.keys(parsed)) {
+									if (!/model|name-ai-config/i.test(k)) continue;
+									const raw = parsed[k];
+									if (typeof raw === "string" && raw.trim()) {
+										value = raw.trim();
+										break;
+									}
+								}
+							}
+						}
+
+						if (!value) continue;
+						this.setPackageConfigCommandArg(source, command.name, value);
+						seeded.add(commandId);
+						if (!loadedFromPath && commandLikelyNeedsModelArg(command)) {
+							loadedFromPath = filePath;
+							loadedModelValue = value;
+						}
+					}
+				} catch {
+					// ignore parse/read errors for this file
+				}
+			}
+			if (loadedFromPath) {
+				if (loadedModelValue) {
+					this.packageConfigLoadedModelBySource.set(normalizeRecommendedSource(source), loadedModelValue);
+				}
+				this.packageConfigStatus = `Loaded package model ${loadedModelValue || "(unknown)"} from ${loadedFromPath}.`;
+			} else if (commands.some((command) => commandLikelyNeedsModelArg(command))) {
+				this.packageConfigLoadedModelBySource.delete(normalizeRecommendedSource(source));
+				this.packageConfigStatus = "No saved model found on disk. Using package default.";
+			}
+			this.render();
+		} catch {
+			// ignore errors
+		}
 	}
 
 	private async runPackageConfigCommand(command: PackageConfigCommand, args = ""): Promise<void> {
@@ -528,18 +1375,103 @@ export class PackagesView {
 			this.packageConfigStatus = `${actionVerbPast} package setting.`;
 			this.commandStatus = `${actionVerbPast} package setting for ${this.activePackageConfigLabel || "package"}.`;
 			this.commandOutput += `${this.commandOutput ? "\n" : ""}[package-config] ${promptText}\n`;
+
+			if (supportsModelPicker && this.activePackageConfigSource && trimmedArgs) {
+				this.packageConfigLoadedModelBySource.set(normalizeRecommendedSource(this.activePackageConfigSource), trimmedArgs);
+			}
+
+			// Persist model-picker changes to canonical extension config file when possible.
+			if (supportsModelPicker && this.activePackageConfigSource) {
+				try {
+					const normalized = this.activePackageConfigSource;
+					const installed = this.findInstalledItemForSource(normalized, "global");
+					const basePath = installed?.location?.trim() || command.path?.trim() || "";
+					const key = command.name.startsWith("/") ? command.name.slice(1) : command.name;
+					const parsedModel = splitModelRef(trimmedArgs);
+					const pkgName = this.getDisplayName(normalized);
+					await this.ensureHomePath();
+					const { exists, readTextFile, writeTextFile, stat, mkdir } = await import("@tauri-apps/plugin-fs");
+					const writtenPaths: string[] = [];
+					const writeErrors: string[] = [];
+
+					// 1) Canonical extension config (~/.pi/agent/extensions/<package>.json)
+					if (parsedModel && this.homePath) {
+						try {
+							const extensionsDir = joinFsPath(joinFsPath(joinFsPath(this.homePath, ".pi"), "agent"), "extensions");
+							const extensionConfigPath = joinFsPath(extensionsDir, `${pkgName}.json`);
+							await mkdir(extensionsDir, { recursive: true });
+							let existing: Record<string, unknown> = {};
+							if (await exists(extensionConfigPath)) {
+								try {
+									const raw = JSON.parse(await readTextFile(extensionConfigPath)) as unknown;
+									if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+										existing = raw as Record<string, unknown>;
+									}
+								} catch {
+									// ignore invalid json and overwrite with valid structure
+								}
+							}
+							existing.provider = parsedModel.provider;
+							existing.id = parsedModel.id;
+							await writeTextFile(extensionConfigPath, `${JSON.stringify(existing, null, 2)}\n`);
+							writtenPaths.push(extensionConfigPath);
+						} catch (err) {
+							writeErrors.push(err instanceof Error ? err.message : String(err));
+						}
+					}
+
+					// 2) Package-local fallback file (keeps previous behavior)
+					if (basePath) {
+						try {
+							let baseDir = basePath;
+							if (await exists(baseDir)) {
+								const info = await stat(baseDir).catch(() => null);
+								if (info?.isFile) baseDir = pathDirName(baseDir);
+							}
+							const configPath = joinFsPath(baseDir, "pi-package-config.json");
+							let existing: Record<string, unknown> = {};
+							if (await exists(configPath)) {
+								try {
+									const raw = JSON.parse(await readTextFile(configPath)) as unknown;
+									if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+										existing = raw as Record<string, unknown>;
+									}
+								} catch {
+									// ignore invalid json
+								}
+							}
+							existing[key] = trimmedArgs;
+							await writeTextFile(configPath, `${JSON.stringify(existing, null, 2)}\n`);
+							writtenPaths.push(configPath);
+						} catch (err) {
+							writeErrors.push(err instanceof Error ? err.message : String(err));
+						}
+					}
+
+					if (writtenPaths.length > 0) {
+						this.packageConfigStatus = `${actionVerbPast} package setting and saved to ${writtenPaths.join(" · ")}.`;
+					} else if (writeErrors.length > 0) {
+						this.packageConfigStatus = `${actionVerbPast} package setting (failed to persist file: ${writeErrors.join("; ")})`;
+					}
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					this.packageConfigStatus = `${actionVerbPast} package setting (failed to persist file: ${message})`;
+				}
+			}
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
 			this.packageConfigStatus = `Failed to ${actionVerb} package setting: ${message}`;
 			this.commandStatus = `Config command failed: ${message}`;
+		} finally {
+			this.runningConfigCommand = false;
+			this.render();
 		}
-		this.runningConfigCommand = false;
-		this.render();
 	}
 
 	private renderPackageConfigCommandEditor(source: string, command: PackageConfigCommand): TemplateResult {
-		const currentArgs = this.getPackageConfigCommandArg(source, command.name);
 		const supportsModelPicker = commandLikelyNeedsModelArg(command);
+		const sourceLoadedModel = this.packageConfigLoadedModelBySource.get(normalizeRecommendedSource(source)) || "";
+		const currentArgs = this.getPackageConfigCommandArg(source, command.name) || (supportsModelPicker ? sourceLoadedModel : "");
 		const selectedModel = this.configModels.some((model) => modelRef(model.provider, model.id) === currentArgs) ? currentArgs : "";
 		const modelSelectValue = selectedModel || currentArgs || "";
 		const title = command.description?.trim() || "Package setting";
@@ -565,12 +1497,12 @@ export class PackagesView {
 									this.render();
 								}}
 							>
-								${this.configModelsLoading ? html`<option value="">Loading models…</option>` : nothing}
-								${!this.configModelsLoading ? html`<option value="">Use package default</option>` : nothing}
-								${!this.configModelsLoading && currentArgs && !selectedModel ? html`<option value=${currentArgs}>${currentArgs}</option>` : nothing}
+								${this.configModelsLoading ? html`<option value="" ?selected=${!modelSelectValue}>Loading models…</option>` : nothing}
+								${!this.configModelsLoading ? html`<option value="" ?selected=${!modelSelectValue}>Use package default</option>` : nothing}
+								${!this.configModelsLoading && currentArgs ? html`<option value=${currentArgs} ?selected=${modelSelectValue === currentArgs}>${currentArgs}</option>` : nothing}
 								${this.configModels.map((model) => {
 									const ref = modelRef(model.provider, model.id);
-									return html`<option value=${ref}>${model.label}</option>`;
+									return html`<option value=${ref} ?selected=${modelSelectValue === ref}>${model.label}</option>`;
 								})}
 							</select>
 						</div>
@@ -642,7 +1574,6 @@ export class PackagesView {
 									</button>
 								`
 								: nothing}
-							<button class="ghost-btn" @click=${() => this.closeActivePackageConfig()}>Close</button>
 						</div>
 
 						${this.configModelsError ? html`<div class="packages-config-inline-error">Model lookup failed: ${this.configModelsError}</div>` : nothing}
@@ -685,17 +1616,12 @@ export class PackagesView {
 	private getRecommendedInstallState(definition: RecommendedPackageDefinition): { global: boolean; project: boolean } {
 		return {
 			global: this.installedUser.some((item) => this.matchesRecommendedSource(item.source, definition)),
-			project: this.installedProject.some((item) => this.matchesRecommendedSource(item.source, definition)),
+			project: false,
 		};
 	}
 
 	private getInstalledItems(applyQuery = true): InstalledDisplayItem[] {
-		const combined = [
-			...this.installedProject.map((item) => ({ ...item, scope: "project" as const })),
-			...this.installedUser.map((item) => ({ ...item, scope: "user" as const })),
-		];
-
-		const unique = uniqueBy(combined, (item) => `${item.scope}:${item.source}`)
+		const unique = uniqueBy(this.installedUser.map((item) => ({ ...item, scope: "user" as const })), (item) => `${item.scope}:${item.source}`)
 			.map(
 				(item) =>
 					({
@@ -712,17 +1638,104 @@ export class PackagesView {
 		return unique.filter((item) => `${item.displayName} ${item.source} ${item.location}`.toLowerCase().includes(q));
 	}
 
+	private filteredPromptTemplateResources(): DiscoveredResourceItem[] {
+		const q = this.normalizeQuery();
+		if (!q) return this.promptTemplateResources;
+		return this.promptTemplateResources.filter((item) => {
+			const haystack = `${item.name} ${item.description} ${item.commandText} ${item.packageSource ?? ""} ${item.path}`.toLowerCase();
+			return haystack.includes(q);
+		});
+	}
+
+	private filteredSkillResources(): DiscoveredResourceItem[] {
+		const q = this.normalizeQuery();
+		if (!q) return this.skillResources;
+		return this.skillResources.filter((item) => {
+			const haystack = `${item.name} ${item.description} ${item.commandText} ${item.packageSource ?? ""} ${item.path}`.toLowerCase();
+			return haystack.includes(q);
+		});
+	}
+
+	private findSkillResourceByName(name: string): DiscoveredResourceItem | null {
+		const normalized = name.trim().toLowerCase();
+		return this.skillResources.find((item) => item.name.trim().toLowerCase() === normalized) ?? null;
+	}
+
+	private buildRecommendedSkillItems(): RecommendedSkillSurfaceItem[] {
+		return RECOMMENDED_SKILLS.map((definition) => {
+			const resource = this.findSkillResourceByName(definition.skillName);
+			const packageInstalled = this.isSourceInstalledForScope(definition.packageSource, "global");
+			const installed = Boolean(resource || packageInstalled);
+			return {
+				id: `recommended-skill:${definition.id}`,
+				definition,
+				resource,
+				installed,
+				packageInstalled,
+			};
+		}).sort((a, b) => a.definition.name.localeCompare(b.definition.name));
+	}
+
+	private recommendedSkillNameSet(items: RecommendedSkillSurfaceItem[]): Set<string> {
+		return new Set(items.map((item) => item.definition.skillName.toLowerCase()));
+	}
+
+	private async resolvePackageSkillContentPath(skillName: string, packageSource: string | null): Promise<string | null> {
+		if (!packageSource) return null;
+		const installedPackage = this.findInstalledItemForSource(packageSource, "global");
+		const basePath = installedPackage?.location?.trim();
+		if (!basePath) return null;
+		const candidates = [
+			joinFsPath(joinFsPath(joinFsPath(basePath, "skills"), skillName), "SKILL.md"),
+			joinFsPath(joinFsPath(basePath, "skills"), `${skillName}.md`),
+		];
+		try {
+			const { exists } = await import("@tauri-apps/plugin-fs");
+			for (const candidate of candidates) {
+				if (await exists(candidate)) return candidate;
+			}
+		} catch {
+			// ignore
+		}
+		return null;
+	}
+
+	private async resolveRecommendedSkillContentPath(item: RecommendedSkillSurfaceItem): Promise<string | null> {
+		if (item.resource?.path) return item.resource.path;
+		return this.resolvePackageSkillContentPath(item.definition.skillName, item.definition.packageSource);
+	}
+
+	private async loadActiveSkillContent(path: string | null, fallbackMessage: string): Promise<void> {
+		this.activeSkillContent = "";
+		this.activeSkillContentError = "";
+		this.activeSkillContentNotice = "";
+		this.activeSkillContentPath = path;
+		if (!path) {
+			this.activeSkillContentNotice = fallbackMessage;
+			this.render();
+			return;
+		}
+		this.activeSkillContentLoading = true;
+		this.render();
+		try {
+			const { readTextFile } = await import("@tauri-apps/plugin-fs");
+			this.activeSkillContent = await readTextFile(path);
+		} catch (err) {
+			this.activeSkillContentError = err instanceof Error ? err.message : String(err);
+		} finally {
+			this.activeSkillContentLoading = false;
+			this.render();
+		}
+	}
+
 	private filteredCatalogItems(): CatalogPackageItem[] {
 		const q = this.normalizeQuery();
 		if (!q) return this.catalogItems;
 		return this.catalogItems.filter((item) => `${item.name} ${item.description}`.toLowerCase().includes(q));
 	}
 
-	private getEffectiveScope(scope: "global" | "local"): "global" | "local" {
-		if (scope === "local" && !this.currentProjectPath) {
-			return "global";
-		}
-		return scope;
+	private getEffectiveScope(_scope: "global" | "local"): "global" | "local" {
+		return "global";
 	}
 
 	private async executePackageCommand(
@@ -736,17 +1749,10 @@ export class PackagesView {
 	): Promise<boolean> {
 		if (this.runningCommand) return false;
 
-		const scope = this.getEffectiveScope(options.scope);
-		if (scope === "local" && !this.currentProjectPath) {
-			this.commandStatus = "Project actions need an active project in this workspace.";
-			this.render();
-			return false;
-		}
-
 		this.runningCommand = true;
 		this.commandStatus = options.statusText;
-		const finalArgs = options.appendLocalFlag && scope === "local" ? [...args, "-l"] : args;
-		const cwd = scope === "local" ? this.currentProjectPath ?? "." : "/";
+		const finalArgs = args;
+		const cwd = "/";
 		this.commandOutput = `${this.commandOutput ? `${this.commandOutput}\n\n` : ""}$ pi ${finalArgs.join(" ")}\n`;
 		this.render();
 
@@ -786,14 +1792,12 @@ export class PackagesView {
 		const effectiveScope = this.getEffectiveScope(scope);
 		const success = await this.executePackageCommand(["install", trimmed], {
 			scope: effectiveScope,
-			appendLocalFlag: true,
-			statusText: `Installing ${trimmed} (${effectiveScope === "local" ? "project" : "global"})…`,
+			appendLocalFlag: false,
+			statusText: `Installing ${trimmed}…`,
 			refreshOnSuccess: true,
 		});
 		if (success) {
-			this.commandStatus = effectiveScope === "local"
-				? `Installed in project settings: ${trimmed}`
-				: `Installed globally: ${trimmed}`;
+			this.commandStatus = `Installed: ${trimmed}`;
 		}
 	}
 
@@ -803,14 +1807,12 @@ export class PackagesView {
 		const effectiveScope = this.getEffectiveScope(scope);
 		const success = await this.executePackageCommand(["remove", trimmed], {
 			scope: effectiveScope,
-			appendLocalFlag: true,
-			statusText: `Removing ${trimmed} (${effectiveScope === "local" ? "project" : "global"})…`,
+			appendLocalFlag: false,
+			statusText: `Removing ${trimmed}…`,
 			refreshOnSuccess: true,
 		});
 		if (success) {
-			this.commandStatus = effectiveScope === "local"
-				? `Removed from project settings: ${trimmed}`
-				: `Removed from global settings: ${trimmed}`;
+			this.commandStatus = `Removed: ${trimmed}`;
 		}
 	}
 
@@ -823,7 +1825,7 @@ export class PackagesView {
 			refreshOnSuccess: true,
 		});
 		if (success) {
-			this.commandStatus = `Updated ${effectiveScope === "local" ? "project" : "global"} packages.`;
+			this.commandStatus = "Updated packages.";
 		}
 	}
 
@@ -836,7 +1838,7 @@ export class PackagesView {
 			refreshOnSuccess: true,
 		});
 		if (success) {
-			this.commandStatus = `Refreshed ${effectiveScope === "local" ? "project" : "global"} package list.`;
+			this.commandStatus = "Refreshed package list.";
 		}
 	}
 
@@ -851,6 +1853,616 @@ export class PackagesView {
 	private async openInstalledItem(item: InstalledDisplayItem): Promise<void> {
 		if (!item.openUrl) return;
 		await this.openExternal(item.openUrl);
+	}
+
+	private async runResourceCommand(item: DiscoveredResourceItem, actionLabel: string): Promise<void> {
+		if (this.runningCommand || this.runningConfigCommand) return;
+		this.runningCommand = true;
+		this.commandStatus = `${actionLabel} ${item.commandText}…`;
+		this.commandOutput = `${this.commandOutput ? `${this.commandOutput}\n\n` : ""}[resource] ${item.commandText}\n`;
+		this.render();
+		try {
+			await rpcBridge.prompt(item.commandText);
+			this.commandStatus = `${actionLabel} ${item.commandText}.`;
+		} catch (err) {
+			this.commandStatus = `Failed to run ${item.commandText}: ${err instanceof Error ? err.message : String(err)}`;
+		} finally {
+			this.runningCommand = false;
+			this.render();
+		}
+	}
+
+	private async applyPromptTemplate(item: DiscoveredResourceItem): Promise<void> {
+		await this.runResourceCommand(item, "Applied prompt template");
+	}
+
+	private async stageResourceCommandInChat(commandText: string, successLabel: string): Promise<void> {
+		if (!this.onInsertPromptTemplate) {
+			this.commandStatus = "Chat composer is not available right now.";
+			this.render();
+			return;
+		}
+		try {
+			await this.onInsertPromptTemplate(commandText);
+			this.commandStatus = successLabel;
+			this.commandOutput = `${this.commandOutput ? `${this.commandOutput}\n\n` : ""}[resource-draft] ${commandText}\n`;
+		} catch (err) {
+			this.commandStatus = `Failed to prepare command in chat: ${err instanceof Error ? err.message : String(err)}`;
+		}
+		this.render();
+	}
+
+	private async runSkill(item: DiscoveredResourceItem): Promise<void> {
+		await this.stageResourceCommandInChat(item.commandText, `Prepared ${item.commandText} in chat. Press Enter to run.`);
+	}
+
+	private async installRecommendedSkill(item: RecommendedSkillSurfaceItem): Promise<void> {
+		if (this.runningCommand) return;
+		if (!item.installed) {
+			await this.installPackage(item.definition.packageSource, "global");
+		}
+		const commandText = `/skill:${item.definition.skillName}`;
+		await this.stageResourceCommandInChat(commandText, `Prepared ${commandText} in chat. Press Enter to run.`);
+		if (this.activePackagesModal?.kind === "recommended-skill") {
+			this.closePackagesItemModal();
+		}
+	}
+
+	private insertPromptTemplate(item: DiscoveredResourceItem): void {
+		void this.stageResourceCommandInChat(item.commandText, `Inserted ${item.commandText} into composer.`);
+	}
+
+	async ensureCreatorSkillInstalled(): Promise<void> {
+		await this.ensureResourceCreatorSkillInstalled();
+		if (rpcBridge.isConnected) {
+			await this.refreshDiscoveredResources();
+		}
+	}
+
+	private openResourceCreatorModal(kind: "auto" | "prompt" | "skill" = "auto", lockKind = false): void {
+		this.resourceCreatorOpen = true;
+		this.resourceCreatorKind = kind;
+		this.resourceCreatorKindLocked = lockKind;
+		this.resourceCreatorScope = "global";
+		this.resourceCreatorBrief = "";
+		this.resourceCreatorError = "";
+		this.resourceStatus = "";
+		void this.ensureHomePath();
+		this.render();
+	}
+
+	private openCreateSkillModal(): void {
+		this.openResourceCreatorModal("skill", true);
+	}
+
+	private async triggerCreatorSkillInChat(): Promise<void> {
+		const creatorItem = this.buildRecommendedSkillItems().find((item) => item.definition.skillName === RESOURCE_CREATOR_SKILL_NAME) ?? null;
+		if (creatorItem) {
+			await this.installRecommendedSkill(creatorItem);
+			return;
+		}
+		const commandText = `/skill:${RESOURCE_CREATOR_SKILL_NAME}`;
+		await this.stageResourceCommandInChat(commandText, `Prepared ${commandText} in chat. Press Enter to run.`);
+	}
+
+	private closeResourceCreatorModal(): void {
+		if (this.resourceCreatorRunning) return;
+		this.resourceCreatorOpen = false;
+		this.resourceCreatorKindLocked = false;
+		this.resourceCreatorError = "";
+		this.render();
+	}
+
+	private resourceCreatorSkillPath(): string | null {
+		if (!this.homePath) return null;
+		const skillsRoot = joinFsPath(joinFsPath(joinFsPath(this.homePath, ".pi"), "agent"), "skills");
+		return joinFsPath(joinFsPath(skillsRoot, RESOURCE_CREATOR_SKILL_NAME), "SKILL.md");
+	}
+
+	private createResourceCreatorSkillMarkdown(): string {
+		return `---
+name: ${RESOURCE_CREATOR_SKILL_NAME}
+description: Create or update Pi prompt templates and Agent skills from a short user brief. Produces minimal, well-structured SKILL.md or prompt files that follow Agent Skills best practices.
+metadata:
+  short-description: Create or update a skill or prompt from a brief
+---
+
+# ${RESOURCE_CREATOR_SKILL_NAME}
+
+Purpose
+
+This skill creates a lightweight, production\u2011ready Pi resource (prompt template or Agent skill) from a short user brief. It favors concise, actionable files that follow the Agent Skills conventions and progressive disclosure: only the minimal metadata is kept in immediate context and larger references are stored separately.
+
+When to use
+
+- You want a new prompt template or skill scaffolded quickly from a short description.
+- You want a small, standards-compliant SKILL.md written for immediate use by Pi or other Agent Skill runtimes.
+- You prefer a single, reviewable change staged in chat (nothing is executed automatically).
+
+Input contract
+
+The skill expects a JSON payload (appended to the command) or equivalent user message with these fields:
+- kind: "auto" | "prompt" | "skill"        # preferred resource type or "auto" to infer
+- scope: "global" | "project"               # target location (global preferred)
+- brief: string                                # one-paragraph description of what the resource should do
+- name: string?                                # optional slug hint (will be normalized)
+
+Behavior
+
+1. Validate the brief. If essential details are missing, ask one concise clarification question.
+2. If kind == "auto", infer whether a prompt template or skill fits the brief.
+3. Determine a safe slug:
+   - Prefer an explicit \`name\` if provided after normalization.
+   - Otherwise derive a short, verb-led slug from the brief (lowercase, letters/numbers/hyphens, \u2264 64 chars).
+4. Create the resource under the chosen scope using Pi conventions:
+   - Prompt template: ~/.pi/agent/prompts/<slug>.md
+   - Skill: ~/.pi/agent/skills/<slug>/SKILL.md
+5. SKILL.md structure for skills:
+   - YAML frontmatter with \`name\` and \`description\` (these are the trigger fields)
+   - Body: short Purpose, Setup (one-time steps), Workflow (ordered steps), Examples (if helpful)
+   - Keep body concise; move large examples or references to \`references/\` files.
+6. For prompt templates:
+   - Create a markdown file with frontmatter \`description\` and a short reusable prompt body and usage notes.
+7. Never execute external commands or run the created scripts—always stage the operation and summarize the created files for user review.
+
+Naming rules
+
+- 1–64 chars, lowercase a-z, digits, hyphens only
+- No leading/trailing hyphens, no consecutive hyphens
+- Must match parent directory for SKILL.md (skill folder name)
+
+Examples
+
+Prepare a skill in chat (staged command):
+
+/skill:${RESOURCE_CREATOR_SKILL_NAME} {"kind":"skill","scope":"global","brief":"Create a skill that reviews staged git changes for security issues and outputs a short remediation plan."}
+
+Prepare a prompt template in chat (staged command):
+
+/skill:${RESOURCE_CREATOR_SKILL_NAME} {"kind":"prompt","scope":"global","brief":"Template for reviewing staged git changes with a strict security checklist."}
+
+Sample SKILL.md created for a security-review skill:
+
+\`\`\`markdown
+---
+name: security-review
+description: Review staged git changes for security issues and suggest concise remediation steps. Use when you want an automated checklist and file-level recommendations for changed files.
+---
+
+# Security Review
+
+## Purpose
+Quickly identify security-relevant changes in staged files and provide prioritized remediation suggestions.
+
+## Setup
+No one-time setup required. (If helper scripts are included, document how to run them.)
+
+## Workflow
+1. List staged files and their diffs.
+2. For each file, check for secrets, insecure patterns, and risky configuration changes.
+3. Produce a short summary and per-file remediation steps.
+
+## Examples
+- \`./scripts/check_secrets.sh\` (run locally after review)
+\`\`\`
+
+Validation & Best Practices
+
+- Keep SKILL.md focused: put large references under \`references/\` and link from SKILL.md.
+- Frontmatter MUST contain \`name\` and \`description\` (description should include trigger contexts).
+- Prefer short, imperative language and examples instead of long prose.
+- Ask at most one clarifying question if input is ambiguous.
+
+Notes
+
+- This skill only prepares and writes files under the chosen scope. It does not run or install anything.
+- On successful creation, summarize exactly which files were written and their absolute paths so the user can review and run them manually.
+`;
+	}
+
+	private async ensureResourceCreatorSkillInstalled(): Promise<string | null> {
+		await this.ensureHomePath();
+		const skillPath = this.resourceCreatorSkillPath();
+		if (!skillPath) return null;
+		try {
+			const { exists, mkdir, writeTextFile } = await import("@tauri-apps/plugin-fs");
+			if (await exists(skillPath)) return skillPath;
+			const skillDir = skillPath.replace(/[\\/]SKILL\.md$/i, "");
+			await mkdir(skillDir, { recursive: true });
+
+			// Prefer packaged asset if available (assets/skills/creatorskill/SKILL.md), fallback to generated template
+			let skillContent = this.createResourceCreatorSkillMarkdown();
+			try {
+				// Path relative from this module to assets directory
+				const assetUrl = new URL("../../assets/skills/creatorskill/SKILL.md", import.meta.url).href;
+				const resp = await fetch(assetUrl);
+				if (resp && resp.ok) {
+					skillContent = await resp.text();
+				}
+			} catch {
+				// ignore and use generated content
+			}
+
+			await writeTextFile(skillPath, skillContent);
+			return skillPath;
+		} catch {
+			return null;
+		}
+	}
+
+	private resolveResourceCreatorLoadedCommand(): string | null {
+		const entry = this.skillResources.find((item) => item.name === RESOURCE_CREATOR_SKILL_NAME && item.loaded);
+		if (!entry) return null;
+		return entry.commandText || `/skill:${RESOURCE_CREATOR_SKILL_NAME}`;
+	}
+
+	private buildResourceCreatorFallbackPrompt(): string {
+		const kind = this.resourceCreatorKind;
+		const brief = this.resourceCreatorBrief.trim();
+		return `Create a Pi resource from this brief with minimal manual steps.
+
+Preferred skill (if available): /skill:${RESOURCE_CREATOR_SKILL_NAME}
+Kind preference: ${kind}
+Scope: global
+Important: create ONLY global resources under ~/.pi/agent.
+
+Brief:
+${brief}
+
+Use Pi conventions:
+- Prompt templates: ~/.pi/agent/prompts/*.md
+- Skills: ~/.pi/agent/skills/<name>/SKILL.md
+- Prompt template format: frontmatter description + reusable markdown body
+- Skill format: Agent Skills style SKILL.md with name + description frontmatter and clear workflow steps
+
+Execute the required file creation/edits directly, then summarize exactly which files were created.`;
+	}
+
+	private async runResourceCreator(): Promise<void> {
+		if (this.resourceCreatorRunning || this.runningCommand || this.runningConfigCommand) return;
+		if (!this.resourceCreatorBrief.trim()) {
+			this.resourceCreatorError = "Describe what you want to create first.";
+			this.render();
+			return;
+		}
+		this.resourceCreatorScope = "global";
+
+		this.resourceCreatorRunning = true;
+		this.resourceCreatorError = "";
+		this.resourceStatus = "Preparing command draft for chat…";
+		this.render();
+
+		try {
+			await this.ensureResourceCreatorSkillInstalled();
+			await this.refreshDiscoveredResources();
+			const loadedCommand = this.resolveResourceCreatorLoadedCommand();
+			const payload = JSON.stringify({
+				kind: this.resourceCreatorKind,
+				scope: "global",
+				brief: this.resourceCreatorBrief.trim(),
+			});
+			const commandPrefix = loadedCommand || `/skill:${RESOURCE_CREATOR_SKILL_NAME}`;
+			const commandText = `${commandPrefix} ${payload}`;
+			const statusText = loadedCommand
+				? "Prepared creator skill command in chat. Press Enter to run."
+				: "Prepared creator skill command in chat (runtime lookup pending). Press Enter to run.";
+
+			await this.stageResourceCommandInChat(commandText, statusText);
+			this.resourceStatus = statusText;
+			this.resourceCreatorOpen = false;
+		} catch (err) {
+			this.resourceCreatorError = err instanceof Error ? err.message : String(err);
+		} finally {
+			this.resourceCreatorRunning = false;
+			this.render();
+		}
+	}
+
+	private renderResourceCreatorModal(): TemplateResult | typeof nothing {
+		if (!this.resourceCreatorOpen) return nothing;
+		const globalTarget = this.homePath
+			? joinFsPath(joinFsPath(this.homePath, ".pi"), "agent")
+			: "~/.pi/agent";
+		const creatingSkill = this.resourceCreatorKindLocked && this.resourceCreatorKind === "skill";
+		return html`
+			<div class="overlay" @click=${(event: Event) => event.target === event.currentTarget && this.closeResourceCreatorModal()}>
+				<div class="overlay-card packages-config-modal packages-item-modal">
+					<div class="overlay-header">
+						<div>
+							<div class="packages-config-modal-title">${creatingSkill ? "Create skill" : "Create resource"} (AI-assisted)</div>
+							<div class="packages-config-modal-sub">Prepares a command in chat. Nothing runs before you press Enter.</div>
+						</div>
+						<button ?disabled=${this.resourceCreatorRunning} @click=${() => this.closeResourceCreatorModal()}>✕</button>
+					</div>
+					<div class="overlay-body packages-config-modal-body">
+						<div class="packages-config-field-grid">
+							${!this.resourceCreatorKindLocked
+								? html`
+									<div class="packages-config-field">
+										<label class="packages-config-field-label">Resource type</label>
+										<select
+											class="packages-config-select"
+											.value=${this.resourceCreatorKind}
+											?disabled=${this.resourceCreatorRunning}
+											@change=${(event: Event) => {
+												this.resourceCreatorKind = (event.target as HTMLSelectElement).value as "auto" | "prompt" | "skill";
+												this.render();
+											}}
+										>
+											<option value="auto">Auto (let AI choose)</option>
+											<option value="prompt">Prompt template</option>
+											<option value="skill">Skill</option>
+										</select>
+									</div>
+								`
+								: nothing}
+
+							<div class="packages-config-field">
+								<label class="packages-config-field-label">Destination</label>
+								<div class="packages-section-submeta">${globalTarget}</div>
+								<div class="packages-section-submeta">Command is staged in chat and only runs after Enter.</div>
+							</div>
+						</div>
+
+						<div class="packages-config-field">
+							<label class="packages-config-field-label">What should this resource do?</label>
+							<textarea
+								class="packages-config-textarea"
+								placeholder="Example: Create a prompt template for reviewing staged git changes with a strict bug/security checklist"
+								?disabled=${this.resourceCreatorRunning}
+								.value=${this.resourceCreatorBrief}
+								@input=${(event: Event) => {
+									this.resourceCreatorBrief = (event.target as HTMLTextAreaElement).value;
+									this.render();
+								}}
+							></textarea>
+						</div>
+
+						<div class="packages-config-modal-actions">
+							<button class="ghost-btn" ?disabled=${this.resourceCreatorRunning} @click=${() => this.closeResourceCreatorModal()}>Cancel</button>
+							<button class="ghost-btn" ?disabled=${this.resourceCreatorRunning} @click=${() => void this.runResourceCreator()}>
+								${this.resourceCreatorRunning ? "Preparing…" : "Prepare in chat"}
+							</button>
+						</div>
+						<div class="packages-section-submeta">Always prepares <code>/skill:${RESOURCE_CREATOR_SKILL_NAME}</code> in chat. You review and press Enter manually.</div>
+						${this.resourceCreatorError ? html`<div class="packages-config-inline-error">${this.resourceCreatorError}</div>` : nothing}
+						${this.resourceStatus ? html`<div class="packages-section-submeta">${this.resourceStatus}</div>` : nothing}
+					</div>
+				</div>
+			</div>
+		`;
+	}
+
+	private openCreateResourceEditor(kind: "prompt" | "skill"): void {
+		this.resourceEditorOpen = true;
+		this.resourceEditorMode = "create";
+		this.resourceEditorKind = kind;
+		this.resourceEditorScope = "global";
+		this.resourceEditorName = kind === "skill" ? "my-skill" : "new-template";
+		this.resourceEditorDescription = kind === "skill"
+			? "What this skill does and when to use it."
+			: "Describe when to use this template.";
+		this.resourceEditorPath = null;
+		this.resourceEditorLoaded = false;
+		this.resourceEditorError = "";
+		this.resourceStatus = "";
+		this.applyResourceTemplate();
+	}
+
+	private closeResourceEditor(): void {
+		this.resourceEditorOpen = false;
+		this.resourceEditorError = "";
+		this.resourceEditorLoaded = false;
+		this.resourceEditorPath = null;
+		this.render();
+	}
+
+	private async openEditResourceEditor(item: DiscoveredResourceItem): Promise<void> {
+		if (!this.canEditResource(item) || !item.path) return;
+		this.resourceEditorOpen = true;
+		this.resourceEditorMode = "edit";
+		this.resourceEditorKind = item.kind;
+		this.resourceEditorScope = "global";
+		this.resourceEditorName = this.normalizeLoadedResourceName(item);
+		this.resourceEditorDescription = item.description || "";
+		this.resourceEditorPath = item.path;
+		this.resourceEditorLoaded = item.loaded;
+		this.resourceEditorError = "";
+		this.resourceStatus = "";
+		this.render();
+		try {
+			const { readTextFile } = await import("@tauri-apps/plugin-fs");
+			this.resourceEditorContent = await readTextFile(item.path);
+		} catch (err) {
+			this.resourceEditorContent = "";
+			this.resourceEditorError = err instanceof Error ? err.message : String(err);
+		}
+		this.render();
+	}
+
+	private async saveResourceEditor(): Promise<void> {
+		if (this.creatingResource || this.deletingResource) return;
+		const kind = this.resourceEditorKind;
+		const name = this.normalizeResourceName(this.resourceEditorName);
+		const validationError = this.validateResourceName(name, kind);
+		if (validationError) {
+			this.resourceEditorError = validationError;
+			this.render();
+			return;
+		}
+		if (!this.resourceEditorContent.trim()) {
+			this.resourceEditorError = "Content cannot be empty.";
+			this.render();
+			return;
+		}
+
+		this.creatingResource = true;
+		this.resourceEditorError = "";
+		this.resourceStatus = this.resourceEditorMode === "create" ? "Saving new resource…" : "Saving resource…";
+		this.render();
+
+		try {
+			await this.ensureHomePath();
+			const { exists, mkdir, writeTextFile } = await import("@tauri-apps/plugin-fs");
+			const targetPath = this.resourceEditorMode === "edit" && this.resourceEditorPath
+				? this.resourceEditorPath
+				: this.resourceFilePath(kind, this.resourceEditorScope, name);
+			if (!targetPath) {
+				throw new Error("Could not resolve resource path.");
+			}
+
+			const root = this.resourceRootPath(kind, this.resourceEditorScope);
+			if (!root) throw new Error("Could not resolve resource root directory.");
+			await mkdir(root, { recursive: true });
+			if (kind === "skill") {
+				const skillDir = joinFsPath(root, name);
+				await mkdir(skillDir, { recursive: true });
+			}
+
+			if (this.resourceEditorMode === "create" && (await exists(targetPath))) {
+				throw new Error("A resource with that name already exists.");
+			}
+
+			await writeTextFile(targetPath, this.resourceEditorContent);
+			this.resourceStatus = this.resourceEditorMode === "create"
+				? "Resource saved. Restart or open a new session to load new commands."
+				: "Resource updated. Restart or open a new session to refresh loaded commands.";
+			this.commandStatus = this.resourceStatus;
+			await this.refreshDiscoveredResources();
+			this.closeResourceEditor();
+		} catch (err) {
+			this.resourceEditorError = err instanceof Error ? err.message : String(err);
+			this.resourceStatus = "";
+			this.render();
+		} finally {
+			this.creatingResource = false;
+		}
+	}
+
+	private async deleteResource(item: DiscoveredResourceItem): Promise<void> {
+		if (!this.canEditResource(item) || !item.path) return;
+		if (this.deletingResource || this.creatingResource) return;
+		const confirmed = window.confirm(`Delete ${item.kind} \"${item.name}\"?`);
+		if (!confirmed) return;
+		this.deletingResource = true;
+		this.resourceStatus = `Deleting ${item.name}…`;
+		this.resourceEditorError = "";
+		this.render();
+		try {
+			const { remove } = await import("@tauri-apps/plugin-fs");
+			if (item.kind === "skill" && /[\\/]skill\.md$/i.test(item.path)) {
+				const skillDir = item.path.replace(/[\\/]skill\.md$/i, "");
+				await remove(skillDir, { recursive: true });
+			} else {
+				await remove(item.path);
+			}
+			this.resourceStatus = `Deleted ${item.kind} ${item.name}.`;
+			this.commandStatus = this.resourceStatus;
+			await this.refreshDiscoveredResources();
+		} catch (err) {
+			this.resourceEditorError = err instanceof Error ? err.message : String(err);
+		} finally {
+			this.deletingResource = false;
+			this.render();
+		}
+	}
+
+	private renderResourceEditorModal(): TemplateResult | typeof nothing {
+		if (!this.resourceEditorOpen) return nothing;
+		const creating = this.resourceEditorMode === "create";
+		const saveLabel = this.creatingResource ? "Saving…" : creating ? "Create resource" : "Save changes";
+		const typeLocked = !creating;
+		return html`
+			<div class="overlay" @click=${(event: Event) => event.target === event.currentTarget && this.closeResourceEditor()}>
+				<div class="overlay-card packages-config-modal">
+					<div class="overlay-header">
+						<div>
+							<div class="packages-config-modal-title">${creating ? "Create resource" : "Edit resource"}</div>
+							<div class="packages-config-modal-sub">Create prompt templates or skills with best-practice starter templates.</div>
+						</div>
+						<button @click=${() => this.closeResourceEditor()}>✕</button>
+					</div>
+					<div class="overlay-body packages-config-modal-body">
+						<div class="packages-config-field-grid">
+							<div class="packages-config-field">
+								<label class="packages-config-field-label">Type</label>
+								<select
+									class="packages-config-select"
+									.value=${this.resourceEditorKind}
+									?disabled=${typeLocked || this.creatingResource}
+									@change=${(event: Event) => {
+										const next = (event.target as HTMLSelectElement).value as "prompt" | "skill";
+										this.resourceEditorKind = next;
+										this.resourceEditorName = this.normalizeResourceName(this.resourceEditorName) || (next === "skill" ? "my-skill" : "new-template");
+										this.applyResourceTemplate();
+									}}
+								>
+									<option value="prompt">Prompt template</option>
+									<option value="skill">Skill</option>
+								</select>
+							</div>
+						</div>
+
+						<div class="packages-config-field">
+							<label class="packages-config-field-label">Name</label>
+							<input
+								class="packages-config-input"
+								type="text"
+								.value=${this.resourceEditorName}
+								?disabled=${!creating || this.creatingResource}
+								@input=${(event: Event) => {
+									this.resourceEditorName = (event.target as HTMLInputElement).value;
+									this.render();
+								}}
+							/>
+						</div>
+
+						<div class="packages-config-field">
+							<label class="packages-config-field-label">Description</label>
+							<input
+								class="packages-config-input"
+								type="text"
+								.value=${this.resourceEditorDescription}
+								?disabled=${this.creatingResource}
+								@input=${(event: Event) => {
+									this.resourceEditorDescription = (event.target as HTMLInputElement).value;
+									this.render();
+								}}
+							/>
+						</div>
+
+						<div class="packages-config-field">
+							<label class="packages-config-field-label">Content</label>
+							<textarea
+								class="packages-config-textarea"
+								?disabled=${this.creatingResource}
+								.value=${this.resourceEditorContent}
+								@input=${(event: Event) => {
+									this.resourceEditorContent = (event.target as HTMLTextAreaElement).value;
+									this.render();
+								}}
+							></textarea>
+						</div>
+
+						<div class="packages-config-modal-actions">
+							<button class="ghost-btn" ?disabled=${this.creatingResource} @click=${() => this.applyResourceTemplate()}>Use best-practice template</button>
+							<button class="ghost-btn" ?disabled=${this.creatingResource} @click=${() => this.closeResourceEditor()}>Cancel</button>
+							<button class="ghost-btn" ?disabled=${this.creatingResource} @click=${() => void this.saveResourceEditor()}>
+								${saveLabel}
+							</button>
+						</div>
+						${this.resourceEditorPath && !creating
+							? html`<div class="packages-section-submeta">Path: ${this.resourceEditorPath}</div>`
+							: nothing}
+						${this.resourceEditorLoaded && !creating
+							? html`<div class="packages-section-submeta">Loaded command may require a new session/restart to pick up changes.</div>`
+							: nothing}
+						${this.resourceEditorError ? html`<div class="packages-config-inline-error">${this.resourceEditorError}</div>` : nothing}
+						${this.resourceStatus ? html`<div class="packages-section-submeta">${this.resourceStatus}</div>` : nothing}
+					</div>
+				</div>
+			</div>
+		`;
 	}
 
 	private statusTone(): "info" | "success" | "error" {
@@ -917,14 +2529,21 @@ export class PackagesView {
 		}
 	}
 
-	private isRecommendedPackageInstalledForScope(scope: "global" | "local", state: { global: boolean; project: boolean }): boolean {
-		return scope === "local" ? state.project : state.global;
+	private isRecommendedPackageInstalledForScope(_scope: "global" | "local", state: { global: boolean; project: boolean }): boolean {
+		return state.global;
 	}
 
-	private isSourceInstalledForScope(source: string, scope: "global" | "local"): boolean {
+	private sourceMatchesInstalled(source: string, installedSource: string): boolean {
 		const normalizedSource = normalizeRecommendedSource(source);
-		const installedPool = scope === "local" ? this.installedProject : this.installedUser;
-		return installedPool.some((item) => normalizeRecommendedSource(item.source) === normalizedSource);
+		const normalizedInstalled = normalizeRecommendedSource(installedSource);
+		if (normalizedSource === normalizedInstalled) return true;
+		const bareSource = normalizedSource.startsWith("npm:") ? normalizedSource.slice(4) : normalizedSource;
+		const bareInstalled = normalizedInstalled.startsWith("npm:") ? normalizedInstalled.slice(4) : normalizedInstalled;
+		return bareSource === bareInstalled;
+	}
+
+	private isSourceInstalledForScope(source: string, _scope: "global" | "local"): boolean {
+		return this.installedUser.some((item) => this.sourceMatchesInstalled(source, item.source));
 	}
 
 	private resolveInstalledRemoveSource(item: InstalledDisplayItem): string {
@@ -941,6 +2560,434 @@ export class PackagesView {
 		return source;
 	}
 
+	private extensionInstallState(source: string): { global: boolean; project: boolean } {
+		return {
+			global: this.installedUser.some((item) => this.sourceMatchesInstalled(source, item.source)),
+			project: false,
+		};
+	}
+
+	private findInstalledItemForSource(source: string, _scope: "global" | "local"): InstalledDisplayItem | null {
+		const hit = this.installedUser.find((item) => this.sourceMatchesInstalled(source, item.source)) ?? null;
+		if (!hit) return null;
+		return {
+			...hit,
+			displayName: this.getDisplayName(hit.source),
+			openUrl: this.resolveSourceUrl(hit.source),
+		};
+	}
+
+	private buildExtensionSurfaceItems(
+		recommended: RecommendedPackageDefinition[],
+		discover: CatalogPackageItem[],
+		installed: InstalledDisplayItem[],
+	): { installed: ExtensionSurfaceItem[]; gallery: ExtensionSurfaceItem[] } {
+		const bySource = new Map<string, ExtensionSurfaceItem>();
+
+		for (const item of installed) {
+			const source = item.source;
+			const normalized = normalizeRecommendedSource(source);
+			const installState = this.extensionInstallState(source);
+			bySource.set(normalized, {
+				id: `installed:${normalized}`,
+				displayName: item.displayName,
+				source,
+				description: "Installed extension package",
+				note: item.location || source,
+				openUrl: item.openUrl,
+				sourceKind: inferSourceKindFromSource(source),
+				installState,
+				installedItemForScope: this.findInstalledItemForSource(source, "global"),
+			});
+		}
+
+		for (const item of recommended) {
+			const source = item.source;
+			const normalized = normalizeRecommendedSource(source);
+			if (bySource.has(normalized)) {
+				const existing = bySource.get(normalized)!;
+				bySource.set(normalized, {
+					...existing,
+					description: item.description || existing.description,
+					note: item.installSourceHint || existing.note,
+					displayName: item.name || existing.displayName,
+				});
+				continue;
+			}
+			const installState = this.extensionInstallState(source);
+			bySource.set(normalized, {
+				id: `recommended:${normalized}`,
+				displayName: item.name,
+				source,
+				description: item.description,
+				note: item.installSourceHint,
+				openUrl: this.resolveSourceUrl(source),
+				sourceKind: item.sourceKind,
+				installState,
+				installedItemForScope: this.findInstalledItemForSource(source, "global"),
+			});
+		}
+
+		for (const item of discover) {
+			const source = `npm:${item.name}`;
+			const normalized = normalizeRecommendedSource(source);
+			if (bySource.has(normalized)) continue;
+			const installState = this.extensionInstallState(source);
+			bySource.set(normalized, {
+				id: `discover:${normalized}`,
+				displayName: item.name,
+				source,
+				description: item.description || "No description",
+				note: `v${item.version}`,
+				openUrl: item.npmUrl,
+				sourceKind: "npm",
+				installState,
+				installedItemForScope: this.findInstalledItemForSource(source, "global"),
+			});
+		}
+
+		const all = [...bySource.values()]
+			.sort((a, b) => a.displayName.localeCompare(b.displayName));
+		const installedOnly = all.filter((item) => item.installState.global || item.installState.project);
+		const galleryOnly = all.filter((item) => !(item.installState.global || item.installState.project));
+		return { installed: installedOnly, gallery: galleryOnly };
+	}
+
+	private buildRecommendedExtensionItems(): ExtensionSurfaceItem[] {
+		return RECOMMENDED_PACKAGES
+			.map((item) => {
+				const source = item.source;
+				const normalized = normalizeRecommendedSource(source);
+				const installState = this.extensionInstallState(source);
+				return {
+					id: `recommended:${normalized}`,
+					displayName: item.name,
+					source,
+					description: item.description,
+					note: item.installSourceHint,
+					openUrl: this.resolveSourceUrl(source),
+					sourceKind: item.sourceKind,
+					installState,
+					installedItemForScope: this.findInstalledItemForSource(source, "global"),
+				} satisfies ExtensionSurfaceItem;
+			})
+			.sort((a, b) => a.displayName.localeCompare(b.displayName));
+	}
+
+	private async openPackagesItemModal(modal: ActivePackagesModal): Promise<void> {
+		this.activePackagesModal = modal;
+		this.activeSkillContent = "";
+		this.activeSkillContentPath = null;
+		this.activeSkillContentError = "";
+		this.activeSkillContentNotice = "";
+		this.activeSkillContentLoading = false;
+		if (modal.kind === "extension") {
+			const source = normalizeRecommendedSource(modal.item.source);
+			const commands = this.packageConfigCommands.get(source) ?? [];
+			this.activePackageConfigSource = source;
+			this.activePackageConfigLabel = modal.item.displayName;
+			this.packageConfigStatus = "";
+			this.render();
+
+			await this.loadPackageConfigFromPackage(source, commands).catch(() => {});
+			if (commands.some((command) => commandLikelyNeedsModelArg(command))) {
+				await this.ensureConfigModelsLoaded();
+			}
+			this.seedModelArgsForSource(source, commands);
+			this.render();
+			return;
+		}
+
+		this.render();
+		if (modal.kind === "skill") {
+			const directPath = modal.item.path.trim() || null;
+			const fallbackPath = directPath ? null : await this.resolvePackageSkillContentPath(modal.item.name, modal.item.packageSource);
+			const path = directPath ?? fallbackPath;
+			const fallbackMessage = modal.item.packageSource
+				? "Skill content is unavailable. Start a new session to refresh skills."
+				: "Skill content is unavailable.";
+			await this.loadActiveSkillContent(path, fallbackMessage);
+			return;
+		}
+
+		const contentPath = await this.resolveRecommendedSkillContentPath(modal.item);
+		const fallbackMessage = modal.item.installed
+			? "Skill content is unavailable. Start a new session to refresh skills."
+			: "Install this skill to view setup instructions.";
+		await this.loadActiveSkillContent(contentPath, fallbackMessage);
+	}
+
+	private closePackagesItemModal(): void {
+		this.activePackagesModal = null;
+		this.activePackageConfigSource = null;
+		this.activePackageConfigLabel = "";
+		this.packageConfigStatus = "";
+		this.activeSkillContent = "";
+		this.activeSkillContentPath = null;
+		this.activeSkillContentLoading = false;
+		this.activeSkillContentError = "";
+		this.activeSkillContentNotice = "";
+		this.render();
+	}
+
+	private async openPath(path: string): Promise<void> {
+		if (!path) return;
+		try {
+			let resolved = path;
+			// Expand ~ to home directory when present
+			if (resolved === "~" || resolved.startsWith("~/")) {
+				try {
+					const { homeDir } = await import("@tauri-apps/api/path");
+					const home = await homeDir();
+					resolved = resolved === "~" ? home : joinFsPath(home, resolved.slice(2));
+				} catch {
+					// ignore, fall back to original
+				}
+			}
+
+			const { exists } = await import("@tauri-apps/plugin-fs");
+			const { open } = await import("@tauri-apps/plugin-shell");
+			if (await exists(resolved)) {
+				await open(resolved);
+				return;
+			}
+			// Try parent folder
+			const parent = pathDirName(resolved);
+			if (parent && await exists(parent)) {
+				await open(parent);
+				return;
+			}
+
+			throw new Error("Path not found");
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			this.commandStatus = `Failed to open folder: ${message}`;
+			this.render();
+		}
+	}
+
+	private async installExtensionItem(item: ExtensionSurfaceItem): Promise<void> {
+		await this.installPackage(item.source, "global");
+		await this.refreshPackages(false);
+	}
+
+	private async uninstallExtensionItem(item: ExtensionSurfaceItem): Promise<void> {
+		const installed = item.installedItemForScope ?? this.findInstalledItemForSource(item.source, "global");
+		if (!installed) return;
+		await this.removePackage(this.resolveInstalledRemoveSource(installed), "global");
+		await this.refreshPackages(false);
+	}
+
+	private renderSkillContentBlock(): TemplateResult {
+		if (this.activeSkillContentLoading) {
+			return html`
+				<div class="packages-skill-content">
+					<div class="packages-empty">Loading skill content…</div>
+				</div>
+			`;
+		}
+		if (this.activeSkillContentError) {
+			return html`
+				<div class="packages-skill-content">
+					<div class="packages-empty error">${this.activeSkillContentError}</div>
+				</div>
+			`;
+		}
+		if (this.activeSkillContent) {
+			const doc = parseSkillDoc(this.activeSkillContent);
+			const modalTitle = this.activePackagesModal?.kind === "recommended-skill"
+				? this.activePackagesModal.item.definition.name
+				: this.activePackagesModal?.kind === "skill"
+					? this.activePackagesModal.item.name
+					: "";
+			const normalizedModalTitle = modalTitle.trim().toLowerCase();
+			const sections = doc.sections.map((section, index) => {
+				if (index === 0 && section.heading && normalizedModalTitle && section.heading.trim().toLowerCase() === normalizedModalTitle) {
+					return { ...section, heading: null };
+				}
+				return section;
+			});
+			return html`
+				<div class="packages-skill-content">
+					<div class="packages-skill-doc">
+						${doc.summary ? html`<div class="packages-skill-doc-summary">${doc.summary}</div>` : nothing}
+						${sections.length > 0
+							? sections.map((section) => html`
+								<section class="packages-skill-doc-section">
+									${section.heading ? html`<h4>${section.heading}</h4>` : nothing}
+									${section.paragraphs.map((paragraph) => html`<p>${paragraph}</p>`) }
+								</section>
+							`)
+							: html`<div class="packages-empty">No readable content found in SKILL.md.</div>`}
+					</div>
+				</div>
+			`;
+		}
+		if (this.activeSkillContentNotice) {
+			return html`
+				<div class="packages-skill-content">
+					<div class="packages-empty">${this.activeSkillContentNotice}</div>
+				</div>
+			`;
+		}
+		return html`
+			<div class="packages-skill-content">
+				<div class="packages-empty">Skill content not available.</div>
+			</div>
+		`;
+	}
+
+	private renderItemMetaRows(entries: Array<{ label: string; value: string }>): TemplateResult {
+		return html`
+			<div class="packages-item-meta-grid">
+				${entries.map((entry) => html`
+					<div class="packages-item-meta-row">
+						<div class="packages-item-meta-label">${entry.label}</div>
+						<div class="packages-item-meta-value" title=${entry.value}>${entry.value}</div>
+					</div>
+				`)}
+			</div>
+		`;
+	}
+
+	private renderPackagesItemModal(): TemplateResult | typeof nothing {
+		const modal = this.activePackagesModal;
+		if (!modal) return nothing;
+		if (modal.kind === "extension") {
+			const item = modal.item;
+			const source = normalizeRecommendedSource(item.source);
+			const commands = this.packageConfigCommands.get(source) ?? [];
+			const installedForScope = item.installedItemForScope ?? this.findInstalledItemForSource(item.source, "global");
+			const selectedScopeInstalled = item.installState.global;
+			const pathNote = installedForScope?.location || "Not installed";
+			return html`
+				<div class="overlay" @click=${(event: Event) => event.target === event.currentTarget && this.closePackagesItemModal()}>
+					<div class="overlay-card packages-config-modal packages-item-modal">
+						<div class="overlay-header">
+							<div>
+								<div class="packages-config-modal-title">${item.displayName}</div>
+							</div>
+							<button @click=${() => this.closePackagesItemModal()}>✕</button>
+						</div>
+						<div class="overlay-body packages-config-modal-body">
+							${item.description ? html`<div class="packages-section-desc">${item.description}</div>` : nothing}
+							${this.renderItemMetaRows([
+								{ label: "Source", value: item.source },
+								{ label: "Status", value: selectedScopeInstalled ? "Installed" : "Not installed" },
+								{ label: "Path", value: pathNote },
+							])}
+
+							${commands.length > 0
+								? html`
+									<div class="packages-section-submeta">Extension settings</div>
+									${commands.map((command) => this.renderPackageConfigCommandEditor(source, command))}
+								`
+								: html`<div class="packages-empty">No extension settings commands discovered.</div>`}
+							${this.packageConfigStatus ? html`<div class="packages-section-submeta">${this.packageConfigStatus}</div>` : nothing}
+
+							<div class="packages-config-modal-actions">
+								<button class="ghost-btn" ?disabled=${this.runningCommand} @click=${() => void (selectedScopeInstalled ? this.uninstallExtensionItem(item) : this.installExtensionItem(item))}>
+									${this.runningCommand ? (selectedScopeInstalled ? "Uninstalling…" : "Installing…") : selectedScopeInstalled ? "Uninstall" : "Install"}
+								</button>
+								${item.openUrl ? html`<button class="ghost-btn" @click=${() => void this.openExternal(item.openUrl!)}>Open page</button>` : nothing}
+								${installedForScope?.location ? html`<button class="ghost-btn" @click=${() => void this.openPath(installedForScope.location)}>Open folder</button>` : nothing}
+							</div>
+						</div>
+					</div>
+				</div>
+			`;
+		}
+
+		if (modal.kind === "recommended-skill") {
+			const item = modal.item;
+			const definition = item.definition;
+			const resource = item.resource;
+			const commandText = resource?.commandText ?? `/skill:${definition.skillName}`;
+			const skillPath = this.activeSkillContentPath;
+			const skillOpenUrl = definition.openUrl ?? (resource?.packageSource ? this.resolveSourceUrl(resource.packageSource) : null);
+			const skillContent = this.renderSkillContentBlock();
+			const primaryLabel = this.runningCommand
+				? item.installed
+					? "Preparing…"
+					: "Installing…"
+				: item.installed
+					? "Try in chat"
+					: "Install + try";
+			return html`
+				<div class="overlay" @click=${(event: Event) => event.target === event.currentTarget && this.closePackagesItemModal()}>
+					<div class="overlay-card packages-config-modal packages-item-modal">
+						<div class="overlay-header">
+							<div>
+								<div class="packages-config-modal-title">${definition.name}</div>
+							</div>
+							<button @click=${() => this.closePackagesItemModal()}>✕</button>
+						</div>
+						<div class="overlay-body packages-config-modal-body">
+							${definition.description ? html`<div class="packages-section-desc">${definition.description}</div>` : nothing}
+							${this.renderItemMetaRows([
+								{ label: "Command", value: commandText },
+								{ label: "Status", value: item.installed ? "Installed" : "Not installed" },
+								{ label: "Path", value: skillPath ?? "Install to view location" },
+							])}
+							${skillContent}
+							${!this.activeSkillContent && !this.activeSkillContentLoading && definition.setupHint
+								? html`<div class="packages-section-submeta">${definition.setupHint}</div>`
+								: nothing}
+							<div class="packages-config-modal-actions">
+								<button
+									class="ghost-btn"
+									?disabled=${this.runningCommand || this.runningConfigCommand}
+									@click=${() => void this.installRecommendedSkill(item)}
+								>
+									${primaryLabel}
+								</button>
+								${skillPath ? html`<button class="ghost-btn" @click=${() => void this.openPath(pathDirName(skillPath))}>Open folder</button>` : nothing}
+								${skillOpenUrl ? html`<button class="ghost-btn" @click=${() => void this.openExternal(skillOpenUrl)}>Open page</button>` : nothing}
+							</div>
+						</div>
+					</div>
+				</div>
+			`;
+		}
+
+		const item = modal.item;
+		const canDelete = this.canEditResource(item);
+		const skillOpenUrl = item.packageSource ? this.resolveSourceUrl(item.packageSource) : null;
+		const skillPath = this.activeSkillContentPath ?? (item.path.trim() || null);
+		const skillContent = this.renderSkillContentBlock();
+		return html`
+			<div class="overlay" @click=${(event: Event) => event.target === event.currentTarget && this.closePackagesItemModal()}>
+				<div class="overlay-card packages-config-modal packages-item-modal">
+					<div class="overlay-header">
+						<div>
+							<div class="packages-config-modal-title">${item.name}</div>
+						</div>
+						<button @click=${() => this.closePackagesItemModal()}>✕</button>
+					</div>
+					<div class="overlay-body packages-config-modal-body">
+						${item.description ? html`<div class="packages-section-desc">${item.description}</div>` : nothing}
+						${this.renderItemMetaRows([
+							{ label: "Command", value: item.commandText },
+							{ label: "Source", value: item.loaded ? "Runtime" : "File" },
+							{ label: "Path", value: skillPath ?? "Runtime command" },
+						])}
+						${skillContent}
+						<div class="packages-config-modal-actions">
+							<button class="ghost-btn" ?disabled=${this.runningCommand || this.runningConfigCommand} @click=${() => void this.runSkill(item)}>Try in chat</button>
+							${skillPath ? html`<button class="ghost-btn" @click=${() => void this.openPath(pathDirName(skillPath))}>Open folder</button>` : nothing}
+							${skillOpenUrl
+								? html`<button class="ghost-btn" @click=${() => void this.openExternal(skillOpenUrl)}>Open page</button>`
+								: nothing}
+							${canDelete
+								? html`<button class="ghost-btn danger" ?disabled=${this.deletingResource} @click=${() => void this.deleteResource(item)}>${this.deletingResource ? "Removing…" : "Uninstall skill"}</button>`
+								: nothing}
+						</div>
+					</div>
+				</div>
+			</div>
+		`;
+	}
+
 	private renderPackageRow(options: {
 		title: string;
 		description: string;
@@ -949,15 +2996,23 @@ export class PackagesView {
 		iconName?: UiIcon;
 		actions?: TemplateResult | typeof nothing;
 		titleAttr?: string;
+		onTitleClick?: (() => void) | null;
 	}): TemplateResult {
+		const iconName = options.iconName ?? "package";
 		return html`
 			<div class="packages-list-row" title=${options.titleAttr ?? ""}>
-				<div class="packages-list-row-icon ${options.iconName === "extension" ? "extension" : ""}">
-					<span class="packages-inline-icon">${icon(options.iconName ?? "package")}</span>
+				<div class="packages-list-row-icon ${iconName}">
+					<span class="packages-inline-icon">${icon(iconName)}</span>
 				</div>
 				<div class="packages-list-row-main">
 					<div class="packages-list-row-top">
-						<div class="packages-list-row-title">${options.title}</div>
+						${options.onTitleClick
+							? html`
+								<button class="packages-list-row-title packages-list-row-title-link" @click=${() => options.onTitleClick?.()}>
+									${options.title}
+								</button>
+							`
+							: html`<div class="packages-list-row-title">${options.title}</div>`}
 						${options.badges && options.badges.length > 0
 							? html`<div class="packages-list-row-badges">${options.badges}</div>`
 							: nothing}
@@ -973,17 +3028,218 @@ export class PackagesView {
 	render(): void {
 		const installedItems = this.getInstalledItems();
 		const catalogItems = this.filteredCatalogItems();
-		const recommendedPackages = RECOMMENDED_PACKAGES.filter((item) => {
-			const q = this.normalizeQuery();
-			if (!q) return true;
-			return `${item.name} ${item.description} ${item.installSourceHint}`.toLowerCase().includes(q);
+		const skillResources = this.filteredSkillResources();
+		const query = this.normalizeQuery();
+		const hasQuery = query.length > 0;
+		const queryLabel = this.query.trim();
+		const recommendedSkills = this.buildRecommendedSkillItems().filter((item) => {
+			if (!query) return true;
+			return `${item.definition.name} ${item.definition.description}`.toLowerCase().includes(query);
 		});
-		const effectiveScope = this.getEffectiveScope(this.packageScope);
-		const installTarget = effectiveScope === "local" ? "Project" : "Global";
-		const discoverItems = catalogItems;
+		const recommendedSkillNames = this.recommendedSkillNameSet(recommendedSkills);
+		const visibleSkillResources = skillResources.filter((item) => !recommendedSkillNames.has(item.name.toLowerCase()));
+		const recommendedExtensions = this.buildRecommendedExtensionItems().filter((item) => {
+			if (!query) return true;
+			return `${item.displayName} ${item.description} ${item.note ?? ""}`.toLowerCase().includes(query);
+		});
+		const recommendedExtensionSources = new Set(
+			RECOMMENDED_PACKAGES.map((item) => normalizeRecommendedSource(item.source)),
+		);
+		const recommendedPackages = RECOMMENDED_PACKAGES.filter((item) => {
+			if (!query) return true;
+			return `${item.name} ${item.description} ${item.installSourceHint}`.toLowerCase().includes(query);
+		});
+		const extensionSurfaces = this.buildExtensionSurfaceItems(recommendedPackages, catalogItems, installedItems);
+		const extensionInstalled = extensionSurfaces.installed;
+		const extensionDiscover = hasQuery
+			? extensionSurfaces.gallery.filter((item) => !recommendedExtensionSources.has(normalizeRecommendedSource(item.source)))
+			: [];
+		const galleryItems = !hasQuery
+			? extensionSurfaces.gallery
+					.filter((item) => !recommendedExtensionSources.has(normalizeRecommendedSource(item.source)))
+					.slice(0, 12)
+			: [];
+
+		const installedRecommendedSkills = recommendedSkills.filter((item) => item.installed);
+		const availableRecommendedSkills = recommendedSkills.filter((item) => !item.installed);
+		const availableRecommendedExtensions = recommendedExtensions.filter((item) => !item.installState.global);
+
+		type RowOptions = {
+			title: string;
+			description: string;
+			note?: string | null;
+			badges?: TemplateResult[];
+			iconName?: UiIcon;
+			actions?: TemplateResult | typeof nothing;
+			titleAttr?: string;
+			onTitleClick?: (() => void) | null;
+		};
+
+		const installedRowsData: Array<{ sortKey: string; options: RowOptions }> = [];
+		const discoverRowsData: Array<{ sortKey: string; priority: number; options: RowOptions }> = [];
+		const recommendedBadge = html`<span class="packages-card-scope recommended">Recommended</span>`;
+
+		const addInstalledRow = (sortKey: string, options: RowOptions) => {
+			installedRowsData.push({ sortKey, options });
+		};
+
+		const addDiscoverRow = (priority: number, sortKey: string, options: RowOptions) => {
+			discoverRowsData.push({ priority, sortKey, options });
+		};
+
+		for (const item of installedRecommendedSkills) {
+			const note = item.resource?.path || `Package: ${this.getDisplayName(item.definition.packageSource)}`;
+			addInstalledRow(item.definition.name.toLowerCase(), {
+				title: item.definition.name,
+				description: item.resource?.description || item.definition.description,
+				note,
+				iconName: "skill",
+				actions: html`<button class="packages-row-install installed" title="Installed" @click=${() => void this.openPackagesItemModal({ kind: "recommended-skill", item })}>✓</button>`,
+				onTitleClick: () => void this.openPackagesItemModal({ kind: "recommended-skill", item }),
+				titleAttr: item.definition.skillName,
+			});
+		}
+
+		for (const item of visibleSkillResources) {
+			addInstalledRow(item.name.toLowerCase(), {
+				title: item.name,
+				description: item.description || "Skill",
+				note: item.path || (item.packageDisplayName ? `Package: ${item.packageDisplayName}` : "Runtime command"),
+				iconName: "skill",
+				actions: html`<button class="packages-row-install installed" title="Installed" @click=${() => void this.openPackagesItemModal({ kind: "skill", item })}>✓</button>`,
+				onTitleClick: () => void this.openPackagesItemModal({ kind: "skill", item }),
+				titleAttr: item.path || item.commandText,
+			});
+		}
+
+		for (const item of extensionInstalled) {
+			addInstalledRow(item.displayName.toLowerCase(), {
+				title: item.displayName,
+				description: item.description || item.source,
+				note: item.note,
+				iconName: "extension",
+				actions: html`<button class="packages-row-install installed" title="Installed" @click=${() => void this.openPackagesItemModal({ kind: "extension", item })}>✓</button>`,
+				onTitleClick: () => void this.openPackagesItemModal({ kind: "extension", item }),
+				titleAttr: item.source,
+			});
+		}
+
+		for (const item of availableRecommendedSkills) {
+			addDiscoverRow(0, item.definition.name.toLowerCase(), {
+				title: item.definition.name,
+				description: item.definition.description,
+				note: `Package: ${this.getDisplayName(item.definition.packageSource)}`,
+				iconName: "skill",
+				badges: [recommendedBadge],
+				actions: html`
+					<button
+						class="packages-row-install add"
+						?disabled=${this.runningCommand}
+						title="Install"
+						@click=${() => void this.installRecommendedSkill(item)}
+					>
+						+
+					</button>
+				`,
+				onTitleClick: () => void this.openPackagesItemModal({ kind: "recommended-skill", item }),
+				titleAttr: item.definition.skillName,
+			});
+		}
+
+		for (const item of availableRecommendedExtensions) {
+			addDiscoverRow(0, item.displayName.toLowerCase(), {
+				title: item.displayName,
+				description: item.description || item.source,
+				note: item.note,
+				iconName: "extension",
+				badges: [recommendedBadge],
+				actions: html`
+					<button
+						class="packages-row-install add"
+						?disabled=${this.runningCommand}
+						title="Install"
+						@click=${() => void this.installExtensionItem(item)}
+					>
+						+
+					</button>
+				`,
+				onTitleClick: () => void this.openPackagesItemModal({ kind: "extension", item }),
+				titleAttr: item.source,
+			});
+		}
+
+		for (const item of galleryItems) {
+			addDiscoverRow(1, item.displayName.toLowerCase(), {
+				title: item.displayName,
+				description: item.description || item.source,
+				note: item.note,
+				iconName: "extension",
+				badges: [html`<span class="packages-card-scope">${sourceKindLabel(item.sourceKind)}</span>`],
+				actions: html`
+					<button
+						class="packages-row-install add"
+						?disabled=${this.runningCommand}
+						title="Install"
+						@click=${() => void this.installExtensionItem(item)}
+					>
+						+
+					</button>
+				`,
+				onTitleClick: () => void this.openPackagesItemModal({ kind: "extension", item }),
+				titleAttr: item.openUrl || item.source,
+			});
+		}
+
+		for (const item of extensionDiscover) {
+			addDiscoverRow(1, item.displayName.toLowerCase(), {
+				title: item.displayName,
+				description: item.description || item.source,
+				note: item.note,
+				iconName: "extension",
+				actions: html`
+					<button
+						class="packages-row-install add"
+						?disabled=${this.runningCommand}
+						title="Install"
+						@click=${() => void this.installExtensionItem(item)}
+					>
+						+
+					</button>
+				`,
+				onTitleClick: () => void this.openPackagesItemModal({ kind: "extension", item }),
+				titleAttr: item.openUrl || item.source,
+			});
+		}
+
+		const sortedInstalled = installedRowsData.sort((a, b) => {
+			const typeOrder = (opt: { sortKey: string; options: RowOptions }) => (opt.options.iconName === "skill" ? 0 : opt.options.iconName === "extension" ? 1 : 2);
+			const ta = typeOrder(a);
+			const tb = typeOrder(b);
+			if (ta !== tb) return ta - tb;
+			return a.sortKey.localeCompare(b.sortKey);
+		});
+		const installedRows = sortedInstalled.map((entry) => this.renderPackageRow(entry.options));
+
+		const discoverRows = discoverRowsData
+			.sort((a, b) => a.priority - b.priority || a.sortKey.localeCompare(b.sortKey))
+			.map((entry) => this.renderPackageRow(entry.options));
+		const installedCount = sortedInstalled.length;
+		const discoverCount = discoverRows.length;
+		const installedLoading = this.loadingResources || this.loadingConfig;
+		const discoverLoading = this.loadingCatalog && hasQuery;
+		const discoverTitle = hasQuery ? "Results" : "Recommended";
+		const discoverMetaLabel = hasQuery ? "results" : "recommended";
+		const discoverSubmeta = hasQuery
+			? `Results for “${queryLabel}”.`
+			: "Recommended skills and extensions to get started.";
+		const discoverEmptyMessage = hasQuery ? "No matches found." : "No recommendations available.";
 		const notifyDebugLines = this.getNotifyDebugLines();
-		const hasDiagnostics = true;
+		const hasDiagnostics = this.runningCommand || this.statusTone() === "error" || notifyDebugLines.length > 0 || this.commandOutput.trim().length > 0;
 		const diagnosticsOpen = this.runningCommand || this.statusTone() === "error";
+		const loadingPackagesInitial = (this.loadingConfig || this.loadingResources) &&
+			installedCount === 0 &&
+			!this.configError &&
+			!this.resourcesError;
 
 		const template = html`
 			<div class="packages-view-root">
@@ -991,14 +3247,15 @@ export class PackagesView {
 					<div class="packages-view-title-wrap">
 						<div class="packages-view-title">Packages</div>
 						<div class="packages-view-meta">
-							${this.loadingConfig
+							${installedLoading || discoverLoading
 								? "Refreshing package state…"
-								: `${installedItems.length} installed · ${recommendedPackages.length} recommended`}
+								: `${installedCount} installed · ${discoverCount} ${discoverMetaLabel}`}
 						</div>
 					</div>
 					<div class="packages-view-header-actions">
 						<button class="packages-back-btn" ?disabled=${this.runningCommand} @click=${() => void this.refreshPackages(true)}>Refresh</button>
-						<button class="packages-back-btn" @click=${() => void this.openCatalog()}>Gallery</button>
+						<button class="packages-back-btn" ?disabled=${this.runningCommand || this.runningConfigCommand} @click=${() => void this.triggerCreatorSkillInChat()}>Create skill</button>
+						<button class="packages-back-btn" @click=${() => void this.openCatalog()}>Browse</button>
 						${this.onBack
 							? html`<button class="packages-back-btn" @click=${() => this.onBack?.()}>← Back</button>`
 							: nothing}
@@ -1008,190 +3265,74 @@ export class PackagesView {
 				<div class="packages-view-body minimal">
 					${this.commandStatus ? html`<div class="packages-banner ${this.statusTone()}">${this.commandStatus}</div>` : nothing}
 					${this.configError ? html`<div class="packages-banner error">Config error: ${this.configError}</div>` : nothing}
+					${this.resourcesError ? html`<div class="packages-banner error">Resource error: ${this.resourcesError}</div>` : nothing}
 					${this.catalogError ? html`<div class="packages-banner error">Catalog error: ${this.catalogError}</div>` : nothing}
 
-					<section class="packages-section packages-top-strip">
-						<div class="packages-scope-toggle" role="tablist" aria-label="Install target scope">
-							<button
-								class="packages-scope-btn ${effectiveScope === "global" ? "active" : ""}"
-								?disabled=${this.runningCommand}
-								@click=${() => {
-									this.packageScope = "global";
-									this.render();
-								}}
-							>
-								Global
-							</button>
-							<button
-								class="packages-scope-btn ${effectiveScope === "local" ? "active" : ""}"
-								?disabled=${this.runningCommand || !this.currentProjectPath}
-								@click=${() => {
-									this.packageScope = "local";
-									this.render();
-								}}
-							>
-								Project
-							</button>
-						</div>
-						<div class="packages-scope-note">
-							${effectiveScope === "local"
-								? this.currentProjectPath
-									? `Installing into project: ${this.currentProjectPath}`
-									: "Open a project to install project-local packages"
-								: "Global is default and available across projects"}
-						</div>
-					</section>
-
-					<section class="packages-section">
-						<div class="packages-section-head">
-							<div>
-								<div class="packages-section-title">Installed</div>
-								<div class="packages-section-submeta">Scope is shown per package.</div>
-							</div>
-							<div class="packages-section-meta">${installedItems.length}</div>
-						</div>
-						${installedItems.length === 0
-							? html`<div class="packages-empty">No packages installed yet.</div>`
-							: html`
-								<div class="packages-list packages-list-grid">
-									${installedItems.map((item) =>
-										this.renderPackageRow({
-											title: item.displayName,
-											description: item.source,
-											badges: [
-												html`<span class="packages-card-scope ${item.scope === "project" ? "project" : "global-installed"}">${item.scope === "project" ? "Project" : "Global"}</span>`,
-											],
-											actions: html`
-												${item.openUrl
-													? html`<button class="packages-card-action" title="Open package page" @click=${() => void this.openInstalledItem(item)}>${icon("open")}</button>`
-													: nothing}
-												<button
-													class="packages-card-action"
-													?disabled=${this.runningCommand || this.runningConfigCommand}
-													title="Package settings"
-													@click=${() => this.openPackageConfig(item)}
-												>
-													${icon("settings")}
-												</button>
-												<button
-													class="packages-card-action danger"
-													?disabled=${this.runningCommand}
-													title="Uninstall"
-													@click=${() => void this.removePackage(this.resolveInstalledRemoveSource(item), item.scope === "project" ? "local" : "global")}
-												>
-													${icon("remove")}
-												</button>
-											`,
-											titleAttr: item.location || item.source,
-										}),
-									)}
-								</div>
-							`}
-					</section>
-
-					<section class="packages-section">
-						<div class="packages-section-head">
-							<div>
-								<div class="packages-section-title">Recommended</div>
-								<div class="packages-section-submeta">Curated desktop packages. Install target: ${installTarget}.</div>
-							</div>
-							<div class="packages-section-meta">${recommendedPackages.length}</div>
-						</div>
-						${recommendedPackages.length === 0
-							? html`<div class="packages-empty">No recommended packages match the current search.</div>`
-							: html`
-								<div class="packages-list packages-list-grid">
-									${recommendedPackages.map((item) => {
-										const installState = this.getRecommendedInstallState(item);
-										const selectedScopeInstalled = this.isRecommendedPackageInstalledForScope(effectiveScope, installState);
-										return this.renderPackageRow({
-											title: item.name,
-											description: item.description,
-											iconName: "extension",
-											badges: [
-												html`<span class="packages-card-scope">${sourceKindLabel(item.sourceKind)}</span>`,
-												...(installState.global ? [html`<span class="packages-card-scope global-installed">Global</span>`] : []),
-												...(installState.project ? [html`<span class="packages-card-scope project">Project</span>`] : []),
-											],
-											actions: html`
-												<button
-													class="packages-row-install ${selectedScopeInstalled ? "remove" : "add"}"
-													?disabled=${this.runningCommand}
-													title=${selectedScopeInstalled ? `Remove from ${installTarget.toLowerCase()} target` : `Install to ${installTarget.toLowerCase()} target`}
-													@click=${() =>
-														void (selectedScopeInstalled
-															? this.removePackage(item.source, this.packageScope)
-															: this.installRecommendedPackage(item, this.packageScope))}
-												>
-													${selectedScopeInstalled ? "×" : "+"}
-												</button>
-											`,
-											titleAttr: item.installSourceHint,
-										});
-									})}
-								</div>
-							`}
-					</section>
-
-					<section class="packages-section">
-						<div class="packages-section-head">
-							<div>
-								<div class="packages-section-title">Discover</div>
-								<div class="packages-section-submeta">Browse and install community packages directly here.</div>
-							</div>
-							<div class="packages-section-meta">${catalogItems.length}</div>
-						</div>
-						${this.loadingCatalog
-							? html`<div class="packages-empty">Loading catalog…</div>`
-							: discoverItems.length === 0
-								? html`<div class="packages-empty">No packages match the current search.</div>`
-								: html`
-									<div class="packages-list packages-list-grid">
-										${discoverItems.map((item) => {
-											const discoverSource = `npm:${item.name}`;
-											const selectedScopeInstalled = this.isSourceInstalledForScope(discoverSource, effectiveScope);
-											return this.renderPackageRow({
-												title: item.name,
-												description: item.description || "No description",
-												note: `v${item.version}`,
-												badges: [html`<span class="packages-card-scope">npm</span>`],
-												actions: html`
-													<button
-														class="packages-row-install ${selectedScopeInstalled ? "remove" : "add"}"
-														?disabled=${this.runningCommand}
-														title=${selectedScopeInstalled ? `Remove from ${installTarget.toLowerCase()} target` : `Install to ${installTarget.toLowerCase()} target`}
-														@click=${() => void (selectedScopeInstalled ? this.removePackage(discoverSource, this.packageScope) : this.addCatalogItem(item))}
-													>
-														${selectedScopeInstalled ? "×" : "+"}
-													</button>
-												`,
-												titleAttr: item.npmUrl,
-											});
-										})}
+					${loadingPackagesInitial
+						? html`<div class="packages-loading-state">Loading packages…</div>`
+						: html`
+							<section class="packages-section">
+								<div class="packages-section-head">
+									<div>
+										<div class="packages-section-title">Installed</div>
+										<div class="packages-section-submeta">Skills and extensions available in this session.</div>
 									</div>
-								`}
-					</section>
-
-					${hasDiagnostics
-						? html`
-							<details class="packages-diagnostics" ?open=${diagnosticsOpen}>
-								<summary>Diagnostics</summary>
-								<div class="packages-diagnostics-actions">
-									<button class="ghost-btn" ?disabled=${this.runningCommand} @click=${() => void this.updatePackages()}>Update target</button>
-									<button class="ghost-btn" ?disabled=${this.runningCommand} @click=${() => void this.listPackages()}>List target</button>
-									<button class="ghost-btn" ?disabled=${this.runningCommand} @click=${() => void this.runDesktopNotificationSmokeTest()}>Test desktop notifications</button>
-									<button class="ghost-btn" ?disabled=${this.runningCommand} @click=${() => this.render()}>Refresh logs</button>
+									<div class="packages-section-meta">${installedCount}</div>
 								</div>
-								<pre class="tool-output packages-command-log">${this.commandOutput || "No package command run yet."}</pre>
-								<pre class="tool-output packages-command-log">${notifyDebugLines.length > 0 ? notifyDebugLines.join("\n") : "No notify trace lines yet."}</pre>
-							</details>
-						`
-						: nothing}
+								${installedLoading
+									? html`<div class="packages-empty">Loading installed items…</div>`
+									: installedRows.length === 0
+										? html`<div class="packages-empty">No packages installed yet.</div>`
+										: html`
+											<div class="packages-list packages-list-grid">
+												${installedRows}
+											</div>
+										`}
+							</section>
+
+							<section class="packages-section">
+								<div class="packages-section-head">
+									<div>
+										<div class="packages-section-title">${discoverTitle}</div>
+										<div class="packages-section-submeta">${discoverSubmeta}</div>
+									</div>
+									<div class="packages-section-meta">${discoverCount}</div>
+								</div>
+								${discoverLoading
+									? html`<div class="packages-empty">Loading results…</div>`
+									: discoverRows.length === 0
+										? html`<div class="packages-empty">${discoverEmptyMessage}</div>`
+										: html`
+											<div class="packages-list packages-list-grid">
+												${discoverRows}
+											</div>
+										`}
+							</section>
+
+							${hasDiagnostics
+								? html`
+									<details class="packages-diagnostics" ?open=${diagnosticsOpen}>
+										<summary>Diagnostics</summary>
+										<div class="packages-diagnostics-actions">
+											<button class="ghost-btn" ?disabled=${this.runningCommand} @click=${() => void this.updatePackages()}>Update target</button>
+											<button class="ghost-btn" ?disabled=${this.runningCommand} @click=${() => void this.listPackages()}>List target</button>
+											<button class="ghost-btn" ?disabled=${this.runningCommand || this.loadingResources} @click=${() => void this.refreshDiscoveredResources()}>Refresh skills</button>
+											<button class="ghost-btn" ?disabled=${this.runningCommand} @click=${() => void this.runDesktopNotificationSmokeTest()}>Test desktop notifications</button>
+											<button class="ghost-btn" ?disabled=${this.runningCommand} @click=${() => this.render()}>Refresh logs</button>
+										</div>
+										<pre class="tool-output packages-command-log">${this.commandOutput || "No package command run yet."}</pre>
+										<pre class="tool-output packages-command-log">${notifyDebugLines.length > 0 ? notifyDebugLines.join("\n") : "No notify trace lines yet."}</pre>
+									</details>
+								`
+								: nothing}
+						`}
 				</div>
 			</div>
-			${this.renderPackageConfigModal()}
+			${this.renderPackagesItemModal()}
+			${this.renderResourceCreatorModal()}
 		`;
 
 		render(template, this.container);
 	}
+
 }

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -34,7 +34,6 @@ interface Project {
 	name: string;
 	color: string;
 	emoji: string;
-	pinned: boolean;
 	expanded: boolean;
 	sessions: SidebarSession[];
 	loadingSessions: boolean;
@@ -50,7 +49,6 @@ interface PersistedProject {
 	name: string;
 	color: string;
 	emoji?: string;
-	pinned?: boolean;
 }
 
 interface FileNode {
@@ -75,6 +73,7 @@ type SidebarContextTarget =
 const LEGACY_STORAGE_KEY = "pi-desktop.projects.v1";
 const WORKSPACE_STORAGE_KEY_PREFIX = "pi-desktop.workspace-projects.v1";
 const SIDEBAR_COLLAPSED_KEY = "pi-desktop.sidebar.collapsed.v1";
+const SESSION_PINS_STORAGE_KEY_SUFFIX = ".session-pins.v1";
 const WORKSPACE_DRAG_THRESHOLD_PX = 5;
 const WORKSPACE_SWIPE_THRESHOLD_PX = 34;
 const WORKSPACE_SWIPE_IDLE_MS = 420;
@@ -241,6 +240,7 @@ export class Sidebar {
 	private contextMenu: { x: number; y: number; target: SidebarContextTarget } | null = null;
 	private transientSessionDraft: { projectId: string; path: string | null; name: string; createdAt: number } | null = null;
 	private suppressedSessionPaths = new Set<string>();
+	private pinnedSessionPaths = new Set<string>();
 
 	private onOpenSettings: (() => void) | null = null;
 	private onTogglePackages: (() => void) | null = null;
@@ -267,6 +267,7 @@ export class Sidebar {
 		this.container = container;
 		this.loadSidebarState();
 		this.loadPersistedProjects();
+		this.loadPinnedSessions();
 		this.render();
 		this.workspaceHydrationToken += 1;
 		void this.hydrateProjects(this.workspaceHydrationToken);
@@ -323,10 +324,12 @@ export class Sidebar {
 		this.closeProjectEmojiPicker(false);
 		this.transientSessionDraft = null;
 		this.suppressedSessionPaths.clear();
+		this.pinnedSessionPaths.clear();
 		this.clearInlineDrafts();
 		this.closeContextMenu(false);
 
 		this.loadPersistedProjects();
+		this.loadPinnedSessions();
 		this.render();
 		void this.hydrateProjects(hydrationToken);
 	}
@@ -521,7 +524,7 @@ export class Sidebar {
 		e.preventDefault();
 		e.stopPropagation();
 		const menuWidth = 170;
-		const menuHeight = target.kind === "workspace" ? 92 : target.kind === "session" ? 164 : 92;
+		const menuHeight = target.kind === "workspace" ? 92 : target.kind === "session" ? 194 : 92;
 		const padding = 8;
 		const x = Math.max(padding, Math.min(e.clientX, window.innerWidth - menuWidth - padding));
 		const y = Math.max(padding, Math.min(e.clientY, window.innerHeight - menuHeight - padding));
@@ -850,7 +853,6 @@ export class Sidebar {
 				name,
 				color: stringToColor(name),
 				emoji: normalizeProjectEmoji(null),
-				pinned: false,
 				expanded: true,
 				sessions: [],
 				loadingSessions: false,
@@ -1000,6 +1002,7 @@ export class Sidebar {
 				await remove(session.path);
 			}
 			project.sessions = project.sessions.filter((entry) => normalizePath(entry.path) !== normalizePath(session.path));
+			this.clearSessionPin(session.path);
 			if (this.activeSessionPath === normalizePath(session.path)) {
 				this.activeSessionPath = null;
 			}
@@ -1071,7 +1074,7 @@ export class Sidebar {
 		this.openContextMenu(e, { kind: "workspace", workspaceId });
 	}
 
-	private runSessionContextAction(action: "rename" | "delete" | "fork" | "markUnread"): void {
+	private runSessionContextAction(action: "rename" | "delete" | "fork" | "markUnread" | "togglePin"): void {
 		const target = this.contextMenu?.target;
 		if (!target || target.kind !== "session") return;
 		this.closeContextMenu(false);
@@ -1090,6 +1093,11 @@ export class Sidebar {
 		}
 		if (action === "markUnread") {
 			this.onSessionMarkUnread?.(found.project.id, found.session.path, found.session.name);
+			return;
+		}
+		if (action === "togglePin") {
+			this.toggleSessionPinned(found.session.path);
+			this.render();
 			return;
 		}
 		void this.deleteSession(found.project, found.session);
@@ -1141,10 +1149,13 @@ export class Sidebar {
 		const target = menu.target;
 		let menuContent: TemplateResult;
 		if (target.kind === "session") {
+			const canPinSession = normalizePath(target.sessionPath).length > 0;
+			const pinned = canPinSession && this.isSessionPinned(target.sessionPath);
 			menuContent = html`
 				<div class="sidebar-context-menu" style=${`left:${menu.x}px;top:${menu.y}px`} @click=${(e: Event) => e.stopPropagation()}>
 					<button @click=${() => this.runSessionContextAction("fork")}>Fork from message…</button>
 					<button @click=${() => this.runSessionContextAction("markUnread")}>Mark unread</button>
+					<button ?disabled=${!canPinSession} @click=${() => this.runSessionContextAction("togglePin")}>${pinned ? "Unpin session" : "Pin session"}</button>
 					<div class="sidebar-context-menu-divider"></div>
 					<button @click=${() => this.runSessionContextAction("rename")}>Rename session</button>
 					<button class="danger" @click=${() => this.runSessionContextAction("delete")}>Delete session</button>
@@ -1694,27 +1705,6 @@ export class Sidebar {
 		this.render();
 	}
 
-	private toggleProjectPinned(projectId: string): void {
-		const index = this.projects.findIndex((entry) => entry.id === projectId);
-		if (index === -1) return;
-		const project = this.projects[index];
-		const nextPinned = !project.pinned;
-		this.projects.splice(index, 1);
-		project.pinned = nextPinned;
-		if (nextPinned) {
-			const pinnedCount = this.projects.filter((entry) => entry.pinned).length;
-			this.projects.splice(pinnedCount, 0, project);
-		} else {
-			const pinnedCount = this.projects.filter((entry) => entry.pinned).length;
-			this.projects.splice(pinnedCount, 0, project);
-		}
-		this.sortProjectsInPlace();
-		this.cancelProjectPointerDrag(false);
-		this.openProjectMenuId = null;
-		this.persistProjects();
-		this.render();
-	}
-
 	private renameProject(projectId: string): void {
 		const project = this.projects.find((p) => p.id === projectId);
 		if (!project) return;
@@ -1776,9 +1766,72 @@ export class Sidebar {
 			name: p.name,
 			color: p.color,
 			emoji: normalizeProjectEmoji(p.emoji),
-			pinned: p.pinned,
 		}));
 		localStorage.setItem(this.storageKey, JSON.stringify(data));
+	}
+
+	private sessionPinsStorageKey(): string {
+		return `${this.storageKey}${SESSION_PINS_STORAGE_KEY_SUFFIX}`;
+	}
+
+	private loadPinnedSessions(): void {
+		try {
+			const raw = localStorage.getItem(this.sessionPinsStorageKey());
+			if (!raw) {
+				this.pinnedSessionPaths.clear();
+				return;
+			}
+			const parsed = JSON.parse(raw);
+			if (!Array.isArray(parsed)) {
+				this.pinnedSessionPaths.clear();
+				return;
+			}
+			const next = parsed
+				.filter((entry): entry is string => typeof entry === "string")
+				.map((entry) => normalizePath(entry))
+				.filter((entry) => entry.length > 0);
+			this.pinnedSessionPaths = new Set(next);
+		} catch {
+			this.pinnedSessionPaths.clear();
+		}
+	}
+
+	private persistPinnedSessions(): void {
+		try {
+			if (this.pinnedSessionPaths.size === 0) {
+				localStorage.removeItem(this.sessionPinsStorageKey());
+				return;
+			}
+			localStorage.setItem(this.sessionPinsStorageKey(), JSON.stringify([...this.pinnedSessionPaths]));
+		} catch {
+			// ignore
+		}
+	}
+
+	private isSessionPinned(sessionPath: string): boolean {
+		const normalized = normalizePath(sessionPath);
+		if (!normalized) return false;
+		return this.pinnedSessionPaths.has(normalized);
+	}
+
+	private toggleSessionPinned(sessionPath: string): boolean {
+		const normalized = normalizePath(sessionPath);
+		if (!normalized) return false;
+		const nextPinned = !this.pinnedSessionPaths.has(normalized);
+		if (nextPinned) {
+			this.pinnedSessionPaths.add(normalized);
+		} else {
+			this.pinnedSessionPaths.delete(normalized);
+		}
+		this.persistPinnedSessions();
+		return nextPinned;
+	}
+
+	private clearSessionPin(sessionPath: string): void {
+		const normalized = normalizePath(sessionPath);
+		if (!normalized) return;
+		if (!this.pinnedSessionPaths.delete(normalized)) return;
+		this.persistPinnedSessions();
 	}
 
 	private loadPersistedProjects(): void {
@@ -1816,7 +1869,6 @@ export class Sidebar {
 					name: p.name,
 					color: typeof p.color === "string" && p.color.trim().length > 0 ? p.color : stringToColor(p.name || pathBaseName(p.path)),
 					emoji: normalizeProjectEmoji(p.emoji),
-					pinned: Boolean(p.pinned),
 					expanded: idx === 0,
 					sessions: [],
 					loadingSessions: false,
@@ -1834,14 +1886,8 @@ export class Sidebar {
 		}
 	}
 
-	private normalizeProjectGrouping(): void {
-		const pinned = this.projects.filter((project) => project.pinned);
-		const unpinned = this.projects.filter((project) => !project.pinned);
-		this.projects = [...pinned, ...unpinned];
-	}
-
 	private sortProjectsInPlace(): void {
-		this.normalizeProjectGrouping();
+		// Keep explicit drag order; no project pin groups.
 	}
 
 	private filteredProjects(includeQuery = true): Project[] {
@@ -1861,6 +1907,8 @@ export class Sidebar {
 	private sortedSessions(sessions: SidebarSession[]): SidebarSession[] {
 		const sorted = [...sessions];
 		sorted.sort((a, b) => {
+			const pinDelta = Number(this.isSessionPinned(b.path)) - Number(this.isSessionPinned(a.path));
+			if (pinDelta !== 0) return pinDelta;
 			const aTs = this.sessionSortBy === "created" ? a.createdAt || a.modifiedAt : a.modifiedAt || a.createdAt;
 			const bTs = this.sessionSortBy === "created" ? b.createdAt || b.modifiedAt : b.modifiedAt || b.createdAt;
 			return bTs - aTs || a.name.localeCompare(b.name);
@@ -1899,8 +1947,10 @@ export class Sidebar {
 		if (this.sessionShow === "all" || q) return sessions;
 
 		const cutoff = Date.now() - 1000 * 60 * 60 * 24 * 14;
+		const pinned = sessions.filter((session) => this.isSessionPinned(session.path));
 		const recent = sessions.filter((session) => session.transient || (session.modifiedAt || session.createdAt || 0) >= cutoff);
-		if (recent.length > 0) return recent;
+		const merged = [...pinned, ...recent.filter((session) => !this.isSessionPinned(session.path))];
+		if (merged.length > 0) return merged;
 		return sessions.slice(0, 5);
 	}
 
@@ -1912,6 +1962,8 @@ export class Sidebar {
 			}
 		}
 		list.sort((a, b) => {
+			const pinDelta = Number(this.isSessionPinned(b.session.path)) - Number(this.isSessionPinned(a.session.path));
+			if (pinDelta !== 0) return pinDelta;
 			const aTs = this.sessionSortBy === "created"
 				? a.session.createdAt || a.session.modifiedAt
 				: a.session.modifiedAt || a.session.createdAt;
@@ -2155,8 +2207,7 @@ export class Sidebar {
 	private isCompatibleProjectDropTarget(draggedProjectId: string, targetProjectId: string): boolean {
 		const dragged = this.projects.find((project) => project.id === draggedProjectId) ?? null;
 		const target = this.projects.find((project) => project.id === targetProjectId) ?? null;
-		if (!dragged || !target) return false;
-		return Boolean(dragged.pinned) === Boolean(target.pinned);
+		return Boolean(dragged && target);
 	}
 
 	private resolveProjectIdFromPoint(clientX: number, clientY: number, draggedProjectId: string): string | null {
@@ -3202,7 +3253,6 @@ export class Sidebar {
 		return html`
 			<div class="sidebar-project-menu" @click=${(e: Event) => e.stopPropagation()}>
 				<button @click=${() => this.renameProject(project.id)}>Rename project</button>
-				<button @click=${() => this.toggleProjectPinned(project.id)}>${project.pinned ? "Unpin project" : "Pin project"}</button>
 				<button @click=${(event: MouseEvent) => this.openProjectEmojiPicker(project.id, event)}>Change emoji</button>
 				<div class="sidebar-project-menu-divider"></div>
 				<button @click=${() => this.removeProject(project.id)}>Remove project</button>
@@ -3229,9 +3279,10 @@ export class Sidebar {
 						: Boolean(session.transient && this.activeProjectId === project.id && !this.activeSessionPath);
 					const runningSession = this.runningSessionPaths.has(normalizedSessionPath);
 					const attentionMessage = this.attentionSessionMessages.get(normalizedSessionPath) ?? null;
+					const pinnedSession = this.isSessionPinned(session.path);
 					return html`
 						<button
-							class="sidebar-chrono-row ${activeSession ? "active-session" : ""}"
+							class="sidebar-chrono-row ${activeSession ? "active-session" : ""} ${pinnedSession ? "pinned" : ""}"
 							@click=${() => {
 								if (session.transient && !session.path) return;
 								this.selectProject(project.id, false);
@@ -3247,6 +3298,7 @@ export class Sidebar {
 							<span class="sidebar-session-leading">
 								${this.renderSessionPiIcon(runningSession)}
 							</span>
+							${pinnedSession ? html`<span class="sidebar-session-pin" title="Pinned session">📌</span>` : nothing}
 							<span class="sidebar-chrono-main">
 								<span class="sidebar-chrono-name sidebar-session-name ${attentionMessage ? "needs-attention" : ""}">${session.name}</span>
 								<span class="sidebar-chrono-project">${project.name}</span>
@@ -3280,11 +3332,8 @@ export class Sidebar {
 					const unreadCount = this.getProjectAttentionCount(project);
 					const showBlockingSessionLoad = project.loadingSessions && sessions.length === 0;
 					const showInlineSessionRefresh = project.loadingSessions && sessions.length > 0;
-					const previousProject = projects[index - 1] ?? null;
-					const showPinnedDivider = Boolean(previousProject?.pinned) && !Boolean(project.pinned);
 					const dragOver = project.id === this.projectDragOverId && this.draggingProjectId !== project.id;
 					return html`
-						${showPinnedDivider ? html`<div class="sidebar-project-pin-divider" role="separator" aria-hidden="true"></div>` : nothing}
 						<div class="sidebar-project-row ${active ? "active" : ""} ${menuOpen ? "menu-open" : ""} ${dragOver ? "drag-over" : ""} ${project.id === this.draggingProjectId ? "dragging" : ""}" data-project-id=${project.id}>
 							<div class="sidebar-project-head">
 								<div class="sidebar-project-main-wrap">
@@ -3366,15 +3415,17 @@ export class Sidebar {
                                                             : Boolean(session.transient && this.activeProjectId === project.id && !this.activeSessionPath);
                                                         const runningSession = this.runningSessionPaths.has(normalizedSessionPath);
                                                         const attentionMessage = this.attentionSessionMessages.get(normalizedSessionPath) ?? null;
+                                                        const pinnedSession = this.isSessionPinned(session.path);
                                                         const sessionRenameActive =
                                                             Boolean(this.sessionRenameDraft) &&
                                                             this.sessionRenameDraft?.projectId === project.id &&
                                                             this.sessionRenameDraft?.sessionPath === normalizePath(session.path);
                                                         return html`
-                                                            <div class="sidebar-session-row ${activeSession ? "active" : ""}">
+                                                            <div class="sidebar-session-row ${activeSession ? "active" : ""} ${pinnedSession ? "pinned" : ""}">
                                                                 <span class="sidebar-session-leading">
                                                                     ${this.renderSessionPiIcon(runningSession)}
                                                                 </span>
+                                                                ${pinnedSession ? html`<span class="sidebar-session-pin" title="Pinned session">📌</span>` : nothing}
                                                                 <button
                                                                     class="sidebar-session ${activeSession ? "active-session" : ""}"
                                                                     @click=${() => {
@@ -3454,12 +3505,9 @@ export class Sidebar {
 					const nodes = this.fileTrees.get(project.id) ?? [];
 					const fileTreeError = this.fileTreeErrors.get(project.id) ?? null;
 					const hasMatchingNode = nodes.some((node) => this.nodeMatchesQuery(node, query));
-					const previousProject = projects[index - 1] ?? null;
-					const showPinnedDivider = Boolean(previousProject?.pinned) && !Boolean(project.pinned);
 					const dragOver = project.id === this.projectDragOverId && this.draggingProjectId !== project.id;
 
 					return html`
-						${showPinnedDivider ? html`<div class="sidebar-project-pin-divider" role="separator" aria-hidden="true"></div>` : nothing}
 						<div class="sidebar-project-row ${active ? "active" : ""} ${menuOpen ? "menu-open" : ""} ${dragOver ? "drag-over" : ""} ${project.id === this.draggingProjectId ? "dragging" : ""}" data-project-id=${project.id}>
 							<div class="sidebar-project-head">
 								<div class="sidebar-project-main-wrap">

--- a/src/main.ts
+++ b/src/main.ts
@@ -192,15 +192,6 @@ function isCliMissingError(message: string | null | undefined): boolean {
 	if (text.includes("'pi' is not recognized as an internal or external command")) {
 		return true;
 	}
-	if (text.includes("failed to spawn pi process")) {
-		return text.includes("no such file") ||
-			text.includes("not found") ||
-			text.includes("cannot find the file specified") ||
-			text.includes("the system cannot find the file specified") ||
-			text.includes("os error 2") ||
-			text.includes("createprocess") ||
-			text.includes("enoent");
-	}
 	return text.includes("enoent") && text.includes("pi");
 }
 
@@ -2167,6 +2158,14 @@ async function initialize(): Promise<void> {
 	try {
 		connectionError = null;
 		renderApp();
+		// Ensure creatorskill exists on first run (copied from packaged assets if available)
+		await packagesView?.ensureCreatorSkillInstalled();
+		// Refresh discovered resources so Packages view shows the new skill immediately
+		try {
+			await packagesView?.refreshPackages(true);
+		} catch {
+			// ignore
+		}
 
 		const chatContainer = document.getElementById("chat-container");
 		if (!chatContainer) throw new Error("Chat container missing");
@@ -3020,6 +3019,16 @@ function renderApp(): void {
 			persistWorkspaces();
 			syncWorkspaceTabsBar();
 			void applyWorkspacePane(workspace);
+		});
+		packagesView.setOnInsertPromptTemplate(async (commandText) => {
+			const workspace = getActiveWorkspace();
+			if (!workspace) return;
+			workspace.pane = "chat";
+			persistWorkspaces();
+			syncWorkspaceTabsBar();
+			await applyWorkspacePane(workspace);
+			chatView?.stageComposerCommand(commandText);
+			clearVisibleActiveSessionAttention();
 		});
 	}
 

--- a/src/recommended-skills.ts
+++ b/src/recommended-skills.ts
@@ -1,0 +1,54 @@
+export interface RecommendedSkillDefinition {
+	id: string;
+	name: string;
+	skillName: string;
+	description: string;
+	packageSource: string;
+	sourceKind: "npm" | "git" | "url" | "local";
+	publisher: "first-party" | "community";
+	openUrl?: string;
+	setupHint?: string;
+}
+
+export const RECOMMENDED_SKILLS: RecommendedSkillDefinition[] = [
+	{
+		id: "creatorskill",
+		name: "Creator Skill",
+		skillName: "creatorskill",
+		description: "Create or update prompt templates and Agent skills from a short user brief. Stages commands in chat; nothing runs automatically.",
+		packageSource: "local:creatorskill",
+		sourceKind: "local",
+		publisher: "first-party",
+	},
+	{
+		id: "brave-search",
+		name: "Brave Search",
+		skillName: "brave-search",
+		description: "Web search and content extraction via Brave Search API.",
+		packageSource: "npm:pi-skills",
+		sourceKind: "npm",
+		publisher: "first-party",
+		openUrl: "https://github.com/badlogic/pi-skills/tree/main/skills/brave-search",
+		setupHint: "Requires a Brave Search API key.",
+	},
+	{
+		id: "browser-tools",
+		name: "Browser Tools",
+		skillName: "browser-tools",
+		description: "Interactive browser automation via Chrome DevTools Protocol.",
+		packageSource: "npm:pi-skills",
+		sourceKind: "npm",
+		publisher: "first-party",
+		openUrl: "https://github.com/badlogic/pi-skills/tree/main/skills/browser-tools",
+	},
+	{
+		id: "youtube-transcript",
+		name: "YouTube Transcript",
+		skillName: "youtube-transcript",
+		description: "Fetch transcripts from YouTube videos for summarization and analysis.",
+		packageSource: "npm:pi-skills",
+		sourceKind: "npm",
+		publisher: "first-party",
+		openUrl: "https://github.com/badlogic/pi-skills/tree/main/skills/youtube-transcript",
+	},
+];

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1590,34 +1590,39 @@ body.sidebar-resizing {
 	flex: 1;
 	min-height: 0;
 	overflow: auto;
-	padding: 18px;
+	padding: 22px 22px 18px;
 	display: grid;
-	gap: 12px;
+	gap: 16px;
 	align-content: start;
-	width: min(1120px, 100%);
+	width: min(1180px, 100%);
 	margin: 0 auto;
 }
 
 .packages-view-body.minimal {
-	gap: 12px;
+	gap: 16px;
 }
 
 .packages-inline-icon {
-	width: 14px;
-	height: 14px;
+	width: 20px;
+	height: 20px;
 	display: grid;
 	place-items: center;
 	color: var(--muted-2);
 }
 
 .packages-inline-icon svg {
-	width: 13px;
-	height: 13px;
+	width: 19px;
+	height: 19px;
 	fill: none;
 	stroke: currentColor;
-	stroke-width: 1.25;
+	stroke-width: 1.55;
 	stroke-linecap: round;
 	stroke-linejoin: round;
+}
+
+.packages-inline-icon svg.filled {
+	fill: currentColor;
+	stroke: none;
 }
 
 .packages-banner {
@@ -1640,12 +1645,12 @@ body.sidebar-resizing {
 }
 
 .packages-section {
-	padding: 12px;
-	border-radius: 14px;
-	background: color-mix(in srgb, var(--bg-elev) 38%, transparent);
-	border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+	padding: 10px 2px 2px;
+	border-radius: 0;
+	background: transparent;
+	border: none;
 	display: grid;
-	gap: 10px;
+	gap: 12px;
 }
 
 .packages-top-strip {
@@ -1697,70 +1702,95 @@ body.sidebar-resizing {
 	display: flex;
 	align-items: flex-start;
 	justify-content: space-between;
-	gap: 10px;
+	gap: 12px;
+}
+
+.packages-section-head-actions {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+	justify-content: flex-end;
 }
 
 .packages-section-title {
-	font-size: 13px;
-	font-weight: 600;
+	font-size: 14px;
+	font-weight: 620;
 	color: var(--text);
 }
 
 .packages-section-meta {
-	font-size: 11px;
+	font-size: 12px;
 	color: var(--muted);
 	flex-shrink: 0;
 }
 
 .packages-section-submeta {
-	font-size: 10px;
+	font-size: 11px;
 	color: var(--muted-2);
 	margin-top: 2px;
-	line-height: 1.45;
+	line-height: 1.48;
+}
+
+.packages-section-desc {
+	font-size: 13px;
+	color: var(--muted);
+	line-height: 1.5;
+	display: -webkit-box;
+	-webkit-line-clamp: 4;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	margin-bottom: 2px;
 }
 
 .packages-list {
 	display: grid;
-	gap: 8px;
+	gap: 12px;
 }
 
 .packages-list-grid {
 	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: 8px;
+	gap: 14px;
 }
 
 .packages-list-row {
 	display: grid;
 	grid-template-columns: auto minmax(0, 1fr) auto;
-	gap: 10px;
+	gap: 12px;
 	align-items: center;
-	padding: 10px;
+	padding: 11px 8px;
 	min-width: 0;
-	border-radius: 12px;
-	background: color-mix(in srgb, var(--bg-soft) 42%, transparent);
-	border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+	border-bottom: none;
+	background: transparent;
+	border-radius: 0;
+}
+
+.packages-list-row:hover {
+	background: transparent;
 }
 
 .packages-list-row-icon {
-	width: 34px;
-	height: 34px;
-	border-radius: 10px;
-	background: color-mix(in srgb, var(--bg) 55%, var(--bg-soft));
-	border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+	width: 36px;
+	height: 36px;
+	border-radius: 0;
+	background: transparent;
 	display: grid;
 	place-items: center;
 	flex-shrink: 0;
+	color: var(--muted);
+	margin-top: 0;
 }
 
-.packages-list-row-icon.extension {
-	background: color-mix(in srgb, var(--accent) 10%, var(--bg-soft));
-	border-color: color-mix(in srgb, var(--accent) 16%, var(--border));
+.packages-list-row-icon.extension,
+.packages-list-row-icon.skill {
+	color: var(--accent);
 }
 
 .packages-list-row-main {
 	min-width: 0;
 	display: grid;
-	gap: 3px;
+	gap: 4px;
 }
 
 .packages-list-row-top {
@@ -1772,13 +1802,29 @@ body.sidebar-resizing {
 }
 
 .packages-list-row-title {
-	font-size: 13px;
-	font-weight: 590;
+	font-size: 14px;
+	font-weight: 600;
 	color: var(--text);
 	min-width: 0;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+}
+
+.packages-list-row-title-link {
+	border: none;
+	padding: 0;
+	background: transparent;
+	cursor: pointer;
+	text-align: left;
+	transition: color 120ms ease;
+}
+
+.packages-list-row-title-link:hover,
+.packages-list-row-title-link:focus-visible {
+	color: var(--accent);
+	text-decoration: underline;
+	outline: none;
 }
 
 .packages-list-row-badges {
@@ -1789,8 +1835,9 @@ body.sidebar-resizing {
 }
 
 .packages-list-row-sub {
-	font-size: 11px;
+	font-size: 12px;
 	color: var(--muted);
+	line-height: 1.4;
 	min-width: 0;
 	white-space: nowrap;
 	overflow: hidden;
@@ -1798,9 +1845,13 @@ body.sidebar-resizing {
 }
 
 .packages-list-row-note {
-	font-size: 10px;
+	font-size: 11px;
 	color: var(--muted-2);
-	line-height: 1.45;
+	line-height: 1.4;
+	min-width: 0;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .packages-list-row-actions {
@@ -1809,17 +1860,19 @@ body.sidebar-resizing {
 	gap: 6px;
 	flex-wrap: nowrap;
 	justify-content: flex-end;
+	margin-top: 0;
 }
 
 .packages-card-scope {
 	display: inline-flex;
 	height: 18px;
-	padding: 0 6px;
+	padding: 0 7px;
 	align-items: center;
 	border-radius: 999px;
-	font-size: 9px;
-	text-transform: uppercase;
-	letter-spacing: 0.05em;
+	font-size: 10px;
+	font-weight: 520;
+	text-transform: none;
+	letter-spacing: 0.01em;
 	color: var(--muted);
 	background: color-mix(in srgb, var(--bg) 36%, var(--bg-soft));
 	flex-shrink: 0;
@@ -1830,9 +1883,89 @@ body.sidebar-resizing {
 	background: color-mix(in srgb, var(--accent) 14%, transparent);
 }
 
+.packages-card-scope.recommended {
+	color: var(--accent);
+	background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
 .packages-card-scope.global-installed {
 	color: var(--success);
 	background: color-mix(in srgb, var(--success) 12%, transparent);
+}
+
+.packages-skill-content {
+	margin-top: 8px;
+	border-radius: 0;
+	border: none;
+	background: transparent;
+	padding: 0;
+	max-height: 420px;
+	overflow: auto;
+}
+
+.packages-skill-doc {
+	display: grid;
+	gap: 12px;
+}
+
+.packages-skill-doc-title {
+	font-size: 15px;
+	font-weight: 620;
+	line-height: 1.35;
+	color: var(--text);
+}
+
+.packages-skill-doc-summary {
+	font-size: 13px;
+	line-height: 1.52;
+	color: var(--text);
+	padding: 0;
+	border-radius: 0;
+	background: transparent;
+	border: none;
+}
+
+.packages-skill-doc-section {
+	display: grid;
+	gap: 8px;
+	padding-bottom: 2px;
+}
+
+.packages-skill-doc-section h4 {
+	margin: 0;
+	font-size: 14px;
+	line-height: 1.3;
+	color: var(--text);
+	font-weight: 620;
+}
+
+.packages-skill-doc-section p {
+	margin: 0;
+	font-size: 13px;
+	line-height: 1.56;
+	color: var(--muted);
+}
+
+.packages-list-group {
+	margin-bottom: 10px;
+	border-radius: 8px;
+	overflow: hidden;
+}
+
+.packages-list-group-head {
+	padding: 8px 10px;
+	background: color-mix(in srgb, var(--bg-soft) 60%, transparent);
+	border-bottom: none;
+}
+
+.packages-list-group-title {
+	font-weight: 600;
+	color: var(--text);
+}
+
+.packages-card-scope.skill {
+	color: var(--accent);
+	background: color-mix(in srgb, var(--accent) 12%, transparent);
 }
 
 .packages-card-action {
@@ -1879,15 +2012,15 @@ body.sidebar-resizing {
 }
 
 .packages-row-install {
-	width: 28px;
-	height: 28px;
+	width: 36px;
+	height: 36px;
 	border-radius: 999px;
-	border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
-	background: color-mix(in srgb, var(--bg-soft) 64%, transparent);
+	border: 1px solid color-mix(in srgb, var(--border) 66%, transparent);
+	background: color-mix(in srgb, var(--bg-soft) 54%, transparent);
 	color: var(--text);
 	display: grid;
 	place-items: center;
-	font-size: 16px;
+	font-size: 17px;
 	line-height: 1;
 	cursor: pointer;
 	padding: 0;
@@ -1899,6 +2032,17 @@ body.sidebar-resizing {
 
 .packages-row-install.add {
 	color: var(--text);
+}
+
+.packages-row-install.installed {
+	color: var(--success);
+	border-color: color-mix(in srgb, var(--success) 34%, var(--border));
+	background: color-mix(in srgb, var(--success) 10%, transparent);
+	font-size: 16px;
+}
+
+.packages-row-install.installed:hover {
+	background: color-mix(in srgb, var(--success) 14%, transparent);
 }
 
 .packages-row-install.remove {
@@ -1927,98 +2071,176 @@ body.sidebar-resizing {
 	color: var(--muted);
 }
 
-.packages-config-modal {
-	width: min(860px, calc(100vw - 40px));
+.packages-empty.error {
+	color: var(--danger);
 }
 
-.packages-config-modal .overlay-header {
-	align-items: flex-start;
-	gap: 10px;
-	padding-top: 12px;
-	padding-bottom: 12px;
-}
-
-.packages-config-modal-title {
+.packages-loading-state {
+	padding: 16px 0;
 	font-size: 13px;
-	font-weight: 600;
-	color: var(--text);
-}
-
-.packages-config-modal-sub {
-	margin-top: 2px;
-	font-size: 11px;
 	color: var(--muted);
 }
 
-.packages-config-modal-body {
-	padding: 14px 16px 16px;
-	display: grid;
+.packages-config-modal {
+	width: min(960px, calc(100vw - 40px));
+}
+
+.overlay-card.packages-config-modal {
+	border: none;
+	box-shadow: 0 20px 48px rgba(0, 0, 0, 0.36);
+}
+
+.packages-item-modal {
+	width: min(1040px, calc(100vw - 40px));
+}
+
+.ghost-btn.danger {
+	color: var(--danger);
+}
+
+.packages-config-modal .overlay-header {
+	height: auto;
+	min-height: 58px;
+	align-items: flex-start;
 	gap: 12px;
+	padding: 14px 20px 8px;
+	border-bottom: none;
+}
+
+.packages-config-modal-title {
+	font-size: 15px;
+	font-weight: 620;
+	color: var(--text);
+	line-height: 1.32;
+}
+
+.packages-config-modal-sub {
+	margin-top: 4px;
+	font-size: 12px;
+	color: var(--muted);
+	line-height: 1.45;
+}
+
+.packages-config-modal-body {
+	padding: 8px 20px 20px;
+	display: grid;
+	gap: 14px;
 }
 
 .packages-config-command-card {
 	display: grid;
-	gap: 8px;
-	padding: 10px;
-	border-radius: 12px;
-	border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
-	background: color-mix(in srgb, var(--bg-soft) 48%, transparent);
+	gap: 9px;
+	padding: 4px 0;
+	border: none;
+	background: transparent;
+	border-radius: 0;
 }
 
 .packages-config-command-name {
-	font-size: 12px;
-	font-weight: 600;
+	font-size: 13px;
+	font-weight: 610;
 	color: var(--text);
 }
 
 .packages-config-command-desc {
-	font-size: 11px;
+	font-size: 12px;
 	color: var(--muted);
 	line-height: 1.45;
 }
 
 .packages-config-field {
 	display: grid;
-	gap: 6px;
+	gap: 7px;
 }
 
 .packages-config-field-label {
-	font-size: 11px;
+	font-size: 12px;
 	color: var(--muted);
+}
+
+.packages-config-field-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 12px;
+}
+
+.packages-config-select,
+.packages-config-input,
+.packages-config-textarea {
+	border-radius: 10px;
+	border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
+	background: var(--bg-muted);
+	color: var(--text);
+	font-size: 13px;
 }
 
 .packages-config-select,
 .packages-config-input {
-	height: 34px;
-	border-radius: 10px;
-	border: 1px solid var(--border);
-	background: var(--bg-muted);
-	color: var(--text);
-	font-size: 12px;
+	height: 36px;
 }
 
 .packages-config-select {
-	padding: 0 8px;
-}
-
-.packages-config-input {
 	padding: 0 10px;
 }
 
+.packages-config-input {
+	padding: 0 11px;
+}
+
+.packages-config-textarea {
+	min-height: 240px;
+	resize: vertical;
+	padding: 12px;
+	font-family: var(--font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+	line-height: 1.55;
+}
+
 .packages-config-select:disabled,
-.packages-config-input:disabled {
+.packages-config-input:disabled,
+.packages-config-textarea:disabled {
 	opacity: 0.78;
 }
 
 .packages-config-command-actions,
 .packages-config-modal-actions {
 	display: flex;
-	gap: 8px;
+	gap: 10px;
 	flex-wrap: wrap;
 }
 
 .packages-config-modal-actions {
-	margin-top: 2px;
+	margin-top: 6px;
+}
+
+.packages-item-meta-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+	gap: 10px;
+}
+
+.packages-item-meta-row {
+	display: grid;
+	gap: 4px;
+	padding: 2px 0;
+	border: none;
+	border-radius: 0;
+	background: transparent;
+}
+
+.packages-item-meta-label {
+	font-size: 11px;
+	color: var(--muted-2);
+	text-transform: uppercase;
+	letter-spacing: 0.02em;
+}
+
+.packages-item-meta-value {
+	font-size: 12px;
+	line-height: 1.42;
+	color: var(--text);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .packages-config-inline-error {
@@ -2077,8 +2299,14 @@ body.sidebar-resizing {
 
 	.packages-list-row-actions,
 	.packages-list-row-badges,
-	.packages-view-header-actions {
+	.packages-view-header-actions,
+	.packages-section-head-actions {
 		justify-content: flex-start;
+	}
+
+	.packages-config-field-grid,
+	.packages-item-meta-grid {
+		grid-template-columns: 1fr;
 	}
 }
 
@@ -3441,6 +3669,11 @@ body.sidebar-resizing {
 	min-width: 0;
 }
 
+.sidebar-session-row.pinned .sidebar-session-name,
+.sidebar-chrono-row.pinned .sidebar-chrono-name {
+	color: var(--text);
+}
+
 .sidebar-session {
 	width: auto;
 	flex: 1;
@@ -3526,6 +3759,14 @@ body.sidebar-resizing {
 	align-items: center;
 	justify-content: center;
 	margin-left: -16px;
+}
+
+.sidebar-session-pin {
+	font-size: 10px;
+	line-height: 1;
+	color: color-mix(in srgb, var(--accent) 70%, var(--text));
+	opacity: 0.9;
+	flex-shrink: 0;
 }
 
 .sidebar-session-pi {
@@ -4960,6 +5201,122 @@ body.sidebar-resizing {
 	gap: 3px;
 	box-shadow: 0 10px 22px rgba(0, 0, 0, 0.28);
 	pointer-events: none;
+}
+
+.composer-skill-draft-row {
+	display: flex;
+	align-items: center;
+	padding: 0 2px 6px;
+}
+
+.composer-skill-draft-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 6px;
+	max-width: 100%;
+	padding: 4px 9px;
+	border-radius: 999px;
+	border: 1px solid color-mix(in srgb, var(--accent) 36%, transparent);
+	background: color-mix(in srgb, var(--accent) 14%, transparent);
+	color: var(--accent);
+	font-size: 11px;
+	line-height: 1;
+}
+
+.composer-skill-draft-label {
+	opacity: 0.9;
+	font-weight: 550;
+}
+
+.composer-skill-draft-name {
+	color: var(--text);
+	font-weight: 600;
+	max-width: 220px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.composer-skill-draft-scope {
+	color: var(--muted);
+	font-size: 10px;
+	padding-left: 2px;
+}
+
+.composer-skill-draft-remove {
+	width: 16px;
+	height: 16px;
+	border: none;
+	border-radius: 999px;
+	background: transparent;
+	color: var(--muted);
+	cursor: pointer;
+	display: inline-grid;
+	place-items: center;
+	line-height: 1;
+	padding: 0;
+}
+
+.composer-skill-draft-remove:hover {
+	color: var(--text);
+	background: color-mix(in srgb, var(--bg-soft) 70%, transparent);
+}
+
+.composer-slash-menu {
+	margin: 0 2px 6px;
+	border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+	border-radius: 10px;
+	background: color-mix(in srgb, var(--bg-elev) 95%, var(--bg));
+	display: grid;
+	gap: 1px;
+	max-height: 270px;
+	overflow-y: auto;
+}
+
+.composer-slash-section {
+	font-size: 10px;
+	color: var(--muted-2);
+	padding: 6px 9px 4px;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+
+.composer-slash-item {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	width: 100%;
+	border: none;
+	background: transparent;
+	color: var(--text);
+	padding: 7px 9px;
+	font-size: 12px;
+	text-align: left;
+	cursor: pointer;
+}
+
+.composer-slash-item:hover,
+.composer-slash-item.active {
+	background: color-mix(in srgb, var(--bg-soft) 72%, transparent);
+}
+
+.composer-slash-item-label {
+	font-weight: 560;
+}
+
+.composer-slash-item-hint {
+	font-size: 10px;
+	color: var(--muted-2);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.composer-slash-empty {
+	padding: 9px;
+	font-size: 11px;
+	color: var(--muted);
 }
 
 .composer-attachments {


### PR DESCRIPTION
## Summary
This PR finalizes the Packages-page work for the related resources/settings issues, with a focus on creatorskill-first defaults, minimal UI polish, and robust package config hydration/persistence.

### What was implemented
- creatorskill-first startup policy
  - bundle creatorskill asset and ensure first native-run install
  - keep creatorskill uninstallable
  - no forced auto-install of other packages
- Packages UI/UX cleanup
  - unified installed list (skills + extensions), recommendation improvements
  - reduced visual noise in list rows and modals
  - icon sizing/alignment polish
  - remove redundant modal close buttons (use header X)
  - add initial loading state (`Loading packages…`) to reduce flicker/jump during async discovery
- Skill details rendering
  - cleaner SKILL.md-derived content rendering in modal
  - reduced duplicate heading/title presentation
- Package settings / model picker fixes
  - robust disk hydration from config files
  - canonical extension config support (`~/.pi/agent/extensions/<package>.json`)
  - provider/id → `provider/model` normalization for model pickers
  - fixed select value mapping edge-cases that could show `Use package default` despite loaded value
  - preserve runtime command execution and persist config writes
- Create skill topbar action
  - now stages `/skill:creatorskill` in chat flow consistent with Try-in-chat behavior
- Docs updates
  - updated `docs/PACKAGES.md`
  - updated issue implementation log for #25 and #40 follow-up
  - updated TODO tracking for package metadata diagnostics/loading state

## Validation
- `npm run check` ✅
- `npm run build:frontend` ✅

## Notes
- Extension config formats can vary; this PR adds robust generic handling and canonical extension JSON support, with further format-specific handling to be extended incrementally as new extensions are added.
