### PR TITLE
Codex-parity UI pass: chat/packages/settings panes, model picker, themes, and overlay fixes

### DIFF
--- a/docs/THEMES_DESKTOP_MAPPING.md
+++ b/docs/THEMES_DESKTOP_MAPPING.md
@@ -1,0 +1,57 @@
+# Pi Desktop Themes: Mapping and Behavior
+
+This document explains how Pi Desktop maps Pi theme files (`~/.pi/agent/themes/*.json`) to desktop UI tokens.
+
+## Default bundled themes
+
+Pi Desktop includes a default first-party theme set (installed on first desktop startup):
+
+- `pi-desktop-notion-dark.json`
+- `pi-desktop-catppuccin-dark.json`
+- `pi-desktop-github-dark.json`
+- `pi-desktop-vscode-plus-dark.json`
+- `pi-desktop-notion-light.json`
+- `pi-desktop-vscode-plus-light.json`
+- `pi-desktop-catppuccin-light.json`
+- `pi-desktop-github-light.json`
+
+These files are placed in:
+
+- `~/.pi/agent/themes`
+
+## Theme package behavior
+
+In the Packages pane, **Pi Desktop Themes** behaves like a package:
+
+- **Install**: restores bundled default theme files.
+- **Uninstall**: removes bundled default theme files.
+
+Only the bundled theme files are touched; user-created themes are not removed.
+
+Automatic bootstrap happens only once on first desktop startup. After explicit uninstall, themes stay uninstalled until you install the package again.
+
+## Theme variant detection (Light vs Dark)
+
+The Settings theme dropdowns separate themes into light and dark variants.
+
+Variant detection order:
+
+1. `piDesktop.variant` in theme JSON (`"light" | "dark"`), if present.
+2. Background luminance heuristic from resolved background color.
+3. Filename fallback (`-light` / `-dark`).
+
+## Desktop token mapping
+
+Pi Desktop projects Pi theme tokens into desktop semantic tokens, focused on:
+
+- Accent
+- Background/surfaces
+- Foreground/text
+
+Primary theme color sources used from Pi theme files:
+
+- Accent candidates: `accent`, `toolTitle`, `mdHeading`, `mdLink`, `customMessageLabel`
+- Background candidates: `selectedBg`, `userMessageBg`, `customMessageBg`, `toolPendingBg`, `mdCodeBlock`
+- Foreground candidates: `text`, `userMessageText`, `customMessageText`, `toolOutput`, `syntaxVariable`
+
+Foreground is used mainly for text hierarchy and borders; surface tinting stays background-led to avoid heavy overlay/veil effects.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["devtools"] }
+tauri = { version = "2", features = ["devtools", "macos-private-api"] }
 tauri-plugin-shell = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1576,6 +1576,16 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_notification::init())
+        .setup(|app| {
+            #[cfg(target_os = "macos")]
+            {
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.set_background_color(Some(tauri::utils::config::Color(0, 0, 0, 0)));
+                    let _ = window.set_shadow(true);
+                }
+            }
+            Ok(())
+        })
         .manage(RpcState::default())
         .invoke_handler(tauri::generate_handler![
             rpc_start,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -11,6 +11,7 @@
 	},
 	"app": {
 		"withGlobalTauri": true,
+		"macOSPrivateApi": true,
 		"windows": [
 			{
 				"title": "Pi Desktop",
@@ -19,7 +20,9 @@
 				"minWidth": 600,
 				"minHeight": 400,
 				"decorations": false,
-				"transparent": false,
+				"transparent": true,
+				"shadow": true,
+				"backgroundColor": "#00000000",
 				"center": true
 			}
 		],

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -230,7 +230,81 @@ function normalizeText(value: unknown): string {
 	return "";
 }
 
-function uiIcon(name: "edit" | "retry" | "copy" | "attach" | "send" | "stop" | "spark" | "terminal" | "git"): TemplateResult {
+function formatProviderDisplayName(provider: string): string {
+	const normalized = normalizeText(provider).toLowerCase();
+	switch (normalized) {
+		case "openai":
+			return "OpenAI";
+		case "anthropic":
+			return "Anthropic";
+		case "google":
+		case "googleai":
+		case "gemini":
+			return "Google";
+		case "xai":
+			return "xAI";
+		case "openrouter":
+			return "OpenRouter";
+		case "ollama":
+			return "Ollama";
+		case "lmstudio":
+			return "LM Studio";
+		default:
+			return normalized
+				.split(/[-_\s]+/)
+				.filter(Boolean)
+				.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+				.join(" ");
+	}
+}
+
+function formatModelDisplayName(modelId: string): string {
+	const raw = normalizeText(modelId);
+	if (!raw) return "Model";
+	let value = raw.replace(/^models\//i, "").trim();
+	value = value.replace(/^(openai|anthropic|google|xai|openrouter|ollama|lmstudio)[:/]/i, "");
+	if (!value) return "Model";
+	if (/^gpt/i.test(value)) return value.replace(/^gpt/i, "GPT");
+	if (/^claude/i.test(value)) {
+		const tail = value.slice("claude".length).replace(/^[-_\s]+/, "");
+		if (!tail) return "Claude";
+		const humanTail = tail
+			.replace(/[-_]+/g, " ")
+			.split(/\s+/)
+			.filter(Boolean)
+			.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+			.join(" ");
+		return `Claude ${humanTail}`;
+	}
+	if (/^gemini/i.test(value)) return value.replace(/^gemini/i, "Gemini");
+	return value
+		.replace(/[-_]+/g, " ")
+		.split(/\s+/)
+		.filter(Boolean)
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(" ");
+}
+
+function formatThinkingDisplayName(level: ThinkingLevel): string {
+	switch (level) {
+		case "off":
+			return "off";
+		case "minimal":
+			return "minimal";
+		case "low":
+			return "low";
+		case "medium":
+			return "medium";
+		case "high":
+			return "high";
+		case "xhigh":
+			return "xhigh";
+		default:
+			return "off";
+	}
+}
+
+function uiIcon(name: "edit" | "retry" | "copy" | "attach" | "send" | "stop" | "spinner" | "spark" | "terminal" | "git"): TemplateResult {
 	switch (name) {
 		case "edit":
 			return html`<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3.2 11.8l.5-2.5L10.2 2.8a1.2 1.2 0 0 1 1.7 0l1.3 1.3a1.2 1.2 0 0 1 0 1.7l-6.5 6.5z"></path><path d="M3.2 11.8l2.5-.5"></path></svg>`;
@@ -239,11 +313,13 @@ function uiIcon(name: "edit" | "retry" | "copy" | "attach" | "send" | "stop" | "
 		case "copy":
 			return html`<svg viewBox="0 0 16 16" aria-hidden="true"><rect x="5" y="5" width="8" height="8" rx="1.4"></rect><rect x="3" y="3" width="8" height="8" rx="1.4"></rect></svg>`;
 		case "attach":
-			return html`<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M11.7 7.1L7.8 11a2.5 2.5 0 1 1-3.5-3.5L8.8 3a1.9 1.9 0 1 1 2.7 2.7L6.6 10.6"></path></svg>`;
+			return html`<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 3.1v9.8"></path><path d="M3.1 8h9.8"></path></svg>`;
 		case "send":
-			return html`<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 2.8v10.4"></path><path d="M4.9 5.9L8 2.8l3.1 3.1"></path></svg>`;
+			return html`<svg class="send-arrow-icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 12.7V3.6"></path><path d="M4.6 7L8 3.6 11.4 7"></path></svg>`;
 		case "stop":
-			return html`<svg viewBox="0 0 16 16" aria-hidden="true"><rect x="5" y="5" width="6" height="6" rx="1.1"></rect></svg>`;
+			return html`<svg class="stop-square-icon" viewBox="0 0 16 16" aria-hidden="true"><rect x="4.9" y="4.9" width="6.2" height="6.2" rx="1.2"></rect></svg>`;
+		case "spinner":
+			return html`<svg class="spinner-icon" viewBox="0 0 16 16" aria-hidden="true"><circle class="spinner-track" cx="8" cy="8" r="5.4"></circle><path class="spinner-arc" d="M8 2.6a5.4 5.4 0 0 1 5.4 5.4"></path></svg>`;
 		case "spark":
 			return html`<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 2.5l1.3 3.1 3.2 1.3-3.2 1.3L8 11.3l-1.3-3.1-3.2-1.3 3.2-1.3z"></path></svg>`;
 		case "terminal":
@@ -251,6 +327,10 @@ function uiIcon(name: "edit" | "retry" | "copy" | "attach" | "send" | "stop" | "
 		case "git":
 			return html`<svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="4" cy="3.6" r="1.2"></circle><circle cx="4" cy="12.4" r="1.2"></circle><circle cx="12" cy="8" r="1.2"></circle><path d="M4 4.8v6.4"></path><path d="M5 4.2l5.8 2.9"></path><path d="M5 11.8l5.8-2.9"></path></svg>`;
 	}
+}
+
+function skillGlyphIcon(): TemplateResult {
+	return html`<svg class="filled" viewBox="0 0 20 20" aria-hidden="true"><path d="M9.2 2.3a1.5 1.5 0 0 1 3 0v3.8h.8V3.8a1.5 1.5 0 0 1 3 0v6.4a4.8 4.8 0 0 1-4.8 4.8H9.8A4.8 4.8 0 0 1 5 10.2V7.8a1.5 1.5 0 1 1 3 0v1.4h.8V2.3a1.5 1.5 0 0 1 .4-1z"></path></svg>`;
 }
 
 function piGlyphIcon(): TemplateResult {
@@ -288,6 +368,10 @@ export class ChatView {
 	private lastBackendSessionFile: string | null = null;
 	private settingModel = false;
 	private settingThinking = false;
+	private modelPickerOpen = false;
+	private modelPickerActiveProvider = "";
+	private modelPickerGlobalListenersBound = false;
+	private sendingPrompt = false;
 	private pendingImages: PendingImage[] = [];
 	private notices: Notice[] = [];
 	private allThinkingExpanded = false;
@@ -314,6 +398,7 @@ export class ChatView {
 	private slashPaletteOpen = false;
 	private slashPaletteQuery = "";
 	private slashPaletteIndex = 0;
+	private slashPaletteNavigationMode: "pointer" | "keyboard" = "pointer";
 	private slashSkills: string[] = [];
 	private slashSkillsLoading = false;
 	private slashSkillsUpdatedAt = 0;
@@ -424,6 +509,7 @@ export class ChatView {
 		}).__PI_DESKTOP_PUSH_TRACE__;
 		push?.(`chat:setProjectPath ${previous ?? "-"} -> ${path ?? "-"}`);
 		this.gitMenuOpen = false;
+		this.modelPickerOpen = false;
 		this.selectedSkillDraft = null;
 		this.slashPaletteOpen = false;
 		this.slashPaletteQuery = "";
@@ -451,6 +537,7 @@ export class ChatView {
 		this.lastBackendSessionFile = null;
 		this.lastBackendRefreshError = null;
 		this.pendingDeliveryMode = "prompt";
+		this.modelPickerOpen = false;
 		this.selectedSkillDraft = null;
 		this.slashPaletteOpen = false;
 		this.slashPaletteQuery = "";
@@ -552,11 +639,13 @@ export class ChatView {
 			this.slashPaletteOpen = false;
 			this.slashPaletteQuery = "";
 			this.slashPaletteIndex = 0;
+			this.slashPaletteNavigationMode = "pointer";
 			return;
 		}
 		const normalized = query.toLowerCase();
 		if (!this.slashPaletteOpen || normalized !== this.slashPaletteQuery) {
 			this.slashPaletteIndex = 0;
+			this.slashPaletteNavigationMode = "pointer";
 		}
 		this.slashPaletteOpen = true;
 		this.slashPaletteQuery = normalized;
@@ -567,6 +656,7 @@ export class ChatView {
 		this.slashPaletteOpen = false;
 		this.slashPaletteQuery = "";
 		this.slashPaletteIndex = 0;
+		this.slashPaletteNavigationMode = "pointer";
 		if (clearInput) this.inputText = "";
 	}
 
@@ -766,9 +856,41 @@ export class ChatView {
 		this.streamingReconcileTimer = null;
 	}
 
+	private onGlobalPointerDownForModelPicker = (event: Event): void => {
+		if (!this.modelPickerOpen) return;
+		const target = event.target;
+		if (target instanceof Element && target.closest(".model-picker-root")) return;
+		this.modelPickerOpen = false;
+		this.render();
+	};
+
+	private onGlobalEscapeForModelPicker = (event: KeyboardEvent): void => {
+		if (!this.modelPickerOpen || event.key !== "Escape") return;
+		event.preventDefault();
+		this.modelPickerOpen = false;
+		this.render();
+	};
+
+	private bindModelPickerGlobalListeners(): void {
+		if (this.modelPickerGlobalListenersBound || typeof document === "undefined") return;
+		document.addEventListener("pointerdown", this.onGlobalPointerDownForModelPicker, true);
+		document.addEventListener("mousedown", this.onGlobalPointerDownForModelPicker, true);
+		document.addEventListener("keydown", this.onGlobalEscapeForModelPicker, true);
+		this.modelPickerGlobalListenersBound = true;
+	}
+
+	private unbindModelPickerGlobalListeners(): void {
+		if (!this.modelPickerGlobalListenersBound || typeof document === "undefined") return;
+		document.removeEventListener("pointerdown", this.onGlobalPointerDownForModelPicker, true);
+		document.removeEventListener("mousedown", this.onGlobalPointerDownForModelPicker, true);
+		document.removeEventListener("keydown", this.onGlobalEscapeForModelPicker, true);
+		this.modelPickerGlobalListenersBound = false;
+	}
+
 	connect(): void {
 		this.unsubscribeEvents?.();
 		this.unsubscribeEvents = rpcBridge.onEvent((event) => this.handleEvent(event));
+		this.bindModelPickerGlobalListeners();
 		void this.bindNativeFileDropListener();
 		this.isConnected = rpcBridge.isConnected;
 		if (!this.isConnected) return;
@@ -786,6 +908,7 @@ export class ChatView {
 			unlisten();
 		}
 		this.nativeFileDropUnlisteners = [];
+		this.unbindModelPickerGlobalListeners();
 	}
 
 	async refreshFromBackend(options: { throwOnError?: boolean } = {}): Promise<void> {
@@ -1198,6 +1321,13 @@ export class ChatView {
 				});
 			}
 			if (mapped.length > 0) {
+				mapped.sort((a, b) => {
+					const providerCompare = formatProviderDisplayName(a.provider).localeCompare(formatProviderDisplayName(b.provider), undefined, {
+						sensitivity: "base",
+					});
+					if (providerCompare !== 0) return providerCompare;
+					return formatModelDisplayName(a.id).localeCompare(formatModelDisplayName(b.id), undefined, { sensitivity: "base" });
+				});
 				this.availableModels = mapped;
 			}
 			this.lastModelLoadError = null;
@@ -1218,6 +1348,7 @@ export class ChatView {
 
 	private async setModel(provider: string, modelId: string): Promise<void> {
 		if (this.settingModel) return;
+		this.modelPickerOpen = false;
 		this.settingModel = true;
 		this.render();
 		try {
@@ -2732,6 +2863,8 @@ export class ChatView {
 
 		this.pushUserEcho(text, actualMode, images);
 		this.clearComposer();
+		this.sendingPrompt = true;
+		this.render();
 
 		try {
 			const rpcImages = this.toRpcImages(images);
@@ -2746,6 +2879,9 @@ export class ChatView {
 		} catch (err) {
 			console.error("Failed to send message:", err);
 			this.pushNotice(err instanceof Error ? err.message : "Failed to send message", "error");
+		} finally {
+			this.sendingPrompt = false;
+			this.render();
 		}
 	}
 
@@ -3644,9 +3780,60 @@ export class ChatView {
 		const currentProvider = normalizeText(this.state?.model?.provider);
 		const currentModelId = normalizeText(this.state?.model?.id);
 		const currentModelValue = currentProvider && currentModelId ? `${currentProvider}::${currentModelId}` : "";
-		const thinking = this.state?.thinkingLevel ?? "off";
-		const thinkingValue = thinking;
-		const thinkingLabel = thinkingValue;
+		const currentModelDisplay = currentModelId ? formatModelDisplayName(currentModelId) : "Select model";
+		const currentProviderDisplay = currentProvider ? formatProviderDisplayName(currentProvider) : "";
+		const currentModelTitle = currentProvider && currentModelId ? `${currentProviderDisplay} / ${currentModelId}` : "Select model";
+		const thinkingValue = (this.state?.thinkingLevel ?? "off") as ThinkingLevel;
+		const thinkingLabel = formatThinkingDisplayName(thinkingValue);
+
+		const groupedByProvider = new Map<string, { providerKey: string; providerLabel: string; models: ModelOption[] }>();
+		for (const model of this.availableModels) {
+			const providerKey = model.provider;
+			const existing = groupedByProvider.get(providerKey);
+			if (existing) {
+				existing.models.push(model);
+			} else {
+				groupedByProvider.set(providerKey, {
+					providerKey,
+					providerLabel: formatProviderDisplayName(providerKey),
+					models: [model],
+				});
+			}
+		}
+
+		if (currentProvider && currentModelId && !this.availableModels.some((m) => m.provider === currentProvider && m.id === currentModelId)) {
+			const existing = groupedByProvider.get(currentProvider);
+			const fallbackModel: ModelOption = {
+				provider: currentProvider,
+				id: currentModelId,
+				label: `${currentProvider}/${currentModelId}`,
+				reasoning: false,
+			};
+			if (existing) existing.models.unshift(fallbackModel);
+			else {
+				groupedByProvider.set(currentProvider, {
+					providerKey: currentProvider,
+					providerLabel: formatProviderDisplayName(currentProvider),
+					models: [fallbackModel],
+				});
+			}
+		}
+
+		const providerGroups = Array.from(groupedByProvider.values())
+			.map((group) => ({
+				...group,
+				models: [...group.models].sort((a, b) =>
+					formatModelDisplayName(a.id).localeCompare(formatModelDisplayName(b.id), undefined, { sensitivity: "base" }),
+				),
+			}))
+			.sort((a, b) => a.providerLabel.localeCompare(b.providerLabel, undefined, { sensitivity: "base" }));
+
+		const resolvedActiveProvider = providerGroups.some((g) => g.providerKey === this.modelPickerActiveProvider)
+			? this.modelPickerActiveProvider
+			: providerGroups.some((g) => g.providerKey === currentProvider)
+				? currentProvider
+				: (providerGroups[0]?.providerKey ?? "");
+		const activeProviderGroup = providerGroups.find((group) => group.providerKey === resolvedActiveProvider) ?? null;
 
 		return html`
 			<div class="composer-controls">
@@ -3664,55 +3851,129 @@ export class ChatView {
 						${uiIcon("attach")}
 					</button>
 
-					<div class="model-select-wrap">
-						<select
-							class="composer-select model-select"
-							.value=${currentModelValue}
+					<div
+						class="model-picker-root"
+						@keydown=${(event: KeyboardEvent) => {
+							if (event.key !== "Escape") return;
+							event.preventDefault();
+							this.modelPickerOpen = false;
+							this.render();
+							requestAnimationFrame(() => {
+								const textarea = this.container.querySelector("#chat-input") as HTMLTextAreaElement | null;
+								textarea?.focus();
+							});
+						}}
+						@focusout=${(event: FocusEvent) => {
+							const next = event.relatedTarget as Node | null;
+							const root = event.currentTarget as HTMLElement;
+							if (next && root.contains(next)) return;
+							if (!this.modelPickerOpen) return;
+							this.modelPickerOpen = false;
+							this.render();
+						}}
+					>
+						<button
+							type="button"
+							class="model-picker-trigger"
+							title=${currentModelTitle}
 							?disabled=${interactionLocked || this.loadingModels || this.settingModel}
-							@pointerdown=${() => {
+							@click=${() => {
+								if (interactionLocked || this.settingModel) return;
 								if (!this.loadingModels && this.availableModels.length === 0) {
 									void this.loadAvailableModels();
 								}
-							}}
-							@focus=${() => {
-								if (!this.loadingModels && this.availableModels.length === 0) {
-									void this.loadAvailableModels();
+								if (this.modelPickerOpen) {
+									this.modelPickerOpen = false;
+									this.render();
+									return;
 								}
-							}}
-							@change=${(e: Event) => {
-								const value = (e.target as HTMLSelectElement).value;
-								const [provider, ...rest] = value.split("::");
-								const modelId = rest.join("::");
-								if (!provider || !modelId || value === currentModelValue) return;
-								void this.setModel(provider, modelId);
+								if (resolvedActiveProvider) this.modelPickerActiveProvider = resolvedActiveProvider;
+								this.modelPickerOpen = true;
+								this.render();
 							}}
 						>
-							${this.loadingModels ? html`<option value="">Loading models…</option>` : nothing}
-							${!this.loadingModels && this.availableModels.length === 0
-								? html`<option value="">No models loaded</option>`
-								: nothing}
-							${!this.loadingModels && currentModelValue && !this.availableModels.some((m) => `${m.provider}::${m.id}` === currentModelValue)
-								? html`<option value=${currentModelValue}>${currentProvider}/${currentModelId}</option>`
-								: nothing}
-							${this.availableModels.map((m) => html`<option value=${`${m.provider}::${m.id}`}>${m.provider}/${m.id}</option>`)}
-						</select>
-						<span class="composer-select-caret">▾</span>
+							<span class="model-picker-trigger-label">${currentProviderDisplay ? `${currentModelDisplay} · ${currentProviderDisplay}` : currentModelDisplay}</span>
+							<span class="composer-select-caret">▾</span>
+						</button>
+
+						${this.modelPickerOpen
+							? html`
+								<div class="model-picker-popover" role="listbox" aria-label="Available models">
+									${this.loadingModels
+										? html`<div class="model-picker-empty">Loading models…</div>`
+										: providerGroups.length === 0
+											? html`<div class="model-picker-empty">No models available</div>`
+											: html`
+												<div class="model-picker-providers">
+													${providerGroups.map(
+														(group) => html`
+															<button
+																type="button"
+																class="model-picker-provider ${group.providerKey === resolvedActiveProvider ? "active" : ""}"
+																@mouseenter=${() => {
+																	if (this.modelPickerActiveProvider === group.providerKey) return;
+																	this.modelPickerActiveProvider = group.providerKey;
+																	this.render();
+																}}
+																@focus=${() => {
+																	if (this.modelPickerActiveProvider === group.providerKey) return;
+																	this.modelPickerActiveProvider = group.providerKey;
+																	this.render();
+																}}
+																@click=${() => {
+																	if (this.modelPickerActiveProvider === group.providerKey) return;
+																	this.modelPickerActiveProvider = group.providerKey;
+																	this.render();
+																}}
+															>
+																<span class="model-picker-provider-label">${group.providerLabel}</span>
+																<span class="model-picker-provider-caret" aria-hidden="true">›</span>
+															</button>
+														`,
+													)}
+												</div>
+												<div class="model-picker-models">
+													${activeProviderGroup
+														? activeProviderGroup.models.map(
+															(model) => html`
+																<button
+																	type="button"
+																	class="model-picker-model ${model.provider === currentProvider && model.id === currentModelId ? "active" : ""}"
+																	title=${`${formatProviderDisplayName(model.provider)} / ${model.id}`}
+																	@click=${() => {
+																		const nextValue = `${model.provider}::${model.id}`;
+																		this.modelPickerOpen = false;
+																		this.render();
+																		if (nextValue === currentModelValue) return;
+																		void this.setModel(model.provider, model.id);
+																	}}
+																>
+																	<span>${formatModelDisplayName(model.id)}</span>
+																</button>
+															`,
+														)
+														: html`<div class="model-picker-empty">No models</div>`}
+												</div>
+											`}
+								</div>
+							`
+							: nothing}
 					</div>
 
-					<div class="thinking-select-wrap">
-						<span class="thinking-select-label">thinking · ${thinkingLabel}</span>
+					<div class="thinking-select-wrap" title="Reasoning effort">
+						<span class="thinking-select-label">${thinkingLabel}</span>
 						<select
 							class="thinking-select-native"
 							.value=${thinkingValue}
 							?disabled=${interactionLocked || this.settingThinking}
 							@change=${(e: Event) => void this.setThinkingLevel((e.target as HTMLSelectElement).value as ThinkingLevel)}
 						>
-							<option value="off">Off</option>
-							<option value="minimal">Minimal</option>
-							<option value="low">Low</option>
-							<option value="medium">Medium</option>
-							<option value="high">High</option>
-							<option value="xhigh">Xhigh</option>
+							<option value="off">off</option>
+							<option value="minimal">minimal</option>
+							<option value="low">low</option>
+							<option value="medium">medium</option>
+							<option value="high">high</option>
+							<option value="xhigh">xhigh</option>
 						</select>
 						<span class="thinking-select-caret">▾</span>
 					</div>
@@ -3733,19 +3994,25 @@ export class ChatView {
 								${uiIcon("stop")}
 							</button>
 						`
-						: html`
-							<button
-								class="send-btn primary-send"
-								?disabled=${interactionLocked || !canSend}
-								title="Send"
-								@click=${() => {
-									if (interactionLocked) return;
-									void this.sendMessage("prompt");
-								}}
-							>
-								${uiIcon("send")}
-							</button>
-						`}
+						: this.sendingPrompt
+							? html`
+								<button class="send-btn pending-send" title="Sending" disabled>
+									${uiIcon("spinner")}
+								</button>
+							`
+							: html`
+								<button
+									class="send-btn primary-send"
+									?disabled=${interactionLocked || !canSend}
+									title="Send"
+									@click=${() => {
+										if (interactionLocked) return;
+										void this.sendMessage("prompt");
+									}}
+								>
+									${uiIcon("send")}
+								</button>
+							`}
 				</div>
 			</div>
 		`;
@@ -3775,14 +4042,32 @@ export class ChatView {
 		const draft = this.selectedSkillDraft;
 		if (!draft) return nothing;
 		return html`
-			<div class="composer-skill-draft-row">
-				<div class="composer-skill-draft-pill">
-					<span class="composer-skill-draft-label">Skill</span>
-					<span class="composer-skill-draft-name">${draft.name}</span>
-					<button class="composer-skill-draft-remove" title="Remove skill" @click=${() => this.removeComposerSkillDraft()}>✕</button>
-				</div>
+			<div class="composer-skill-draft-pill inline">
+				<span class="composer-skill-draft-icon" aria-hidden="true">${skillGlyphIcon()}</span>
+				<span class="composer-skill-draft-name">${draft.name}</span>
+				<button class="composer-skill-draft-remove" title="Remove skill" @click=${() => this.removeComposerSkillDraft()}>✕</button>
 			</div>
 		`;
+	}
+
+	private ensureActiveSlashItemVisible(): void {
+		if (!this.slashPaletteOpen || this.slashPaletteNavigationMode !== "keyboard") return;
+		requestAnimationFrame(() => {
+			const menu = this.container.querySelector<HTMLElement>(".composer-slash-menu");
+			const activeItem = this.container.querySelector<HTMLElement>(".composer-slash-item.active");
+			if (!menu || !activeItem) return;
+			const menuTop = menu.scrollTop;
+			const menuBottom = menuTop + menu.clientHeight;
+			const itemTop = activeItem.offsetTop;
+			const itemBottom = itemTop + activeItem.offsetHeight;
+			if (itemTop < menuTop) {
+				menu.scrollTop = Math.max(0, itemTop - 4);
+				return;
+			}
+			if (itemBottom > menuBottom) {
+				menu.scrollTop = itemBottom - menu.clientHeight + 4;
+			}
+		});
 	}
 
 	private renderSlashPalette(items: SlashPaletteItem[]): TemplateResult | typeof nothing {
@@ -3796,7 +4081,26 @@ export class ChatView {
 		const activeIndex = Math.max(0, Math.min(this.slashPaletteIndex, items.length - 1));
 		let currentSection: "Actions" | "Skills" | null = null;
 		return html`
-			<div class="composer-slash-menu">
+			<div
+				class="composer-slash-menu ${this.slashPaletteNavigationMode === "keyboard" ? "keyboard-nav" : ""}"
+				@mousemove=${(event: MouseEvent) => {
+					if (this.slashPaletteNavigationMode === "keyboard") {
+						const moved = Math.abs(event.movementX) + Math.abs(event.movementY) > 0;
+						if (!moved) return;
+						this.slashPaletteNavigationMode = "pointer";
+					}
+					const target = event.target instanceof Element ? event.target.closest(".composer-slash-item") as HTMLElement | null : null;
+					if (!target) return;
+					const indexRaw = target.dataset.index;
+					if (!indexRaw) return;
+					const index = Number(indexRaw);
+					if (!Number.isFinite(index)) return;
+					if (this.slashPaletteIndex !== index) {
+						this.slashPaletteIndex = index;
+						this.render();
+					}
+				}}
+			>
 				${items.map((item, index) => {
 					const sectionChanged = item.section !== currentSection;
 					currentSection = item.section;
@@ -3804,6 +4108,7 @@ export class ChatView {
 						${sectionChanged ? html`<div class="composer-slash-section">${item.section}</div>` : nothing}
 						<button
 							class="composer-slash-item ${index === activeIndex ? "active" : ""}"
+							data-index=${String(index)}
 							@click=${() => this.selectSlashPaletteItem(item)}
 						>
 							<span class="composer-slash-item-label">${item.label}</span>
@@ -3838,8 +4143,8 @@ export class ChatView {
 				<div class="composer-inner">
 					<div class="composer-panel">
 						${this.renderPendingImages()}
-						${this.renderComposerSkillDraftPill()}
 						<div class="composer-row">
+							${this.renderComposerSkillDraftPill()}
 							<textarea
 								id="chat-input"
 								class="chat-input"
@@ -3885,18 +4190,33 @@ export class ChatView {
 								}}
 								@keydown=${(e: KeyboardEvent) => {
 									if (interactionLocked) return;
+									if (e.key === "Escape" && this.modelPickerOpen) {
+										e.preventDefault();
+										this.modelPickerOpen = false;
+										this.render();
+										return;
+									}
+									if ((e.key === "Backspace" || e.key === "Delete") && this.inputText.length === 0 && this.selectedSkillDraft) {
+										e.preventDefault();
+										this.removeComposerSkillDraft();
+										return;
+									}
 									const liveSlashItems = this.getSlashPaletteItems();
 									if (this.slashPaletteOpen && liveSlashItems.length > 0) {
 										if (e.key === "ArrowDown") {
 											e.preventDefault();
+											this.slashPaletteNavigationMode = "keyboard";
 											this.slashPaletteIndex = (this.slashPaletteIndex + 1) % liveSlashItems.length;
 											this.render();
+											this.ensureActiveSlashItemVisible();
 											return;
 										}
 										if (e.key === "ArrowUp") {
 											e.preventDefault();
+											this.slashPaletteNavigationMode = "keyboard";
 											this.slashPaletteIndex = (this.slashPaletteIndex - 1 + liveSlashItems.length) % liveSlashItems.length;
 											this.render();
+											this.ensureActiveSlashItemVisible();
 											return;
 										}
 										if (e.key === "Enter" && !e.shiftKey) {
@@ -3930,6 +4250,7 @@ export class ChatView {
 					</div>
 
 					<div class="composer-under-row">
+						${this.renderGitRepoControl()}
 						<div class="composer-stats-slot">
 							<div
 								class="session-stats-wrap"
@@ -3972,7 +4293,6 @@ export class ChatView {
 									: nothing}
 							</div>
 						</div>
-						${this.renderGitRepoControl()}
 					</div>
 
 					<input
@@ -4335,6 +4655,7 @@ export class ChatView {
 		this.doRender();
 		this.scrollToBottom();
 		this.syncWorkingStatusAnimation();
+		this.ensureActiveSlashItemVisible();
 	}
 
 	notify(text: string, kind: "info" | "success" | "error" = "info"): void {

--- a/src/components/content-tabs.ts
+++ b/src/components/content-tabs.ts
@@ -42,6 +42,8 @@ export class ContentTabs {
 	private onSelect: ((id: string) => void) | null = null;
 	private onClose: ((id: string) => void) | null = null;
 	private onRename: ((id: string, title: string) => void) | null = null;
+	private onOpenTerminal: (() => void) | null = null;
+	private terminalActive = false;
 
 	private tabColors: Record<string, string> = {};
 	private tabPins: Record<string, boolean> = {};
@@ -63,7 +65,7 @@ export class ContentTabs {
 
 	private readonly onWindowPointerDown = (event: PointerEvent) => {
 		if (!this.contextTabKey) return;
-		const target = event.target as HTMLElement | null;
+		const target = event.target instanceof Element ? event.target : null;
 		if (target?.closest(".content-tab-context-menu")) return;
 		this.closeContext();
 	};
@@ -121,6 +123,16 @@ export class ContentTabs {
 
 	setOnRename(cb: (id: string, title: string) => void): void {
 		this.onRename = cb;
+	}
+
+	setOnOpenTerminal(cb: () => void): void {
+		this.onOpenTerminal = cb;
+	}
+
+	setTerminalActive(active: boolean): void {
+		if (this.terminalActive === active) return;
+		this.terminalActive = active;
+		this.render();
 	}
 
 	private tabKey(tab: MainContentTab): string {
@@ -435,10 +447,10 @@ export class ContentTabs {
 	}
 
 	private getDragGhostLeft(): number {
-		const root = this.container.querySelector<HTMLElement>(".content-tabs-root");
-		if (!root) return 0;
-		const rect = root.getBoundingClientRect();
-		return this.dragCurrentX - this.dragGrabOffsetX - rect.left + root.scrollLeft;
+		const scroll = this.container.querySelector<HTMLElement>(".content-tabs-scroll");
+		if (!scroll) return 0;
+		const rect = scroll.getBoundingClientRect();
+		return this.dragCurrentX - this.dragGrabOffsetX - rect.left + scroll.scrollLeft;
 	}
 
 	private scheduleOverflowMeasurement(): void {
@@ -505,26 +517,41 @@ export class ContentTabs {
 				data-tauri-drag-region
 				@click=${(e: Event) => {
 					if (!menuOpen) return;
-					const target = e.target as HTMLElement;
-					if (target.closest(".content-tab-context-menu")) return;
+					const target = e.target instanceof Element ? e.target : null;
+					if (target?.closest(".content-tab-context-menu")) return;
 					this.closeContext();
 				}}
 			>
-				${renderedTabs.map((tab, index) => this.renderTab(tab, index, this.draggingTabKey === this.tabKey(tab)))}
-				${draggingTab
-					? html`
-						<div
-							class="content-tab content-tab-drag-ghost ${draggingTab.pinned ? "pinned" : ""} ${draggingTab.needsAttention ? "needs-attention" : ""} ${this.activeId === draggingTab.id ? "active" : ""}"
-							style=${`left:${dragGhostLeft}px;width:${this.dragGhostWidth}px;${this.tabColors[this.tabKey(draggingTab)] ? `--content-tab-fill:${this.tabColors[this.tabKey(draggingTab)]};` : ""}`}
-						>
-							<div class="content-tab-main">
-								<span class="content-tab-title-wrap">
-									<span class="content-tab-title ${draggingTab.needsAttention ? "needs-attention" : ""}">${draggingTab.title}</span>
-								</span>
+				<div class="content-tabs-scroll" data-tauri-drag-region>
+					${renderedTabs.map((tab, index) => this.renderTab(tab, index, this.draggingTabKey === this.tabKey(tab)))}
+					${draggingTab
+						? html`
+							<div
+								class="content-tab content-tab-drag-ghost ${draggingTab.pinned ? "pinned" : ""} ${draggingTab.needsAttention ? "needs-attention" : ""} ${this.activeId === draggingTab.id ? "active" : ""}"
+								style=${`left:${dragGhostLeft}px;width:${this.dragGhostWidth}px;${this.tabColors[this.tabKey(draggingTab)] ? `--content-tab-fill:${this.tabColors[this.tabKey(draggingTab)]};` : ""}`}
+							>
+								<div class="content-tab-main">
+									<span class="content-tab-title-wrap">
+										<span class="content-tab-title ${draggingTab.needsAttention ? "needs-attention" : ""}">${draggingTab.title}</span>
+									</span>
+								</div>
 							</div>
-						</div>
-					`
-					: nothing}
+						`
+						: nothing}
+				</div>
+
+				<div class="content-tabs-trailing" data-tauri-drag-region>
+					<button
+						class="content-tabs-terminal-btn ${this.terminalActive ? "active" : ""}"
+						title="Open terminal"
+						@click=${(event: Event) => {
+							event.stopPropagation();
+							this.onOpenTerminal?.();
+						}}
+					>
+						<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M3 3.2h10v9.6H3z"></path><path d="M5.1 6.2l1.9 1.8-1.9 1.8"></path><path d="M8.6 9.8h2.6"></path></svg>
+					</button>
+				</div>
 
 				${this.contextTabKey
 					? html`

--- a/src/components/packages-view.ts
+++ b/src/components/packages-view.ts
@@ -6,6 +6,7 @@ import { html, nothing, render, type TemplateResult } from "lit";
 import { normalizeRecommendedSource, RECOMMENDED_PACKAGES, type RecommendedPackageDefinition } from "../recommended-packages.js";
 import { RECOMMENDED_SKILLS, type RecommendedSkillDefinition } from "../recommended-skills.js";
 import { rpcBridge } from "../rpc/bridge.js";
+import { getBundledThemesStatus, isBundledThemeId, removeBundledThemes, restoreBundledThemes } from "../theme/bundled-themes.js";
 
 interface CatalogPackageItem {
 	name: string;
@@ -53,6 +54,17 @@ interface DiscoveredResourceItem {
 	sourceKind: "npm" | "git" | "url" | "local" | "unknown";
 }
 
+interface DiscoveredThemeItem {
+	id: string;
+	name: string;
+	description: string;
+	variant: "light" | "dark";
+	accent: string;
+	background: string;
+	foreground: string;
+	path: string;
+}
+
 interface ExtensionSurfaceItem {
 	id: string;
 	displayName: string;
@@ -76,7 +88,8 @@ interface RecommendedSkillSurfaceItem {
 type ActivePackagesModal =
 	| { kind: "extension"; item: ExtensionSurfaceItem }
 	| { kind: "skill"; item: DiscoveredResourceItem }
-	| { kind: "recommended-skill"; item: RecommendedSkillSurfaceItem };
+	| { kind: "recommended-skill"; item: RecommendedSkillSurfaceItem }
+	| { kind: "theme"; item: DiscoveredThemeItem };
 
 type UiIcon =
 	| "package"
@@ -92,6 +105,8 @@ type UiIcon =
 const PACKAGES_CATALOG_URL = "https://shittycodingagent.ai/packages";
 const PACKAGES_SEARCH_URL = "https://registry.npmjs.org/-/v1/search?text=keywords:pi-package&size=250";
 const RESOURCE_CREATOR_SKILL_NAME = "creatorskill";
+const DESKTOP_THEMES_PACKAGE_SOURCE = "local:pi-desktop-themes";
+const DESKTOP_THEMES_DOC_URL = "https://github.com/gustavonline/pi-desktop/blob/dev/docs/THEMES_DESKTOP_MAPPING.md";
 
 function uniqueBy<T>(items: T[], getKey: (item: T) => string): T[] {
 	const seen = new Set<string>();
@@ -432,6 +447,7 @@ export class PackagesView {
 	private installedProject: InstalledPackageItem[] = [];
 	private promptTemplateResources: DiscoveredResourceItem[] = [];
 	private skillResources: DiscoveredResourceItem[] = [];
+	private themeResources: DiscoveredThemeItem[] = [];
 
 	private loadingCatalog = false;
 	private loadingResources = false;
@@ -485,6 +501,10 @@ export class PackagesView {
 	private activeSkillContentLoading = false;
 	private activeSkillContentError = "";
 	private activeSkillContentNotice = "";
+	private desktopThemesInstalled = false;
+	private desktopThemesInstalledCount = 0;
+	private desktopThemesTotal = 8;
+	private desktopThemesRootPath = "";
 
 	constructor(container: HTMLElement) {
 		this.container = container;
@@ -520,7 +540,7 @@ export class PackagesView {
 	}
 
 	async open(): Promise<void> {
-		await Promise.all([this.loadCatalog(this.catalogItems.length === 0), this.loadConfig()]);
+		await Promise.all([this.loadCatalog(this.catalogItems.length === 0), this.loadConfig(), this.refreshBundledThemesStatus()]);
 		await this.refreshDiscoveredResources();
 	}
 
@@ -529,8 +549,22 @@ export class PackagesView {
 	}
 
 	async refreshPackages(forceCatalog = false): Promise<void> {
-		await Promise.all([this.loadCatalog(forceCatalog), this.loadConfig()]);
+		await Promise.all([this.loadCatalog(forceCatalog), this.loadConfig(), this.refreshBundledThemesStatus()]);
 		await this.refreshDiscoveredResources();
+	}
+
+	private async refreshBundledThemesStatus(): Promise<void> {
+		try {
+			const status = await getBundledThemesStatus();
+			this.desktopThemesInstalled = status.installed;
+			this.desktopThemesInstalledCount = status.installedCount;
+			this.desktopThemesTotal = status.total;
+			this.desktopThemesRootPath = status.themesRoot;
+		} catch {
+			this.desktopThemesInstalled = false;
+			this.desktopThemesInstalledCount = 0;
+			this.desktopThemesRootPath = "";
+		}
 	}
 
 	private async openExternal(url: string): Promise<void> {
@@ -1040,9 +1074,10 @@ export class PackagesView {
 				.map((item) => ({ ...item, loaded: true }))
 				.filter((item) => item.packageScope !== "project");
 
-			const [globalPrompts, globalSkills] = await Promise.all([
+			const [globalPrompts, globalSkills, globalThemes] = await Promise.all([
 				this.scanPromptResources("global"),
 				this.scanSkillResources("global"),
+				this.scanThemeResources(),
 			]);
 			const localResources = [...globalPrompts, ...globalSkills];
 			const merged = this.mergeDiscoveredResources(commandResources, localResources);
@@ -1056,9 +1091,15 @@ export class PackagesView {
 				merged.filter((item) => item.kind === "skill"),
 				(item) => `${item.kind}:${item.name}:${normalizeFsPath(item.path) || item.packageScope || "runtime"}`.toLowerCase(),
 			).sort((a, b) => a.name.localeCompare(b.name));
+
+			this.themeResources = uniqueBy(
+				globalThemes,
+				(item) => `${item.id}:${normalizeFsPath(item.path)}`,
+			).sort((a, b) => a.name.localeCompare(b.name));
 		} catch (err) {
 			this.promptTemplateResources = [];
 			this.skillResources = [];
+			this.themeResources = [];
 			this.resourcesError = err instanceof Error ? err.message : String(err);
 		} finally {
 			this.loadingResources = false;
@@ -1594,6 +1635,7 @@ export class PackagesView {
 
 	private resolveSourceUrl(source: string): string | null {
 		if (!source) return null;
+		if (normalizeRecommendedSource(source) === DESKTOP_THEMES_PACKAGE_SOURCE) return DESKTOP_THEMES_DOC_URL;
 		if (/^https?:\/\//i.test(source)) return source;
 		if (source.startsWith("npm:")) return `https://www.npmjs.com/package/${source.slice(4)}`;
 		if (source.startsWith("github:")) return `https://github.com/${source.slice(7).replace(/^\/+/, "")}`;
@@ -1654,6 +1696,141 @@ export class PackagesView {
 			const haystack = `${item.name} ${item.description} ${item.commandText} ${item.packageSource ?? ""} ${item.path}`.toLowerCase();
 			return haystack.includes(q);
 		});
+	}
+
+	private filteredThemeResources(): DiscoveredThemeItem[] {
+		const q = this.normalizeQuery();
+		if (!q) return this.themeResources;
+		return this.themeResources.filter((item) => {
+			const haystack = `${item.name} ${item.description} ${item.variant} ${item.path}`.toLowerCase();
+			return haystack.includes(q);
+		});
+	}
+
+	private parseThemeRgb(color: string): { r: number; g: number; b: number } | null {
+		const trimmed = color.trim();
+		const short = trimmed.match(/^#([0-9a-f]{3})$/i);
+		if (short) {
+			const [r, g, b] = short[1].split("");
+			return {
+				r: parseInt(`${r}${r}`, 16),
+				g: parseInt(`${g}${g}`, 16),
+				b: parseInt(`${b}${b}`, 16),
+			};
+		}
+		const full = trimmed.match(/^#([0-9a-f]{6})$/i);
+		if (full) {
+			return {
+				r: parseInt(full[1].slice(0, 2), 16),
+				g: parseInt(full[1].slice(2, 4), 16),
+				b: parseInt(full[1].slice(4, 6), 16),
+			};
+		}
+		return null;
+	}
+
+	private inferThemeVariantFromBackground(background: string): "light" | "dark" {
+		const rgb = this.parseThemeRgb(background);
+		if (!rgb) return "dark";
+		const toLinear = (channel: number): number => {
+			const s = channel / 255;
+			return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+		};
+		const luminance = 0.2126 * toLinear(rgb.r) + 0.7152 * toLinear(rgb.g) + 0.0722 * toLinear(rgb.b);
+		return luminance >= 0.42 ? "light" : "dark";
+	}
+
+	private normalizeThemeColorLiteral(value: unknown): string | null {
+		if (typeof value === "string") {
+			const trimmed = value.trim();
+			if (/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(trimmed)) return trimmed;
+		}
+		return null;
+	}
+
+	private resolveThemeColorValue(doc: Record<string, unknown>, value: unknown, seen = new Set<string>()): string | null {
+		const direct = this.normalizeThemeColorLiteral(value);
+		if (direct) return direct;
+		if (typeof value !== "string") return null;
+		const ref = value.trim();
+		if (!ref || seen.has(ref)) return null;
+		seen.add(ref);
+		const vars = (doc.vars as Record<string, unknown> | undefined) ?? {};
+		if (Object.prototype.hasOwnProperty.call(vars, ref)) {
+			const fromVar = this.resolveThemeColorValue(doc, vars[ref], seen);
+			if (fromVar) return fromVar;
+		}
+		const colors = (doc.colors as Record<string, unknown> | undefined) ?? {};
+		if (Object.prototype.hasOwnProperty.call(colors, ref)) {
+			const fromColor = this.resolveThemeColorValue(doc, colors[ref], seen);
+			if (fromColor) return fromColor;
+		}
+		return null;
+	}
+
+	private themeBackgroundColor(doc: Record<string, unknown>): string {
+		const colors = (doc.colors as Record<string, unknown> | undefined) ?? {};
+		return (
+			this.resolveThemeColorValue(doc, colors.selectedBg) ??
+			this.resolveThemeColorValue(doc, colors.userMessageBg) ??
+			this.resolveThemeColorValue(doc, colors.customMessageBg) ??
+			"#101010"
+		);
+	}
+
+	private inferThemeVariant(doc: Record<string, unknown>, fileName: string): "light" | "dark" {
+		const meta = doc.piDesktop;
+		if (meta && typeof meta === "object" && !Array.isArray(meta)) {
+			const variant = (meta as Record<string, unknown>).variant;
+			if (variant === "light" || variant === "dark") return variant;
+		}
+		const background = this.themeBackgroundColor(doc);
+		const byBackground = this.inferThemeVariantFromBackground(background);
+		if (byBackground) return byBackground;
+		return fileName.toLowerCase().includes("light") ? "light" : "dark";
+	}
+
+	private async scanThemeResources(): Promise<DiscoveredThemeItem[]> {
+		await this.ensureHomePath();
+		if (!this.homePath) return [];
+		const themesRoot = joinFsPath(joinFsPath(joinFsPath(this.homePath, ".pi"), "agent"), "themes");
+		try {
+			const { exists, readDir, readTextFile } = await import("@tauri-apps/plugin-fs");
+			if (!(await exists(themesRoot))) return [];
+			const entries = await readDir(themesRoot);
+			const out: DiscoveredThemeItem[] = [];
+			for (const entry of entries) {
+				if (!entry.isFile || !entry.name.toLowerCase().endsWith(".json")) continue;
+				const path = joinFsPath(themesRoot, entry.name);
+				let parsed: Record<string, unknown> = {};
+				try {
+					const raw = await readTextFile(path);
+					const json = JSON.parse(raw) as unknown;
+					if (json && typeof json === "object" && !Array.isArray(json)) {
+						parsed = json as Record<string, unknown>;
+					}
+				} catch {
+					// keep defaults for malformed files
+				}
+				const fileId = entry.name.replace(/\.json$/i, "");
+				const name = typeof parsed.name === "string" && parsed.name.trim() ? parsed.name.trim() : fileId;
+				const variant = this.inferThemeVariant(parsed, fileId);
+				const colors = (parsed.colors as Record<string, unknown> | undefined) ?? {};
+				const accent = this.resolveThemeColorValue(parsed, colors.accent) ?? "#7A818F";
+				const background = this.themeBackgroundColor(parsed);
+				const foreground =
+					this.resolveThemeColorValue(parsed, colors.text) ??
+					this.resolveThemeColorValue(parsed, colors.userMessageText) ??
+					(variant === "dark" ? "#EFEFEF" : "#37352F");
+				const description = typeof parsed.description === "string" && parsed.description.trim()
+					? parsed.description.trim()
+					: `${variant === "dark" ? "Dark" : "Light"} theme`;
+				out.push({ id: fileId.toLowerCase(), name, description, variant, accent, background, foreground, path });
+			}
+			return out.sort((a, b) => a.name.localeCompare(b.name));
+		} catch {
+			return [];
+		}
 	}
 
 	private findSkillResourceByName(name: string): DiscoveredResourceItem | null {
@@ -2561,6 +2738,12 @@ Execute the required file creation/edits directly, then summarize exactly which 
 	}
 
 	private extensionInstallState(source: string): { global: boolean; project: boolean } {
+		if (normalizeRecommendedSource(source) === DESKTOP_THEMES_PACKAGE_SOURCE) {
+			return {
+				global: this.desktopThemesInstalled,
+				project: false,
+			};
+		}
 		return {
 			global: this.installedUser.some((item) => this.sourceMatchesInstalled(source, item.source)),
 			project: false,
@@ -2568,6 +2751,16 @@ Execute the required file creation/edits directly, then summarize exactly which 
 	}
 
 	private findInstalledItemForSource(source: string, _scope: "global" | "local"): InstalledDisplayItem | null {
+		if (normalizeRecommendedSource(source) === DESKTOP_THEMES_PACKAGE_SOURCE) {
+			if (!this.desktopThemesInstalled) return null;
+			return {
+				source: DESKTOP_THEMES_PACKAGE_SOURCE,
+				location: this.desktopThemesRootPath || "~/.pi/agent/themes",
+				scope: "user",
+				displayName: "Pi Desktop Themes",
+				openUrl: this.resolveSourceUrl(DESKTOP_THEMES_PACKAGE_SOURCE),
+			};
+		}
 		const hit = this.installedUser.find((item) => this.sourceMatchesInstalled(source, item.source)) ?? null;
 		if (!hit) return null;
 		return {
@@ -2654,24 +2847,22 @@ Execute the required file creation/edits directly, then summarize exactly which 
 	}
 
 	private buildRecommendedExtensionItems(): ExtensionSurfaceItem[] {
-		return RECOMMENDED_PACKAGES
-			.map((item) => {
-				const source = item.source;
-				const normalized = normalizeRecommendedSource(source);
-				const installState = this.extensionInstallState(source);
-				return {
-					id: `recommended:${normalized}`,
-					displayName: item.name,
-					source,
-					description: item.description,
-					note: item.installSourceHint,
-					openUrl: this.resolveSourceUrl(source),
-					sourceKind: item.sourceKind,
-					installState,
-					installedItemForScope: this.findInstalledItemForSource(source, "global"),
-				} satisfies ExtensionSurfaceItem;
-			})
-			.sort((a, b) => a.displayName.localeCompare(b.displayName));
+		return RECOMMENDED_PACKAGES.map((item) => {
+			const source = item.source;
+			const normalized = normalizeRecommendedSource(source);
+			const installState = this.extensionInstallState(source);
+			return {
+				id: `recommended:${normalized}`,
+				displayName: item.name,
+				source,
+				description: item.description,
+				note: item.installSourceHint,
+				openUrl: this.resolveSourceUrl(source),
+				sourceKind: item.sourceKind,
+				installState,
+				installedItemForScope: this.findInstalledItemForSource(source, "global"),
+			} satisfies ExtensionSurfaceItem;
+		});
 	}
 
 	private async openPackagesItemModal(modal: ActivePackagesModal): Promise<void> {
@@ -2699,6 +2890,9 @@ Execute the required file creation/edits directly, then summarize exactly which 
 		}
 
 		this.render();
+		if (modal.kind === "theme") {
+			return;
+		}
 		if (modal.kind === "skill") {
 			const directPath = modal.item.path.trim() || null;
 			const fallbackPath = directPath ? null : await this.resolvePackageSkillContentPath(modal.item.name, modal.item.packageSource);
@@ -2767,15 +2961,70 @@ Execute the required file creation/edits directly, then summarize exactly which 
 	}
 
 	private async installExtensionItem(item: ExtensionSurfaceItem): Promise<void> {
+		if (normalizeRecommendedSource(item.source) === DESKTOP_THEMES_PACKAGE_SOURCE) {
+			if (this.runningCommand || this.runningConfigCommand) return;
+			this.runningCommand = true;
+			this.commandStatus = "Installing Pi Desktop Themes…";
+			this.render();
+			try {
+				const result = await restoreBundledThemes();
+				await this.refreshBundledThemesStatus();
+				this.commandStatus = `Installed Pi Desktop Themes (${result.created} created, ${result.renamed} renamed).`;
+			} catch (err) {
+				this.commandStatus = `Failed to install Pi Desktop Themes: ${err instanceof Error ? err.message : String(err)}`;
+			} finally {
+				this.runningCommand = false;
+				this.render();
+			}
+			return;
+		}
 		await this.installPackage(item.source, "global");
 		await this.refreshPackages(false);
 	}
 
 	private async uninstallExtensionItem(item: ExtensionSurfaceItem): Promise<void> {
+		if (normalizeRecommendedSource(item.source) === DESKTOP_THEMES_PACKAGE_SOURCE) {
+			if (this.runningCommand || this.runningConfigCommand) return;
+			this.runningCommand = true;
+			this.commandStatus = "Uninstalling Pi Desktop Themes…";
+			this.render();
+			try {
+				const result = await removeBundledThemes();
+				await this.refreshBundledThemesStatus();
+				this.commandStatus = `Uninstalled Pi Desktop Themes (${result.removed} removed, ${result.removedLegacy} legacy removed).`;
+			} catch (err) {
+				this.commandStatus = `Failed to uninstall Pi Desktop Themes: ${err instanceof Error ? err.message : String(err)}`;
+			} finally {
+				this.runningCommand = false;
+				this.render();
+			}
+			return;
+		}
 		const installed = item.installedItemForScope ?? this.findInstalledItemForSource(item.source, "global");
 		if (!installed) return;
 		await this.removePackage(this.resolveInstalledRemoveSource(installed), "global");
 		await this.refreshPackages(false);
+	}
+
+	private async uninstallThemeItem(item: DiscoveredThemeItem): Promise<void> {
+		if (this.runningCommand || this.runningConfigCommand) return;
+		this.runningCommand = true;
+		this.commandStatus = `Uninstalling theme ${item.name}…`;
+		this.render();
+		try {
+			const { exists, remove } = await import("@tauri-apps/plugin-fs");
+			if (await exists(item.path)) {
+				await remove(item.path);
+			}
+			this.closePackagesItemModal();
+			await this.refreshPackages(false);
+			this.commandStatus = `Uninstalled theme ${item.name}.`;
+		} catch (err) {
+			this.commandStatus = `Failed to uninstall theme ${item.name}: ${err instanceof Error ? err.message : String(err)}`;
+		} finally {
+			this.runningCommand = false;
+			this.render();
+		}
 	}
 
 	private renderSkillContentBlock(): TemplateResult {
@@ -2891,6 +3140,49 @@ Execute the required file creation/edits directly, then summarize exactly which 
 								</button>
 								${item.openUrl ? html`<button class="ghost-btn" @click=${() => void this.openExternal(item.openUrl!)}>Open page</button>` : nothing}
 								${installedForScope?.location ? html`<button class="ghost-btn" @click=${() => void this.openPath(installedForScope.location)}>Open folder</button>` : nothing}
+							</div>
+						</div>
+					</div>
+				</div>
+			`;
+		}
+
+		if (modal.kind === "theme") {
+			const item = modal.item;
+			return html`
+				<div class="overlay" @click=${(event: Event) => event.target === event.currentTarget && this.closePackagesItemModal()}>
+					<div class="overlay-card packages-config-modal packages-item-modal">
+						<div class="overlay-header">
+							<div>
+								<div class="packages-config-modal-title">${item.name}</div>
+							</div>
+							<button @click=${() => this.closePackagesItemModal()}>✕</button>
+						</div>
+						<div class="overlay-body packages-config-modal-body">
+							${item.description ? html`<div class="packages-section-desc">${item.description}</div>` : nothing}
+							${this.renderItemMetaRows([
+								{ label: "Type", value: `${item.variant === "dark" ? "Dark" : "Light"} theme` },
+								{ label: "Path", value: item.path },
+							])}
+							<div class="packages-theme-preview-grid">
+								<div class="packages-theme-preview-row">
+									<span>Accent</span>
+									<div class="packages-theme-color-chip"><span class="packages-theme-color-dot" style=${`background:${item.accent}`}></span>${item.accent}</div>
+								</div>
+								<div class="packages-theme-preview-row">
+									<span>Background</span>
+									<div class="packages-theme-color-chip"><span class="packages-theme-color-dot" style=${`background:${item.background}`}></span>${item.background}</div>
+								</div>
+								<div class="packages-theme-preview-row">
+									<span>Foreground</span>
+									<div class="packages-theme-color-chip"><span class="packages-theme-color-dot" style=${`background:${item.foreground}`}></span>${item.foreground}</div>
+								</div>
+							</div>
+							<div class="packages-config-modal-actions">
+								<button class="ghost-btn danger" ?disabled=${this.runningCommand || this.runningConfigCommand} @click=${() => void this.uninstallThemeItem(item)}>
+									${this.runningCommand ? "Uninstalling…" : "Uninstall"}
+								</button>
+								<button class="ghost-btn" @click=${() => void this.openPath(pathDirName(item.path))}>Open folder</button>
 							</div>
 						</div>
 					</div>
@@ -3029,6 +3321,7 @@ Execute the required file creation/edits directly, then summarize exactly which 
 		const installedItems = this.getInstalledItems();
 		const catalogItems = this.filteredCatalogItems();
 		const skillResources = this.filteredSkillResources();
+		const themeResources = this.filteredThemeResources().filter((item) => !isBundledThemeId(item.id));
 		const query = this.normalizeQuery();
 		const hasQuery = query.length > 0;
 		const queryLabel = this.query.trim();
@@ -3078,6 +3371,8 @@ Execute the required file creation/edits directly, then summarize exactly which 
 		const installedRowsData: Array<{ sortKey: string; options: RowOptions }> = [];
 		const discoverRowsData: Array<{ sortKey: string; priority: number; options: RowOptions }> = [];
 		const recommendedBadge = html`<span class="packages-card-scope recommended">Recommended</span>`;
+		const extensionIconFor = (item: ExtensionSurfaceItem): UiIcon =>
+			normalizeRecommendedSource(item.source) === DESKTOP_THEMES_PACKAGE_SOURCE ? "theme" : "extension";
 
 		const addInstalledRow = (sortKey: string, options: RowOptions) => {
 			installedRowsData.push({ sortKey, options });
@@ -3112,12 +3407,24 @@ Execute the required file creation/edits directly, then summarize exactly which 
 			});
 		}
 
+		for (const item of themeResources) {
+			addInstalledRow(`theme:${item.name.toLowerCase()}`, {
+				title: item.name,
+				description: item.description,
+				note: item.path,
+				iconName: "theme",
+				actions: html`<button class="packages-row-install installed" title="Installed" @click=${() => void this.openPackagesItemModal({ kind: "theme", item })}>✓</button>`,
+				onTitleClick: () => void this.openPackagesItemModal({ kind: "theme", item }),
+				titleAttr: item.path,
+			});
+		}
+
 		for (const item of extensionInstalled) {
 			addInstalledRow(item.displayName.toLowerCase(), {
 				title: item.displayName,
 				description: item.description || item.source,
 				note: item.note,
-				iconName: "extension",
+				iconName: extensionIconFor(item),
 				actions: html`<button class="packages-row-install installed" title="Installed" @click=${() => void this.openPackagesItemModal({ kind: "extension", item })}>✓</button>`,
 				onTitleClick: () => void this.openPackagesItemModal({ kind: "extension", item }),
 				titleAttr: item.source,
@@ -3151,7 +3458,7 @@ Execute the required file creation/edits directly, then summarize exactly which 
 				title: item.displayName,
 				description: item.description || item.source,
 				note: item.note,
-				iconName: "extension",
+				iconName: extensionIconFor(item),
 				badges: [recommendedBadge],
 				actions: html`
 					<button
@@ -3173,7 +3480,7 @@ Execute the required file creation/edits directly, then summarize exactly which 
 				title: item.displayName,
 				description: item.description || item.source,
 				note: item.note,
-				iconName: "extension",
+				iconName: extensionIconFor(item),
 				badges: [html`<span class="packages-card-scope">${sourceKindLabel(item.sourceKind)}</span>`],
 				actions: html`
 					<button
@@ -3228,7 +3535,6 @@ Execute the required file creation/edits directly, then summarize exactly which 
 		const installedLoading = this.loadingResources || this.loadingConfig;
 		const discoverLoading = this.loadingCatalog && hasQuery;
 		const discoverTitle = hasQuery ? "Results" : "Recommended";
-		const discoverMetaLabel = hasQuery ? "results" : "recommended";
 		const discoverSubmeta = hasQuery
 			? `Results for “${queryLabel}”.`
 			: "Recommended skills and extensions to get started.";
@@ -3246,11 +3552,6 @@ Execute the required file creation/edits directly, then summarize exactly which 
 				<div class="packages-view-header">
 					<div class="packages-view-title-wrap">
 						<div class="packages-view-title">Packages</div>
-						<div class="packages-view-meta">
-							${installedLoading || discoverLoading
-								? "Refreshing package state…"
-								: `${installedCount} installed · ${discoverCount} ${discoverMetaLabel}`}
-						</div>
 					</div>
 					<div class="packages-view-header-actions">
 						<button class="packages-back-btn" ?disabled=${this.runningCommand} @click=${() => void this.refreshPackages(true)}>Refresh</button>
@@ -3277,7 +3578,6 @@ Execute the required file creation/edits directly, then summarize exactly which 
 										<div class="packages-section-title">Installed</div>
 										<div class="packages-section-submeta">Skills and extensions available in this session.</div>
 									</div>
-									<div class="packages-section-meta">${installedCount}</div>
 								</div>
 								${installedLoading
 									? html`<div class="packages-empty">Loading installed items…</div>`
@@ -3290,13 +3590,12 @@ Execute the required file creation/edits directly, then summarize exactly which 
 										`}
 							</section>
 
-							<section class="packages-section">
+							<section class="packages-section packages-section-discover">
 								<div class="packages-section-head">
 									<div>
 										<div class="packages-section-title">${discoverTitle}</div>
 										<div class="packages-section-submeta">${discoverSubmeta}</div>
 									</div>
-									<div class="packages-section-meta">${discoverCount}</div>
 								</div>
 								${discoverLoading
 									? html`<div class="packages-empty">Loading results…</div>`

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -2,8 +2,18 @@
  * Settings Panel - runtime controls for RPC session + app preferences
  */
 
-import { html, render, type TemplateResult } from "lit";
+import { html, nothing, render, type TemplateResult } from "lit";
 import { fetchDesktopUpdateStatus, openDesktopUpdate, type DesktopUpdateStatus } from "../desktop-updates.js";
+import {
+	applyDesktopAppearanceProfileToRoot,
+	DEFAULT_APPEARANCE_PROFILES,
+	type DesktopAppearanceProfile,
+	type DesktopAppearanceProfiles,
+	type ThemeVariant,
+	loadDesktopAppearanceProfiles,
+	notifyDesktopAppearanceProfileChanged,
+	saveDesktopAppearanceProfiles,
+} from "../theme/appearance-profiles.js";
 import {
 	type CliUpdateStatus,
 	type PiAuthStatus,
@@ -11,9 +21,29 @@ import {
 	type RpcCompatibilityReport,
 	rpcBridge,
 } from "../rpc/bridge.js";
+import { applyDesktopTheme, getResolvedDesktopTheme, readStoredDesktopTheme, type DesktopThemeMode } from "../theme/theme-manager.js";
+
+interface ThemeOption {
+	id: string;
+	label: string;
+	variant: ThemeVariant;
+	accent: string;
+	background: string;
+	foreground: string;
+	contrast: number | null;
+	uiFont: string | null;
+	codeFont: string | null;
+	translucentSidebar: boolean | null;
+}
+
+interface ThemeColorDraft {
+	accent: string;
+	background: string;
+	foreground: string;
+}
 
 interface SettingsState {
-	theme: "dark" | "light";
+	theme: DesktopThemeMode;
 	autoCompactionEnabled: boolean;
 	autoRetryEnabled: boolean;
 	steeringMode: QueueMode;
@@ -46,6 +76,20 @@ export class SettingsPanel {
 	private onCliStatusChange: ((status: CliUpdateStatus | null) => void) | null = null;
 	private compatibilityReport: RpcCompatibilityReport | null = null;
 	private compatibilityLoading = false;
+	private appearanceProfiles: DesktopAppearanceProfiles = loadDesktopAppearanceProfiles();
+	private availableThemes: ThemeOption[] = [];
+	private themeCatalogLoading = false;
+	private themeCatalogError = "";
+	private themeCatalogMessage = "";
+	private createThemeDialogOpen = false;
+	private createThemeDialogTheme: ThemeVariant = "dark";
+	private createThemeDialogName = "";
+	private createThemeDialogSaving = false;
+	private createThemeDialogError = "";
+	private colorDrafts: Record<ThemeVariant, ThemeColorDraft> = {
+		light: { accent: "", background: "", foreground: "" },
+		dark: { accent: "", background: "", foreground: "" },
+	};
 
 	constructor(container: HTMLElement) {
 		this.container = container;
@@ -70,6 +114,13 @@ export class SettingsPanel {
 
 	async open(): Promise<void> {
 		this.isOpen = true;
+		this.appearanceProfiles = loadDesktopAppearanceProfiles();
+		this.resetColorDrafts();
+		this.createThemeDialogOpen = false;
+		this.createThemeDialogSaving = false;
+		this.createThemeDialogError = "";
+		this.clearPersistedProfileColorOverrides();
+		this.themeCatalogMessage = "";
 		this.loadTheme();
 		this.render();
 		await this.loadState();
@@ -77,22 +128,610 @@ export class SettingsPanel {
 		this.render();
 	}
 
-	close(): void {
+	close(notify = true): void {
+		this.resetColorDrafts();
+		this.createThemeDialogOpen = false;
+		this.createThemeDialogSaving = false;
+		this.createThemeDialogError = "";
+		this.applyAppearanceProfileForCurrentResolvedTheme();
 		this.isOpen = false;
 		this.render();
-		this.onClose?.();
+		if (notify) this.onClose?.();
 	}
 
 	private loadTheme(): void {
-		const saved = (localStorage.getItem("pi-theme") as "dark" | "light" | null) ?? "dark";
+		const saved = readStoredDesktopTheme();
 		this.state.theme = saved;
 		this.applyTheme(saved);
 	}
 
-	private applyTheme(theme: "dark" | "light"): void {
-		document.documentElement.classList.remove("light", "dark");
-		document.documentElement.classList.add(theme);
-		localStorage.setItem("pi-theme", theme);
+	private applyTheme(theme: DesktopThemeMode): void {
+		applyDesktopTheme(theme);
+	}
+
+	private getCurrentResolvedTheme(): ThemeVariant {
+		return getResolvedDesktopTheme() === "light" ? "light" : "dark";
+	}
+
+	private applyAppearanceProfileForCurrentResolvedTheme(notify = true): void {
+		const resolved = this.getCurrentResolvedTheme();
+		applyDesktopAppearanceProfileToRoot(resolved, this.appearanceProfiles);
+		if (this.isOpen) this.applyColorDraftPreviewToRoot(resolved);
+		if (notify) notifyDesktopAppearanceProfileChanged();
+	}
+
+	private getProfile(theme: ThemeVariant): DesktopAppearanceProfile {
+		return theme === "light" ? this.appearanceProfiles.light : this.appearanceProfiles.dark;
+	}
+
+	private saveAppearanceProfiles(): void {
+		saveDesktopAppearanceProfiles(this.appearanceProfiles);
+	}
+
+	private normalizeThemeSelection(value: unknown): string {
+		if (typeof value !== "string") return "";
+		const trimmed = value.trim();
+		if (!trimmed || trimmed === "dark" || trimmed === "light" || trimmed === "system") return "";
+		return trimmed;
+	}
+
+	private resetColorDrafts(): void {
+		this.colorDrafts.light = { accent: "", background: "", foreground: "" };
+		this.colorDrafts.dark = { accent: "", background: "", foreground: "" };
+	}
+
+	private clearPersistedProfileColorOverrides(): void {
+		let changed = false;
+		for (const variant of ["light", "dark"] as const) {
+			const profile = this.getProfile(variant);
+			if (profile.accent || profile.background || profile.foreground) {
+				profile.accent = "";
+				profile.background = "";
+				profile.foreground = "";
+				changed = true;
+			}
+		}
+		if (changed) this.saveAppearanceProfiles();
+	}
+
+	private applyColorDraftPreviewToRoot(theme: ThemeVariant): void {
+		const draft = this.colorDrafts[theme];
+		if (!draft.accent && !draft.background && !draft.foreground) return;
+
+		const root = document.documentElement;
+		const base = this.baseThemePreview(theme);
+		const effectiveBackground = draft.background || base.background;
+		const neutralLift = theme === "dark" ? "white" : "black";
+
+		if (draft.accent) {
+			root.style.setProperty("--color-accent-primary", draft.accent);
+			root.style.setProperty("--color-accent-soft", `color-mix(in srgb, ${draft.accent} 20%, transparent)`);
+		}
+
+		if (draft.background) {
+			root.style.setProperty("--color-bg-app", draft.background);
+			root.style.setProperty("--color-bg-elevated", `color-mix(in srgb, ${draft.background} 94%, ${neutralLift} 6%)`);
+			root.style.setProperty("--color-bg-muted", `color-mix(in srgb, ${draft.background} 89%, ${neutralLift} 11%)`);
+			root.style.setProperty("--color-bg-soft", `color-mix(in srgb, ${draft.background} 84%, ${neutralLift} 16%)`);
+			root.style.setProperty("--color-bg-sidebar", `color-mix(in srgb, ${draft.background} 91%, ${neutralLift} 9%)`);
+			root.style.setProperty("--color-bg-workspace-chrome", `color-mix(in srgb, ${draft.background} 92%, ${neutralLift} 8%)`);
+			root.style.setProperty("--color-bg-workspace-chrome-soft", `color-mix(in srgb, ${draft.background} 86%, ${neutralLift} 14%)`);
+		}
+
+		if (draft.foreground) {
+			root.style.setProperty("--color-text-primary", draft.foreground);
+			root.style.setProperty("--color-text-secondary", `color-mix(in srgb, ${draft.foreground} 68%, ${effectiveBackground} 32%)`);
+			root.style.setProperty("--color-text-tertiary", `color-mix(in srgb, ${draft.foreground} 52%, ${effectiveBackground} 48%)`);
+			root.style.setProperty("--color-border-default", `color-mix(in srgb, ${draft.foreground} 12%, transparent)`);
+			root.style.setProperty("--border", `color-mix(in srgb, var(--color-border-default) ${40 + Math.round((this.getProfile(theme).contrast / 100) * 60)}%, transparent)`);
+		}
+	}
+
+	private async refreshThemeCatalog(): Promise<void> {
+		this.themeCatalogLoading = true;
+		this.themeCatalogError = "";
+		this.render();
+		try {
+			const { homeDir } = await import("@tauri-apps/api/path");
+			const { exists, readDir, readTextFile } = await import("@tauri-apps/plugin-fs");
+			const home = await homeDir();
+			const themesRoot = `${home.replace(/\\/g, "/").replace(/\/+$/, "")}/.pi/agent/themes`;
+			if (!(await exists(themesRoot))) {
+				this.availableThemes = [];
+				return;
+			}
+			const entries = await readDir(themesRoot);
+			const list: ThemeOption[] = [];
+			for (const entry of entries) {
+				if (!entry.isFile || !entry.name.toLowerCase().endsWith(".json")) continue;
+				const path = `${themesRoot}/${entry.name}`;
+				const id = entry.name.replace(/\.json$/i, "");
+				try {
+					const raw = await readTextFile(path);
+					const parsed = JSON.parse(raw) as Record<string, unknown>;
+					const label = id;
+					const preview = this.extractThemePreview(parsed);
+					const variant = this.extractThemeVariant(parsed, id, preview.background);
+					const defaults = this.extractThemeDesktopDefaults(parsed);
+					list.push({
+						id,
+						label,
+						variant,
+						accent: preview.accent,
+						background: preview.background,
+						foreground: preview.foreground,
+						contrast: defaults.contrast,
+						uiFont: defaults.uiFont,
+						codeFont: defaults.codeFont,
+						translucentSidebar: defaults.translucentSidebar,
+					});
+				} catch {
+					// ignore malformed theme file
+				}
+			}
+			list.sort((a, b) => a.label.localeCompare(b.label));
+			this.availableThemes = list;
+
+			let migrated = false;
+			for (const variant of ["light", "dark"] as const) {
+				const profile = this.getProfile(variant);
+				const match = this.lookupThemeOption(profile.themeName);
+				if (match && profile.themeName !== match.id) {
+					profile.themeName = match.id;
+					migrated = true;
+				}
+				const selected = this.lookupThemeOption(profile.themeName);
+				if (!profile.themeName || !selected || selected.variant !== variant) {
+					const defaultId = this.resolveDefaultThemeId(variant);
+					if (defaultId && profile.themeName !== defaultId) {
+						profile.themeName = defaultId;
+						migrated = true;
+					}
+				}
+			}
+			if (migrated) this.saveAppearanceProfiles();
+		} catch (err) {
+			this.themeCatalogError = err instanceof Error ? err.message : String(err);
+			this.availableThemes = [];
+		} finally {
+			this.themeCatalogLoading = false;
+			this.render();
+		}
+	}
+
+	private xtermIndexToHex(index: number): string | null {
+		if (!Number.isInteger(index) || index < 0 || index > 255) return null;
+		const hex = (value: number): string => value.toString(16).padStart(2, "0");
+		const levels = [0, 95, 135, 175, 215, 255] as const;
+		if (index < 16) {
+			const ansi = [
+				"#000000", "#800000", "#008000", "#808000", "#000080", "#800080", "#008080", "#c0c0c0",
+				"#808080", "#ff0000", "#00ff00", "#ffff00", "#0000ff", "#ff00ff", "#00ffff", "#ffffff",
+			] as const;
+			return ansi[index] ?? null;
+		}
+		if (index <= 231) {
+			const value = index - 16;
+			const r = Math.floor(value / 36);
+			const g = Math.floor((value % 36) / 6);
+			const b = value % 6;
+			return `#${hex(levels[r] ?? 0)}${hex(levels[g] ?? 0)}${hex(levels[b] ?? 0)}`;
+		}
+		const gray = 8 + (index - 232) * 10;
+		return `#${hex(gray)}${hex(gray)}${hex(gray)}`;
+	}
+
+	private normalizeColorLiteral(value: unknown): string | null {
+		if (typeof value === "number") return this.xtermIndexToHex(value);
+		if (typeof value !== "string") return null;
+		const trimmed = value.trim();
+		if (!trimmed) return null;
+		if (/^#([0-9a-f]{3,8})$/i.test(trimmed)) return trimmed;
+		if (/^\d{1,3}$/.test(trimmed)) return this.xtermIndexToHex(Number(trimmed));
+		return null;
+	}
+
+	private resolveThemeValue(theme: Record<string, unknown>, value: unknown, seen = new Set<string>()): string | null {
+		const direct = this.normalizeColorLiteral(value);
+		if (direct) return direct;
+		if (typeof value !== "string") return null;
+		const ref = value.trim();
+		if (!ref || seen.has(ref)) return null;
+		seen.add(ref);
+		const vars = (theme.vars as Record<string, unknown> | undefined) ?? {};
+		if (Object.prototype.hasOwnProperty.call(vars, ref)) {
+			const fromVar = this.resolveThemeValue(theme, vars[ref], seen);
+			if (fromVar) return fromVar;
+		}
+		const colors = (theme.colors as Record<string, unknown> | undefined) ?? {};
+		if (Object.prototype.hasOwnProperty.call(colors, ref)) {
+			const fromColor = this.resolveThemeValue(theme, colors[ref], seen);
+			if (fromColor) return fromColor;
+		}
+		return null;
+	}
+
+	private extractThemePreview(theme: Record<string, unknown>): { accent: string; background: string; foreground: string } {
+		const colors = (theme.colors as Record<string, unknown> | undefined) ?? {};
+		const accent = this.resolveThemeValue(theme, colors.accent) ?? "#7a818f";
+		const background =
+			this.resolveThemeValue(theme, colors.selectedBg) ??
+			this.resolveThemeValue(theme, colors.userMessageBg) ??
+			(this.getCurrentResolvedTheme() === "light" ? "#ffffff" : "#101010");
+		const foreground =
+			this.resolveThemeValue(theme, colors.text) ??
+			this.resolveThemeValue(theme, colors.userMessageText) ??
+			(this.getCurrentResolvedTheme() === "light" ? "#37352f" : "#efefef");
+		return { accent, background, foreground };
+	}
+
+	private parseColorRgb(color: string): { r: number; g: number; b: number } | null {
+		const trimmed = color.trim();
+		const short = trimmed.match(/^#([0-9a-f]{3})$/i);
+		if (short) {
+			const [r, g, b] = short[1].split("");
+			return {
+				r: parseInt(`${r}${r}`, 16),
+				g: parseInt(`${g}${g}`, 16),
+				b: parseInt(`${b}${b}`, 16),
+			};
+		}
+		const full = trimmed.match(/^#([0-9a-f]{6})$/i);
+		if (full) {
+			return {
+				r: parseInt(full[1].slice(0, 2), 16),
+				g: parseInt(full[1].slice(2, 4), 16),
+				b: parseInt(full[1].slice(4, 6), 16),
+			};
+		}
+		const rgb = trimmed.match(/^rgb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i);
+		if (rgb) {
+			return {
+				r: Math.max(0, Math.min(255, Number(rgb[1]))),
+				g: Math.max(0, Math.min(255, Number(rgb[2]))),
+				b: Math.max(0, Math.min(255, Number(rgb[3]))),
+			};
+		}
+		return null;
+	}
+
+	private colorLuminance(color: string): number | null {
+		const rgb = this.parseColorRgb(color);
+		if (!rgb) return null;
+		const toLinear = (channel: number): number => {
+			const s = channel / 255;
+			return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+		};
+		const r = toLinear(rgb.r);
+		const g = toLinear(rgb.g);
+		const b = toLinear(rgb.b);
+		return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+	}
+
+	private inferVariantFromBackground(background: string): ThemeVariant | null {
+		const luminance = this.colorLuminance(background);
+		if (luminance === null) return null;
+		return luminance >= 0.42 ? "light" : "dark";
+	}
+
+	private extractThemeVariant(theme: Record<string, unknown>, id: string, background: string): ThemeVariant {
+		const colors = (theme.colors as Record<string, unknown> | undefined) ?? {};
+		const directBackground =
+			this.resolveThemeValue(theme, colors.selectedBg) ??
+			this.resolveThemeValue(theme, colors.userMessageBg) ??
+			this.resolveThemeValue(theme, colors.customMessageBg) ??
+			null;
+		if (directBackground) {
+			const byDirectBackground = this.inferVariantFromBackground(directBackground);
+			if (byDirectBackground) return byDirectBackground;
+		}
+
+		const meta = theme.piDesktop;
+		if (meta && typeof meta === "object" && !Array.isArray(meta)) {
+			const variant = (meta as Record<string, unknown>).variant;
+			if (variant === "light" || variant === "dark") return variant;
+		}
+		const normalizedId = id.toLowerCase();
+		if (normalizedId.includes("-light")) return "light";
+		if (normalizedId.includes("-dark")) return "dark";
+		const fromBackground = this.inferVariantFromBackground(background);
+		if (fromBackground) return fromBackground;
+		return normalizedId.includes("light") ? "light" : "dark";
+	}
+
+	private extractThemeDesktopDefaults(theme: Record<string, unknown>): {
+		contrast: number | null;
+		uiFont: string | null;
+		codeFont: string | null;
+		translucentSidebar: boolean | null;
+	} {
+		const meta = theme.piDesktop;
+		if (!meta || typeof meta !== "object" || Array.isArray(meta)) {
+			return { contrast: null, uiFont: null, codeFont: null, translucentSidebar: null };
+		}
+		const m = meta as Record<string, unknown>;
+		const contrast = typeof m.contrast === "number" && Number.isFinite(m.contrast)
+			? Math.max(0, Math.min(100, Math.round(m.contrast)))
+			: null;
+		const fonts = m.fonts;
+		const fontsObj = fonts && typeof fonts === "object" && !Array.isArray(fonts)
+			? (fonts as Record<string, unknown>)
+			: null;
+		const uiFont = fontsObj && typeof fontsObj.ui === "string" && fontsObj.ui.trim() ? fontsObj.ui.trim() : null;
+		const codeFont = fontsObj && typeof fontsObj.code === "string" && fontsObj.code.trim() ? fontsObj.code.trim() : null;
+		const translucentSidebar = typeof m.opaqueWindows === "boolean" ? !m.opaqueWindows : null;
+		return { contrast, uiFont, codeFont, translucentSidebar };
+	}
+
+	private themeOptionsForVariant(theme: ThemeVariant): ThemeOption[] {
+		return this.availableThemes.filter((entry) => entry.variant === theme);
+	}
+
+	private lookupThemeOption(themeName: string): ThemeOption | null {
+		const normalized = themeName.trim().toLowerCase();
+		if (!normalized) return null;
+		return this.availableThemes.find((entry) => entry.id.toLowerCase() === normalized || entry.label.toLowerCase() === normalized) ?? null;
+	}
+
+	private resolveDefaultThemeId(theme: ThemeVariant): string {
+		const scoped = this.themeOptionsForVariant(theme);
+		const preferred = `pi-desktop-notion-${theme}`;
+		const exact = scoped.find((entry) => entry.id.toLowerCase() === preferred);
+		if (exact) return exact.id;
+		return scoped[0]?.id ?? "";
+	}
+
+	private themeBehaviorDefaults(theme: ThemeVariant, selected: ThemeOption | null): {
+		contrast: number;
+		uiFont: string;
+		codeFont: string;
+		translucentSidebar: boolean;
+	} {
+		const profileDefaults = theme === "light" ? DEFAULT_APPEARANCE_PROFILES.light : DEFAULT_APPEARANCE_PROFILES.dark;
+		return {
+			contrast: selected?.contrast ?? profileDefaults.contrast,
+			uiFont: selected?.uiFont ?? profileDefaults.uiFont,
+			codeFont: selected?.codeFont ?? profileDefaults.codeFont,
+			translucentSidebar: selected?.translucentSidebar ?? profileDefaults.translucentSidebar,
+		};
+	}
+
+	private hasThemeDraftChanges(theme: ThemeVariant): boolean {
+		const draft = this.colorDrafts[theme];
+		if (draft.accent || draft.background || draft.foreground) return true;
+		const profile = this.getProfile(theme);
+		const selected = this.lookupThemeOption(profile.themeName);
+		const defaults = this.themeBehaviorDefaults(theme, selected);
+		return (
+			profile.contrast !== defaults.contrast ||
+			profile.uiFont !== defaults.uiFont ||
+			profile.codeFont !== defaults.codeFont ||
+			profile.translucentSidebar !== defaults.translucentSidebar
+		);
+	}
+
+	private baseThemePreview(theme: ThemeVariant): { accent: string; background: string; foreground: string } {
+		const profile = this.getProfile(theme);
+		const option = this.lookupThemeOption(profile.themeName);
+		if (option) {
+			return { accent: option.accent, background: option.background, foreground: option.foreground };
+		}
+		if (theme === "light") return { accent: "#3183D8", background: "#FFFFFF", foreground: "#37352F" };
+		return { accent: "#FF6363", background: "#101010", foreground: "#EFEFEF" };
+	}
+
+	private profilePreview(theme: ThemeVariant): { accent: string; background: string; foreground: string } {
+		const base = this.baseThemePreview(theme);
+		const draft = this.colorDrafts[theme];
+		return {
+			accent: draft.accent || base.accent,
+			background: draft.background || base.background,
+			foreground: draft.foreground || base.foreground,
+		};
+	}
+
+	private setProfileThemeName(theme: ThemeVariant, name: string): void {
+		const profile = this.getProfile(theme);
+		const normalized = this.normalizeThemeSelection(name);
+		profile.themeName = normalized || this.resolveDefaultThemeId(theme);
+		profile.accent = "";
+		profile.background = "";
+		profile.foreground = "";
+
+		const selected = this.lookupThemeOption(profile.themeName);
+		const defaults = this.themeBehaviorDefaults(theme, selected);
+		profile.contrast = defaults.contrast;
+		profile.uiFont = defaults.uiFont;
+		profile.codeFont = defaults.codeFont;
+		profile.translucentSidebar = defaults.translucentSidebar;
+
+		this.colorDrafts[theme] = { accent: "", background: "", foreground: "" };
+		this.saveAppearanceProfiles();
+		if (theme === this.getCurrentResolvedTheme()) {
+			this.applyAppearanceProfileForCurrentResolvedTheme();
+		}
+		this.render();
+	}
+
+	private setProfileTranslucentSidebar(theme: ThemeVariant, value: boolean): void {
+		const profile = this.getProfile(theme);
+		profile.translucentSidebar = value;
+		this.saveAppearanceProfiles();
+		if (theme === this.getCurrentResolvedTheme()) {
+			this.applyAppearanceProfileForCurrentResolvedTheme(false);
+		}
+		this.render();
+	}
+
+	private setProfileContrast(theme: ThemeVariant, value: number): void {
+		const profile = this.getProfile(theme);
+		profile.contrast = Math.max(0, Math.min(100, Math.round(value)));
+		this.saveAppearanceProfiles();
+		if (theme === this.getCurrentResolvedTheme()) {
+			this.applyAppearanceProfileForCurrentResolvedTheme(false);
+		}
+		this.render();
+	}
+
+	private normalizeHex6(value: string): string | null {
+		const trimmed = value.trim();
+		const short = trimmed.match(/^#([0-9a-f]{3})$/i);
+		if (short) {
+			const [r, g, b] = short[1].split("");
+			return `#${r}${r}${g}${g}${b}${b}`.toUpperCase();
+		}
+		const full = trimmed.match(/^#([0-9a-f]{6})$/i);
+		if (full) return `#${full[1].toUpperCase()}`;
+		return null;
+	}
+
+	private coercePickerColor(value: string): string {
+		return this.normalizeHex6(value) ?? "#7A818F";
+	}
+
+	private setProfileColor(theme: ThemeVariant, key: "accent" | "background" | "foreground", value: string): void {
+		const normalized = this.normalizeHex6(value);
+		if (!normalized) return;
+		this.colorDrafts[theme][key] = normalized;
+		if (theme === this.getCurrentResolvedTheme()) {
+			this.applyAppearanceProfileForCurrentResolvedTheme(false);
+		}
+		this.render();
+	}
+
+	private setProfileFont(theme: ThemeVariant, key: "uiFont" | "codeFont", value: string): void {
+		const next = value.trim();
+		if (!next) return;
+		const profile = this.getProfile(theme);
+		profile[key] = next;
+		this.saveAppearanceProfiles();
+		if (theme === this.getCurrentResolvedTheme()) {
+			this.applyAppearanceProfileForCurrentResolvedTheme(false);
+		}
+		this.render();
+	}
+
+	private joinFsPath(base: string, child: string): string {
+		const b = base.replace(/\\/g, "/").replace(/\/+$/, "");
+		const c = child.replace(/\\/g, "/").replace(/^\/+/, "");
+		return b ? `${b}/${c}` : c;
+	}
+
+	private async createThemeFromProfile(theme: ThemeVariant): Promise<void> {
+		if (!this.hasThemeDraftChanges(theme)) return;
+		this.createThemeDialogOpen = true;
+		this.createThemeDialogTheme = theme;
+		this.createThemeDialogName = `${theme}-custom`;
+		this.createThemeDialogSaving = false;
+		this.createThemeDialogError = "";
+		this.render();
+	}
+
+	private closeCreateThemeDialog(): void {
+		if (this.createThemeDialogSaving) return;
+		this.createThemeDialogOpen = false;
+		this.createThemeDialogError = "";
+		this.render();
+	}
+
+	private async saveCreateThemeFromDialog(): Promise<void> {
+		if (!this.createThemeDialogOpen || this.createThemeDialogSaving) return;
+		const normalizedName = this.createThemeDialogName.trim();
+		if (!normalizedName) {
+			this.createThemeDialogError = "Theme name is required.";
+			this.render();
+			return;
+		}
+		this.createThemeDialogSaving = true;
+		this.createThemeDialogError = "";
+		this.render();
+		try {
+			await this.persistThemeFromProfile(this.createThemeDialogTheme, normalizedName);
+			this.createThemeDialogOpen = false;
+			this.createThemeDialogSaving = false;
+			this.createThemeDialogError = "";
+			this.render();
+		} catch (err) {
+			this.createThemeDialogSaving = false;
+			this.createThemeDialogError = err instanceof Error ? err.message : String(err);
+			this.render();
+		}
+	}
+
+	private async persistThemeFromProfile(theme: ThemeVariant, normalizedName: string): Promise<void> {
+		const profile = this.getProfile(theme);
+		const preview = this.profilePreview(theme);
+		const accent = preview.accent;
+		const background = preview.background;
+		const foreground = preview.foreground;
+		const doc = {
+			name: normalizedName,
+			vars: {
+				accent,
+				background,
+				foreground,
+			},
+			colors: {
+				accent: "accent",
+				text: "foreground",
+				muted: "foreground",
+				dim: "foreground",
+				selectedBg: "background",
+				userMessageBg: "background",
+				userMessageText: "foreground",
+				customMessageBg: "background",
+				customMessageText: "foreground",
+				toolPendingBg: "background",
+				toolSuccessBg: "background",
+				toolErrorBg: "background",
+				toolTitle: "accent",
+				toolOutput: "foreground",
+			},
+			piDesktop: {
+				source: "pi-desktop-theme-v1",
+				variant: theme,
+				contrast: profile.contrast,
+				fonts: {
+					ui: profile.uiFont || null,
+					code: profile.codeFont || null,
+				},
+				opaqueWindows: !profile.translucentSidebar,
+			},
+		};
+
+		const safeBase = normalizedName
+			.toLowerCase()
+			.replace(/[^a-z0-9._-]+/g, "-")
+			.replace(/^-+/, "")
+			.replace(/-+$/, "") || `${theme}-custom`;
+
+		const { homeDir } = await import("@tauri-apps/api/path");
+		const { exists, mkdir, writeTextFile } = await import("@tauri-apps/plugin-fs");
+		const home = (await homeDir()).replace(/\\/g, "/").replace(/\/+$/, "");
+		const themesRoot = this.joinFsPath(this.joinFsPath(this.joinFsPath(home, ".pi"), "agent"), "themes");
+		await mkdir(themesRoot, { recursive: true });
+
+		let fileStem = safeBase;
+		let targetPath = this.joinFsPath(themesRoot, `${fileStem}.json`);
+		let index = 2;
+		while (await exists(targetPath)) {
+			fileStem = `${safeBase}-${index}`;
+			targetPath = this.joinFsPath(themesRoot, `${fileStem}.json`);
+			index += 1;
+		}
+
+		await writeTextFile(targetPath, `${JSON.stringify(doc, null, 2)}\n`);
+		profile.themeName = fileStem;
+		profile.accent = "";
+		profile.background = "";
+		profile.foreground = "";
+		this.colorDrafts[theme] = { accent: "", background: "", foreground: "" };
+		this.saveAppearanceProfiles();
+		if (theme === this.getCurrentResolvedTheme()) {
+			this.applyAppearanceProfileForCurrentResolvedTheme();
+		}
+		await this.refreshThemeCatalog();
+		this.themeCatalogMessage = `Created theme ${fileStem}.json in ~/.pi/agent/themes`;
 	}
 
 	private async loadState(): Promise<void> {
@@ -111,7 +750,7 @@ export class SettingsPanel {
 				theme?: string;
 				auto_retry?: boolean;
 			};
-			if (saved.theme === "dark" || saved.theme === "light") {
+			if (saved.theme === "dark" || saved.theme === "light" || saved.theme === "system") {
 				this.state.theme = saved.theme;
 				this.applyTheme(saved.theme);
 			}
@@ -127,7 +766,9 @@ export class SettingsPanel {
 			this.refreshDesktopStatus(),
 			this.refreshCliStatus(),
 			this.refreshCompatibilityStatus(),
+			this.refreshThemeCatalog(),
 		]);
+		this.applyAppearanceProfileForCurrentResolvedTheme(false);
 	}
 
 	private async refreshAuthStatus(): Promise<void> {
@@ -231,9 +872,10 @@ export class SettingsPanel {
 		}
 	}
 
-	private async setTheme(theme: "dark" | "light"): Promise<void> {
+	private async setTheme(theme: DesktopThemeMode): Promise<void> {
 		this.state.theme = theme;
 		this.applyTheme(theme);
+		this.applyAppearanceProfileForCurrentResolvedTheme(false);
 		this.render();
 		await this.saveSettings();
 	}
@@ -325,6 +967,141 @@ export class SettingsPanel {
 		`;
 	}
 
+	private renderColorControl(
+		theme: ThemeVariant,
+		key: "accent" | "background" | "foreground",
+		value: string,
+	): TemplateResult {
+		const normalized = this.coercePickerColor(value);
+		const inputId = `appearance-${theme}-${key}`;
+		return html`
+			<label class="appearance-pill appearance-pill-button" for=${inputId}>
+				<input
+					id=${inputId}
+					type="color"
+					class="appearance-color-input"
+					.value=${normalized}
+					@input=${(e: Event) => this.setProfileColor(theme, key, (e.target as HTMLInputElement).value)}
+				/>
+				<span class="appearance-swatch" style=${`background:${normalized}`}></span>
+				<span>${normalized}</span>
+			</label>
+		`;
+	}
+
+	private renderThemeProfileCard(theme: ThemeVariant): TemplateResult {
+		const title = theme === "light" ? "Light theme" : "Dark theme";
+		const profile = this.getProfile(theme);
+		const preview = this.profilePreview(theme);
+		const scopedOptions = this.themeOptionsForVariant(theme);
+		const selected = profile.themeName;
+		const selectedOption = this.lookupThemeOption(selected);
+		const selectedValue = selectedOption && selectedOption.variant === theme
+			? selectedOption.id
+			: this.resolveDefaultThemeId(theme);
+		const canCreateTheme = this.hasThemeDraftChanges(theme);
+		return html`
+			<section class="appearance-profile-card">
+				<div class="appearance-profile-header">
+					<div class="appearance-profile-title">${title}</div>
+					<button
+						class="appearance-profile-action-btn"
+						?disabled=${!canCreateTheme}
+						title=${canCreateTheme ? "Create a new theme from current adjustments" : "Adjust colors, fonts, contrast, or translucency first"}
+						@click=${() => this.createThemeFromProfile(theme)}
+					>
+						Create theme
+					</button>
+					<div class="appearance-theme-select-wrap">
+						<select
+							class="appearance-theme-select"
+							.value=${selectedValue}
+							@change=${(e: Event) => this.setProfileThemeName(theme, (e.target as HTMLSelectElement).value)}
+						>
+							${scopedOptions.map((entry) => html`<option value=${entry.id} ?selected=${selectedValue === entry.id}>${entry.label}</option>`)}
+						</select>
+					</div>
+				</div>
+				<div class="appearance-profile-row"><span>Accent</span>${this.renderColorControl(theme, "accent", preview.accent)}</div>
+				<div class="appearance-profile-row"><span>Background</span>${this.renderColorControl(theme, "background", preview.background)}</div>
+				<div class="appearance-profile-row"><span>Foreground</span>${this.renderColorControl(theme, "foreground", preview.foreground)}</div>
+				<div class="appearance-profile-row">
+					<span>UI font</span>
+					<input
+						class="appearance-font-input"
+						.value=${profile.uiFont}
+						@change=${(e: Event) => this.setProfileFont(theme, "uiFont", (e.target as HTMLInputElement).value)}
+					/>
+				</div>
+				<div class="appearance-profile-row">
+					<span>Code font</span>
+					<input
+						class="appearance-font-input"
+						.value=${profile.codeFont}
+						@change=${(e: Event) => this.setProfileFont(theme, "codeFont", (e.target as HTMLInputElement).value)}
+					/>
+				</div>
+				<div class="appearance-profile-row">
+					<span>Translucent sidebar</span>
+					<button class="toggle ${profile.translucentSidebar ? "on" : "off"}" @click=${() => this.setProfileTranslucentSidebar(theme, !profile.translucentSidebar)}>
+						<span></span>
+					</button>
+				</div>
+				<div class="appearance-profile-row">
+					<span>Contrast</span>
+					<div class="appearance-contrast-wrap">
+						<input
+							type="range"
+							min="0"
+							max="100"
+							.step="1"
+							.value=${String(profile.contrast)}
+							@input=${(e: Event) => this.setProfileContrast(theme, Number((e.target as HTMLInputElement).value))}
+						/>
+						<span>${profile.contrast}</span>
+					</div>
+				</div>
+			</section>
+		`;
+	}
+
+	private renderCreateThemeDialog(): TemplateResult | typeof nothing {
+		if (!this.createThemeDialogOpen) return nothing;
+		const variantLabel = this.createThemeDialogTheme === "dark" ? "Dark" : "Light";
+		return html`
+			<div class="settings-subdialog-backdrop" @click=${() => this.closeCreateThemeDialog()}>
+				<div class="settings-subdialog-card" @click=${(e: Event) => e.stopPropagation()}>
+					<div class="settings-subdialog-title">Create theme (${variantLabel})</div>
+					<div class="settings-subdialog-desc">Give your adjusted theme a name and save it to ~/.pi/agent/themes.</div>
+					<input
+						class="settings-subdialog-input"
+						placeholder="my-theme-name"
+						.value=${this.createThemeDialogName}
+						?disabled=${this.createThemeDialogSaving}
+						@input=${(e: Event) => {
+							this.createThemeDialogName = (e.target as HTMLInputElement).value;
+							if (this.createThemeDialogError) this.createThemeDialogError = "";
+							this.render();
+						}}
+						@keydown=${(e: KeyboardEvent) => {
+							if (e.key === "Enter") {
+								e.preventDefault();
+								void this.saveCreateThemeFromDialog();
+							}
+						}}
+					/>
+					${this.createThemeDialogError ? html`<div class="settings-subdialog-error">${this.createThemeDialogError}</div>` : nothing}
+					<div class="settings-subdialog-actions">
+						<button class="ghost-btn" ?disabled=${this.createThemeDialogSaving} @click=${() => this.closeCreateThemeDialog()}>Cancel</button>
+						<button class="ghost-btn" ?disabled=${this.createThemeDialogSaving} @click=${() => void this.saveCreateThemeFromDialog()}>
+							${this.createThemeDialogSaving ? "Saving…" : "Save theme"}
+						</button>
+					</div>
+				</div>
+			</div>
+		`;
+	}
+
 	render(): void {
 		if (!this.isOpen) {
 			this.container.innerHTML = "";
@@ -332,202 +1109,202 @@ export class SettingsPanel {
 		}
 
 		const template = html`
-			<div class="overlay" @click=${(e: Event) => e.target === e.currentTarget && this.close()}>
-				<div class="settings-card">
-					<div class="settings-header">
-						<h2>Settings</h2>
-						<button @click=${() => this.close()}>✕</button>
+			<div class="settings-view-root">
+				<div class="settings-view-header">
+					<div class="settings-view-title-wrap">
+						<div class="settings-view-title">Settings</div>
+						<div class="settings-view-meta">Desktop configuration and runtime preferences.</div>
 					</div>
-
-					<div class="settings-section">
-						<div class="settings-section-title">Appearance</div>
-						<div class="theme-grid">
-							<button class="theme-btn ${this.state.theme === "dark" ? "active" : ""}" @click=${() => this.setTheme("dark")}>Dark</button>
-							<button class="theme-btn ${this.state.theme === "light" ? "active" : ""}" @click=${() => this.setTheme("light")}>Light</button>
-						</div>
-					</div>
-
-					<div class="settings-section">
-						<div class="settings-section-title">Assistant</div>
-						${this.renderToggle(
-							"Auto-compaction",
-							"Summarize older context automatically when conversations get long.",
-							this.state.autoCompactionEnabled,
-							(v) => this.setAutoCompaction(v),
-						)}
-						${this.renderToggle(
-							"Auto-retry",
-							"Retry temporary provider errors automatically.",
-							this.state.autoRetryEnabled,
-							(v) => this.setAutoRetry(v),
-						)}
-					</div>
-
-					<div class="settings-section">
-						<div class="settings-section-title">Message queue</div>
-						<div class="settings-row">
-							<div>
-								<div class="settings-label">Steering messages</div>
-								<div class="settings-desc">How queued steering messages are sent while a response is streaming.</div>
-							</div>
-							<select class="settings-select" .value=${this.state.steeringMode} @change=${(e: Event) => this.setSteeringMode((e.target as HTMLSelectElement).value as QueueMode)}>
-								<option value="one-at-a-time">One at a time</option>
-								<option value="all">All queued</option>
-							</select>
-						</div>
-						<div class="settings-row">
-							<div>
-								<div class="settings-label">Follow-up messages</div>
-								<div class="settings-desc">How queued follow-up prompts are sent after each run.</div>
-							</div>
-							<select class="settings-select" .value=${this.state.followUpMode} @change=${(e: Event) => this.setFollowUpMode((e.target as HTMLSelectElement).value as QueueMode)}>
-								<option value="one-at-a-time">One at a time</option>
-								<option value="all">All queued</option>
-							</select>
-						</div>
-					</div>
-
-					<div class="settings-section">
-						<div class="settings-section-title">Account</div>
-						${this.authLoading
-							? html`<div class="settings-desc">Checking account status…</div>`
-							: html`
-								<div class="settings-desc">
-									${this.authStatus && this.authStatus.configured_providers.length > 0
-										? `Connected providers: ${this.authStatus.configured_providers.length}`
-										: "No provider connected yet."}
-								</div>
-								<div class="settings-actions">
-									<button class="ghost-btn" @click=${() => this.refreshAuthStatus()}>Refresh account status</button>
-								</div>
-								${this.authStatus && this.authStatus.configured_providers.length > 0
-									? html`
-										<div class="account-chips">
-											${this.authStatus.configured_providers.map(
-												(p) => html`<span class="account-chip">${p.provider} · ${p.source === "environment" ? "env" : p.kind}</span>`,
-											)}
-										</div>
-									`
-									: null}
-								<div class="settings-desc">Tip: run <code>/login</code> in terminal once, then restart desktop.</div>
-								${this.authStatus?.auth_file
-									? html`
-										<details class="settings-advanced">
-											<summary>Advanced account details</summary>
-											<div class="settings-desc">Auth file: <code>${this.authStatus.auth_file}</code></div>
-										</details>
-									`
-									: null}
-							`}
-					</div>
-
-					<div class="settings-section">
-						<div class="settings-section-title">Package configuration</div>
-						<div class="settings-desc">
-							Package-specific settings are managed in <strong>Packages</strong> (gear icon on installed packages).
-						</div>
-						<div class="settings-desc">
-							Desktop stays capability-driven: packages can expose config commands, and those run via the normal chat/runtime flow.
-						</div>
-					</div>
-
-					<div class="settings-section">
-						<div class="settings-section-title">Desktop updates</div>
-						${this.desktopLoading
-							? html`<div class="settings-desc">Checking desktop release…</div>`
-							: html`
-								<div class="settings-desc">
-									Current: <code>${this.desktopStatus?.currentVersion || "unknown"}</code>
-									 · Latest: <code>${this.desktopStatus?.latestVersion || "unknown"}</code>
-								</div>
-								${this.desktopStatus
-									? this.desktopStatus.updateAvailable
-										? html`<div class="settings-desc">A newer Pi Desktop release is available.</div>`
-										: html`<div class="settings-desc">No desktop update available right now.</div>`
-									: html`<div class="settings-desc">Desktop update status unavailable. Check your network and try again.</div>`}
-								${this.desktopStatus?.assetName
-									? html`<div class="settings-desc">Recommended installer: <code>${this.desktopStatus.assetName}</code></div>`
-									: null}
-								${this.desktopStatus?.note ? html`<div class="settings-desc">${this.desktopStatus.note}</div>` : null}
-							`}
-						<div class="settings-actions">
-							<button class="ghost-btn" ?disabled=${this.desktopLoading} @click=${() => this.refreshDesktopStatus()}>Refresh desktop status</button>
-							<button
-								class="ghost-btn"
-								?disabled=${this.desktopOpening || !this.desktopStatus?.updateAvailable}
-								@click=${() => this.openDesktopUpdateNow()}
-							>
-								${this.desktopOpening
-									? "Opening…"
-									: this.desktopStatus?.assetUrl
-										? "Download desktop update"
-										: "Open release page"}
-							</button>
-						</div>
-						${this.desktopActionMessage ? html`<div class="settings-desc">${this.desktopActionMessage}</div>` : null}
-					</div>
-
-					<div class="settings-section">
-						<div class="settings-section-title">CLI updates</div>
-						${this.cliLoading
-							? html`<div class="settings-desc">Checking CLI version…</div>`
-							: html`
-								<div class="settings-desc">
-									Current: <code>${this.cliStatus?.current_version || "unknown"}</code>
-									 · Latest: <code>${this.cliStatus?.latest_version || "unknown"}</code>
-								</div>
-								${this.cliStatus
-									? this.cliStatus.update_available
-										? html`<div class="settings-desc">A newer Pi CLI is available.</div>`
-										: html`<div class="settings-desc">No update available right now.</div>`
-									: html`<div class="settings-desc">CLI status unavailable. Install or reconnect CLI, then refresh.</div>`}
-								${this.cliStatus?.note ? html`<div class="settings-desc">${this.cliStatus.note}</div>` : null}
-							`}
-						<div class="settings-actions">
-							<button class="ghost-btn" ?disabled=${this.cliLoading} @click=${() => this.refreshCliStatus()}>Refresh CLI status</button>
-							<button
-								class="ghost-btn"
-								?disabled=${
-									this.cliUpdating ||
-									!this.cliStatus?.can_update_in_app ||
-									!this.cliStatus?.npm_available ||
-									!this.cliStatus?.update_available
-								}
-								@click=${() => this.updateCliNow()}
-							>
-								${this.cliUpdating ? "Updating…" : "Update CLI now"}
-							</button>
-						</div>
-						${this.cliActionMessage ? html`<div class="settings-desc">${this.cliActionMessage}</div>` : null}
-						<details class="settings-advanced">
-							<summary>Advanced CLI diagnostics</summary>
-							<div class="settings-desc">
-								Discovery: <code>${this.cliStatus?.discovery || rpcBridge.discoveryInfo || "unknown"}</code>
-							</div>
-							${this.cliStatus?.update_command
-								? html`<div class="settings-desc">Manual update: <code>${this.cliStatus.update_command}</code></div>`
-								: null}
-							<div class="settings-actions">
-								<button class="ghost-btn" ?disabled=${this.compatibilityLoading} @click=${() => this.refreshCompatibilityStatus()}>
-									${this.compatibilityLoading ? "Checking RPC…" : "Run RPC compatibility check"}
-								</button>
-							</div>
-							${this.compatibilityReport
-								? html`
-									<div class="settings-desc">
-										RPC compatibility: ${this.compatibilityReport.ok ? "OK" : "Failed"}
-										${this.compatibilityReport.checks.length > 0
-											? html` (${this.compatibilityReport.checks.join(", ")})`
-											: null}
-									</div>
-									${this.compatibilityReport.error
-										? html`<div class="settings-desc">${this.compatibilityReport.error}</div>`
-										: null}
-								`
-								: null}
-						</details>
+					<div class="settings-view-header-actions">
+						<button class="settings-back-btn" @click=${() => this.close()}>← Back</button>
 					</div>
 				</div>
+
+				<div class="settings-view-body">
+					<div class="settings-view-grid">
+						<section class="settings-group settings-group-full">
+							<div class="settings-section">
+								<div class="settings-section-title">Appearance</div>
+								<div class="appearance-theme-block">
+									<div class="appearance-theme-header-row">
+										<div>
+											<div class="settings-label">Theme</div>
+											<div class="settings-desc">Use light, dark, or match your system.</div>
+										</div>
+										<div class="theme-grid">
+											<button class="theme-btn ${this.state.theme === "light" ? "active" : ""}" @click=${() => this.setTheme("light")}>Light</button>
+											<button class="theme-btn ${this.state.theme === "dark" ? "active" : ""}" @click=${() => this.setTheme("dark")}>Dark</button>
+											<button class="theme-btn ${this.state.theme === "system" ? "active" : ""}" @click=${() => this.setTheme("system")}>System</button>
+										</div>
+									</div>
+									${this.themeCatalogLoading ? html`<div class="settings-desc">Loading available Pi themes…</div>` : nothing}
+									${this.themeCatalogError ? html`<div class="settings-desc">Theme catalog error: ${this.themeCatalogError}</div>` : nothing}
+									${this.themeCatalogMessage ? html`<div class="settings-desc">${this.themeCatalogMessage}</div>` : nothing}
+									${this.renderThemeProfileCard("light")}
+									${this.renderThemeProfileCard("dark")}
+								</div>
+							</div>
+						</section>
+
+						<section class="settings-group">
+							<div class="settings-section">
+								<div class="settings-section-title">Assistant</div>
+								${this.renderToggle(
+									"Auto-compaction",
+									"Summarize older context automatically when conversations get long.",
+									this.state.autoCompactionEnabled,
+									(v) => this.setAutoCompaction(v),
+								)}
+								${this.renderToggle(
+									"Auto-retry",
+									"Retry temporary provider errors automatically.",
+									this.state.autoRetryEnabled,
+									(v) => this.setAutoRetry(v),
+								)}
+							</div>
+							<div class="settings-section">
+								<div class="settings-section-title">Message queue</div>
+								<div class="settings-row">
+									<div>
+										<div class="settings-label">Steering messages</div>
+										<div class="settings-desc">How queued steering messages are sent while a response is streaming.</div>
+									</div>
+									<select class="settings-select" .value=${this.state.steeringMode} @change=${(e: Event) => this.setSteeringMode((e.target as HTMLSelectElement).value as QueueMode)}>
+										<option value="one-at-a-time">One at a time</option>
+										<option value="all">All queued</option>
+									</select>
+								</div>
+								<div class="settings-row">
+									<div>
+										<div class="settings-label">Follow-up messages</div>
+										<div class="settings-desc">How queued follow-up prompts are sent after each run.</div>
+									</div>
+									<select class="settings-select" .value=${this.state.followUpMode} @change=${(e: Event) => this.setFollowUpMode((e.target as HTMLSelectElement).value as QueueMode)}>
+										<option value="one-at-a-time">One at a time</option>
+										<option value="all">All queued</option>
+									</select>
+								</div>
+							</div>
+						</section>
+
+						<section class="settings-group">
+							<div class="settings-section">
+								<div class="settings-section-title">Account</div>
+								${this.authLoading
+									? html`<div class="settings-desc">Checking account status…</div>`
+									: html`
+										<div class="settings-desc">
+											${this.authStatus && this.authStatus.configured_providers.length > 0
+												? `Connected providers: ${this.authStatus.configured_providers.length}`
+												: "No provider connected yet."}
+										</div>
+										<div class="settings-actions">
+											<button class="ghost-btn" @click=${() => this.refreshAuthStatus()}>Refresh account status</button>
+										</div>
+										${this.authStatus && this.authStatus.configured_providers.length > 0
+											? html`
+												<div class="account-chips">
+													${this.authStatus.configured_providers.map(
+														(p) => html`<span class="account-chip">${p.provider} · ${p.source === "environment" ? "env" : p.kind}</span>`,
+													)}
+												</div>
+											`
+											: null}
+										<div class="settings-desc">Tip: run <code>/login</code> in terminal once, then restart desktop.</div>
+										${this.authStatus?.auth_file
+											? html`
+												<details class="settings-advanced">
+													<summary>Advanced account details</summary>
+													<div class="settings-desc">Auth file: <code>${this.authStatus.auth_file}</code></div>
+												</details>
+											`
+											: null}
+									`}
+							</div>
+							<div class="settings-section">
+								<div class="settings-section-title">Package configuration</div>
+								<div class="settings-desc">Package-specific settings are managed in <strong>Packages</strong> (gear icon on installed packages).</div>
+								<div class="settings-desc">Desktop stays capability-driven: packages can expose config commands, and those run via the normal chat/runtime flow.</div>
+							</div>
+						</section>
+
+						<section class="settings-group settings-group-full">
+							<div class="settings-section">
+								<div class="settings-section-title">Desktop updates</div>
+								${this.desktopLoading
+									? html`<div class="settings-desc">Checking desktop release…</div>`
+									: html`
+										<div class="settings-desc">Current: <code>${this.desktopStatus?.currentVersion || "unknown"}</code> · Latest: <code>${this.desktopStatus?.latestVersion || "unknown"}</code></div>
+										${this.desktopStatus
+											? this.desktopStatus.updateAvailable
+												? html`<div class="settings-desc">A newer Pi Desktop release is available.</div>`
+												: html`<div class="settings-desc">No desktop update available right now.</div>`
+											: html`<div class="settings-desc">Desktop update status unavailable. Check your network and try again.</div>`}
+										${this.desktopStatus?.assetName ? html`<div class="settings-desc">Recommended installer: <code>${this.desktopStatus.assetName}</code></div>` : null}
+										${this.desktopStatus?.note ? html`<div class="settings-desc">${this.desktopStatus.note}</div>` : null}
+									`}
+								<div class="settings-actions">
+									<button class="ghost-btn" ?disabled=${this.desktopLoading} @click=${() => this.refreshDesktopStatus()}>Refresh desktop status</button>
+									<button class="ghost-btn" ?disabled=${this.desktopOpening || !this.desktopStatus?.updateAvailable} @click=${() => this.openDesktopUpdateNow()}>
+										${this.desktopOpening ? "Opening…" : this.desktopStatus?.assetUrl ? "Download desktop update" : "Open release page"}
+									</button>
+								</div>
+								${this.desktopActionMessage ? html`<div class="settings-desc">${this.desktopActionMessage}</div>` : null}
+							</div>
+
+							<div class="settings-section">
+								<div class="settings-section-title">CLI updates</div>
+								${this.cliLoading
+									? html`<div class="settings-desc">Checking CLI version…</div>`
+									: html`
+										<div class="settings-desc">Current: <code>${this.cliStatus?.current_version || "unknown"}</code> · Latest: <code>${this.cliStatus?.latest_version || "unknown"}</code></div>
+										${this.cliStatus
+											? this.cliStatus.update_available
+												? html`<div class="settings-desc">A newer Pi CLI is available.</div>`
+												: html`<div class="settings-desc">No update available right now.</div>`
+											: html`<div class="settings-desc">CLI status unavailable. Install or reconnect CLI, then refresh.</div>`}
+										${this.cliStatus?.note ? html`<div class="settings-desc">${this.cliStatus.note}</div>` : null}
+									`}
+								<div class="settings-actions">
+									<button class="ghost-btn" ?disabled=${this.cliLoading} @click=${() => this.refreshCliStatus()}>Refresh CLI status</button>
+									<button
+										class="ghost-btn"
+										?disabled=${
+											this.cliUpdating ||
+											!this.cliStatus?.can_update_in_app ||
+											!this.cliStatus?.npm_available ||
+											!this.cliStatus?.update_available
+										}
+										@click=${() => this.updateCliNow()}
+									>
+										${this.cliUpdating ? "Updating…" : "Update CLI now"}
+									</button>
+								</div>
+								${this.cliActionMessage ? html`<div class="settings-desc">${this.cliActionMessage}</div>` : null}
+								<details class="settings-advanced">
+									<summary>Advanced CLI diagnostics</summary>
+									<div class="settings-desc">Discovery: <code>${this.cliStatus?.discovery || rpcBridge.discoveryInfo || "unknown"}</code></div>
+									${this.cliStatus?.update_command ? html`<div class="settings-desc">Manual update: <code>${this.cliStatus.update_command}</code></div>` : null}
+									<div class="settings-actions">
+										<button class="ghost-btn" ?disabled=${this.compatibilityLoading} @click=${() => this.refreshCompatibilityStatus()}>
+											${this.compatibilityLoading ? "Checking RPC…" : "Run RPC compatibility check"}
+										</button>
+									</div>
+									${this.compatibilityReport
+										? html`
+											<div class="settings-desc">
+												RPC compatibility: ${this.compatibilityReport.ok ? "OK" : "Failed"}
+												${this.compatibilityReport.checks.length > 0 ? html` (${this.compatibilityReport.checks.join(", ")})` : null}
+											</div>
+											${this.compatibilityReport.error ? html`<div class="settings-desc">${this.compatibilityReport.error}</div>` : null}
+										`
+										: null}
+								</details>
+							</div>
+						</section>
+					</div>
+				</div>
+				${this.renderCreateThemeDialog()}
 			</div>
 		`;
 

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -67,7 +67,7 @@ interface FileNode {
 
 type SidebarContextTarget =
 	| { kind: "session"; projectId: string; sessionPath: string }
-	| { kind: "file"; projectId: string; filePath: string }
+	| { kind: "file"; projectId: string; filePath: string; isDirectory: boolean }
 	| { kind: "workspace"; workspaceId: string };
 
 const LEGACY_STORAGE_KEY = "pi-desktop.projects.v1";
@@ -115,6 +115,19 @@ function joinFsPath(base: string, name: string): string {
 	const sep = base.includes("\\") ? "\\" : "/";
 	const normalizedBase = base.replace(/[\\/]+$/, "");
 	return `${normalizedBase}${sep}${name}`;
+}
+
+function parentFsPath(path: string): string {
+	const trimmed = path.replace(/[\\/]+$/, "");
+	if (!trimmed) return "";
+	const parent = trimmed.replace(/[\\/][^\\/]+$/, "");
+	if (parent && parent !== trimmed) {
+		if (/^[A-Za-z]:$/.test(parent)) return `${parent}\\`;
+		return parent;
+	}
+	if (/^[A-Za-z]:[\\/]/.test(trimmed)) return `${trimmed.slice(0, 2)}\\`;
+	if (trimmed.startsWith("/")) return "/";
+	return parent || trimmed;
 }
 
 function isAbsolutePath(path: string): boolean {
@@ -207,6 +220,7 @@ export class Sidebar {
 	private projectEmojiPickerX = 0;
 	private projectEmojiPickerY = 0;
 	private projectEmojiSearchQuery = "";
+	private projectEmojiPortalHost: HTMLElement | null = null;
 	private pendingProjectDragId: string | null = null;
 	private draggingProjectId: string | null = null;
 	private projectDragOverId: string | null = null;
@@ -257,7 +271,8 @@ export class Sidebar {
 	private onSessionFork: ((projectId: string, sessionPath: string, sessionName?: string) => void) | null = null;
 	private onSessionMarkUnread: ((projectId: string, sessionPath: string, sessionName?: string) => void) | null = null;
 	private onNewSessionInProject: ((project: { id: string; name: string; path: string }) => void) | null = null;
-	private onNewFileInProject: ((project: { id: string; name: string; path: string }) => void) | null = null;
+	private onNewFileInProject: ((project: { id: string; name: string; path: string; directoryPath?: string | null; anchorPath?: string | null }) => void) | null = null;
+	private newFilePlacementHint: { projectId: string; anchorPath: string; newPath: string; expiresAt: number } | null = null;
 	private onFileOpen: ((projectId: string, filePath: string) => void) | null = null;
 	private onFileDelete: ((projectId: string, filePath: string) => void) | null = null;
 	private onModeChange: ((mode: SidebarMode) => void) | null = null;
@@ -485,7 +500,7 @@ export class Sidebar {
 		this.onNewSessionInProject = cb;
 	}
 
-	setOnNewFileInProject(cb: (project: { id: string; name: string; path: string }) => void): void {
+	setOnNewFileInProject(cb: (project: { id: string; name: string; path: string; directoryPath?: string | null; anchorPath?: string | null }) => void): void {
 		this.onNewFileInProject = cb;
 	}
 
@@ -514,9 +529,25 @@ export class Sidebar {
 		}
 	}
 
+	private readonly onWindowContextMenuPointerDown = (event: PointerEvent): void => {
+		if (!this.contextMenu) return;
+		const target = event.target instanceof Element ? event.target : null;
+		if (target?.closest(".sidebar-context-menu")) return;
+		this.closeContextMenu();
+	};
+
+	private readonly onWindowContextMenuMouseDown = (event: MouseEvent): void => {
+		if (!this.contextMenu) return;
+		const target = event.target instanceof Element ? event.target : null;
+		if (target?.closest(".sidebar-context-menu")) return;
+		this.closeContextMenu();
+	};
+
 	private closeContextMenu(shouldRender = true): void {
 		if (!this.contextMenu) return;
 		this.contextMenu = null;
+		window.removeEventListener("pointerdown", this.onWindowContextMenuPointerDown, true);
+		window.removeEventListener("mousedown", this.onWindowContextMenuMouseDown, true);
 		if (shouldRender) this.render();
 	}
 
@@ -524,13 +555,28 @@ export class Sidebar {
 		e.preventDefault();
 		e.stopPropagation();
 		const menuWidth = 170;
-		const menuHeight = target.kind === "workspace" ? 92 : target.kind === "session" ? 194 : 92;
+		const menuHeight = target.kind === "workspace"
+			? 92
+			: target.kind === "session"
+				? 194
+				: target.isDirectory
+					? 52
+					: 122;
 		const padding = 8;
-		const x = Math.max(padding, Math.min(e.clientX, window.innerWidth - menuWidth - padding));
-		const y = Math.max(padding, Math.min(e.clientY, window.innerHeight - menuHeight - padding));
+		const bounds = this.container.getBoundingClientRect();
+		const minX = Math.max(padding, Math.floor(bounds.left + padding));
+		const maxX = Math.min(window.innerWidth - menuWidth - padding, Math.floor(bounds.right - menuWidth - padding));
+		const minY = Math.max(padding, Math.floor(bounds.top + padding));
+		const maxY = Math.min(window.innerHeight - menuHeight - padding, Math.floor(bounds.bottom - menuHeight - padding));
+		const x = Math.max(minX, Math.min(e.clientX, Math.max(minX, maxX)));
+		const y = Math.max(minY, Math.min(e.clientY, Math.max(minY, maxY)));
 		this.closeWorkspaceEmojiPicker(false);
 		this.closeProjectEmojiPicker(false);
 		this.contextMenu = { x, y, target };
+		window.removeEventListener("pointerdown", this.onWindowContextMenuPointerDown, true);
+		window.removeEventListener("mousedown", this.onWindowContextMenuMouseDown, true);
+		window.addEventListener("pointerdown", this.onWindowContextMenuPointerDown, true);
+		window.addEventListener("mousedown", this.onWindowContextMenuMouseDown, true);
 		this.render();
 	}
 
@@ -823,6 +869,19 @@ export class Sidebar {
 		void this.ensureFileTreeForProject(active.id, forceReload);
 	}
 
+	setNewFilePlacementHint(projectId: string, newFilePath: string, anchorPath: string): void {
+		const normalizedProjectId = projectId.trim();
+		const normalizedNewPath = normalizePath(newFilePath);
+		const normalizedAnchorPath = normalizePath(anchorPath);
+		if (!normalizedProjectId || !normalizedNewPath || !normalizedAnchorPath) return;
+		this.newFilePlacementHint = {
+			projectId: normalizedProjectId,
+			newPath: normalizedNewPath,
+			anchorPath: normalizedAnchorPath,
+			expiresAt: Date.now() + 120_000,
+		};
+	}
+
 	// Legacy compatibility for existing keybindings in main.ts
 	setActiveView(_view: string): void {
 		// no-op
@@ -879,6 +938,12 @@ export class Sidebar {
 	private async createFileInActiveProject(): Promise<void> {
 		const project = this.getActiveProject();
 		if (!project) return;
+		await this.createFileInDirectory(project.id, project.path);
+	}
+
+	private async createFileInDirectory(projectId: string, directoryPath: string): Promise<void> {
+		const project = this.projects.find((entry) => entry.id === projectId) ?? null;
+		if (!project) return;
 
 		const input = window.prompt("New file name", "new-file.txt")?.trim();
 		if (!input) return;
@@ -887,7 +952,8 @@ export class Sidebar {
 			return;
 		}
 
-		const filePath = joinFsPath(project.path, input);
+		const targetDir = directoryPath || project.path;
+		const filePath = joinFsPath(targetDir, input);
 		try {
 			const { exists, writeTextFile } = await import("@tauri-apps/plugin-fs");
 			if (await exists(filePath)) {
@@ -896,8 +962,8 @@ export class Sidebar {
 			}
 
 			await writeTextFile(filePath, "");
-			await this.ensureFileTreeForProject(project.id, true);
-			this.openFile(project.id, filePath);
+			await this.ensureFileTreeForProject(projectId, true);
+			this.openFile(projectId, filePath);
 		} catch (err) {
 			console.error("Failed to create file:", err);
 			window.alert(err instanceof Error ? err.message : String(err));
@@ -1062,12 +1128,11 @@ export class Sidebar {
 	}
 
 	private handleFileContextMenu(e: MouseEvent, projectId: string, node: FileNode): void {
-		if (node.isDirectory) return;
 		this.selectProject(projectId, false);
 		this.activeSessionPath = null;
-		this.activeFilePath = normalizePath(node.path);
+		this.activeFilePath = node.isDirectory ? null : normalizePath(node.path);
 		this.clearInlineDrafts();
-		this.openContextMenu(e, { kind: "file", projectId, filePath: node.path });
+		this.openContextMenu(e, { kind: "file", projectId, filePath: node.path, isDirectory: node.isDirectory });
 	}
 
 	private handleWorkspaceContextMenu(e: MouseEvent, workspaceId: string): void {
@@ -1077,7 +1142,7 @@ export class Sidebar {
 	private runSessionContextAction(action: "rename" | "delete" | "fork" | "markUnread" | "togglePin"): void {
 		const target = this.contextMenu?.target;
 		if (!target || target.kind !== "session") return;
-		this.closeContextMenu(false);
+		this.closeContextMenu();
 		const found = this.findSession(target.projectId, target.sessionPath);
 		if (!found) {
 			this.render();
@@ -1103,10 +1168,26 @@ export class Sidebar {
 		void this.deleteSession(found.project, found.session);
 	}
 
-	private runFileContextAction(action: "rename" | "delete"): void {
+	private runFileContextAction(action: "newFile" | "rename" | "delete"): void {
 		const target = this.contextMenu?.target;
 		if (!target || target.kind !== "file") return;
-		this.closeContextMenu(false);
+		this.closeContextMenu();
+		if (action === "newFile") {
+			const project = this.projects.find((entry) => entry.id === target.projectId) ?? null;
+			if (!project) {
+				this.render();
+				return;
+			}
+			const baseDir = target.isDirectory ? target.filePath : parentFsPath(target.filePath);
+			this.onNewFileInProject?.({
+				id: project.id,
+				name: project.name,
+				path: project.path,
+				directoryPath: baseDir,
+				anchorPath: target.isDirectory ? null : target.filePath,
+			});
+			return;
+		}
 		const node = this.findFileNode(target.projectId, target.filePath);
 		if (!node) {
 			this.render();
@@ -1122,7 +1203,7 @@ export class Sidebar {
 	private runWorkspaceContextAction(action: "rename" | "delete"): void {
 		const target = this.contextMenu?.target;
 		if (!target || target.kind !== "workspace") return;
-		this.closeContextMenu(false);
+		this.closeContextMenu();
 		const workspace = this.workspaces.find((entry) => entry.id === target.workspaceId) ?? null;
 		if (!workspace) {
 			this.render();
@@ -1162,10 +1243,18 @@ export class Sidebar {
 				</div>
 			`;
 		} else if (target.kind === "file") {
+			const node = this.findFileNode(target.projectId, target.filePath);
+			const isDirectory = node?.isDirectory ?? target.isDirectory;
 			menuContent = html`
 				<div class="sidebar-context-menu" style=${`left:${menu.x}px;top:${menu.y}px`} @click=${(e: Event) => e.stopPropagation()}>
-					<button @click=${() => this.runFileContextAction("rename")}>Rename file</button>
-					<button class="danger" @click=${() => this.runFileContextAction("delete")}>Delete file</button>
+					<button @click=${() => this.runFileContextAction("newFile")}>New file</button>
+					${isDirectory
+						? nothing
+						: html`
+							<div class="sidebar-context-menu-divider"></div>
+							<button @click=${() => this.runFileContextAction("rename")}>Rename file</button>
+							<button class="danger" @click=${() => this.runFileContextAction("delete")}>Delete file</button>
+						`}
 				</div>
 			`;
 		} else {
@@ -1976,6 +2065,25 @@ export class Sidebar {
 	}
 
 	private compareFileNodes(a: FileNode, b: FileNode): number {
+		const hint = this.newFilePlacementHint;
+		if (hint && Date.now() > hint.expiresAt) {
+			this.newFilePlacementHint = null;
+		}
+		if (hint && this.activeProjectId === hint.projectId) {
+			const aPath = normalizePath(a.path);
+			const bPath = normalizePath(b.path);
+			const matchesPair =
+				(aPath === hint.newPath && bPath === hint.anchorPath) ||
+				(aPath === hint.anchorPath && bPath === hint.newPath);
+			if (matchesPair) {
+				const aParent = normalizePath(parentFsPath(a.path));
+				const bParent = normalizePath(parentFsPath(b.path));
+				const hintParent = normalizePath(parentFsPath(hint.newPath));
+				if (aParent && aParent === bParent && aParent === hintParent) {
+					return aPath === hint.newPath ? 1 : -1;
+				}
+			}
+		}
 		if (this.fileKind === "all" && a.isDirectory !== b.isDirectory) {
 			return a.isDirectory ? -1 : 1;
 		}
@@ -2978,13 +3086,6 @@ export class Sidebar {
 				class="sidebar-workspace-header"
 				@contextmenu=${(e: MouseEvent) => this.handleWorkspaceContextMenu(e, activeWorkspace.id)}
 			>
-				<button
-					class="sidebar-workspace-header-emoji"
-					title="Change workspace emoji"
-					@click=${(e: MouseEvent) => this.openWorkspaceEmojiPicker(activeWorkspace.id, e)}
-				>
-					<span class="sidebar-workspace-avatar">${activeWorkspace.emoji || "💼"}</span>
-				</button>
 				<div class="sidebar-workspace-header-main">
 					${isRenaming
 						? html`
@@ -3032,12 +3133,8 @@ export class Sidebar {
 					}}
 				>
 					<svg class="sidebar-icon-svg" viewBox="0 0 16 16" aria-hidden="true">
-						<path d="M2.8 4h10.4" />
-						<path d="M2.8 8h10.4" />
-						<path d="M2.8 12h10.4" />
-						<circle cx="6" cy="4" r="1.1" />
-						<circle cx="10" cy="8" r="1.1" />
-						<circle cx="7" cy="12" r="1.1" />
+						<path d="M6.6 1.9h2.8l.3 1.5c.4.1.7.3 1 .5l1.4-.6 1.4 2.4-1.1 1c.1.4.1.8 0 1.2l1.1 1-1.4 2.4-1.4-.6c-.3.2-.6.4-1 .5l-.3 1.5H6.6l-.3-1.5c-.4-.1-.7-.3-1-.5l-1.4.6-1.4-2.4 1.1-1a3.8 3.8 0 0 1 0-1.2l-1.1-1 1.4-2.4 1.4.6c.3-.2.6-.4 1-.5z" />
+						<circle cx="8" cy="8" r="2.1" />
 					</svg>
 				</button>
 				<div class="sidebar-workspace-dock-list" @click=${(e: Event) => e.stopPropagation()}>
@@ -3202,6 +3299,12 @@ export class Sidebar {
 		const project = this.projects.find((entry) => entry.id === this.projectEmojiPickerProjectId) ?? null;
 		const filteredEmojis = this.filteredProjectEmojis();
 		return html`
+			<button
+				type="button"
+				class="project-emoji-picker-backdrop"
+				aria-label="Close emoji picker"
+				@click=${() => this.closeProjectEmojiPicker()}
+			></button>
 			<div class="workspace-emoji-picker project-emoji-picker" style=${`left:${this.projectEmojiPickerX}px;top:${this.projectEmojiPickerY}px`} @click=${(event: Event) => event.stopPropagation()}>
 				<input
 					class="workspace-emoji-search project-emoji-search"
@@ -3235,6 +3338,22 @@ export class Sidebar {
 				</div>
 			</div>
 		`;
+	}
+
+	private ensureProjectEmojiPortalHost(): HTMLElement | null {
+		if (typeof document === "undefined") return null;
+		if (this.projectEmojiPortalHost && document.body.contains(this.projectEmojiPortalHost)) return this.projectEmojiPortalHost;
+		const host = document.createElement("div");
+		host.className = "sidebar-project-emoji-portal-host";
+		document.body.appendChild(host);
+		this.projectEmojiPortalHost = host;
+		return host;
+	}
+
+	private renderProjectEmojiPickerPortal(): void {
+		const host = this.ensureProjectEmojiPortalHost();
+		if (!host) return;
+		render(this.renderProjectEmojiPicker(), host);
 	}
 
 	private renderSessionPiIcon(running = false): TemplateResult | typeof nothing {
@@ -3271,7 +3390,7 @@ export class Sidebar {
 
 		return html`
 			<div class="sidebar-chrono-list">
-				${rows.map(({ project, session }) => {
+				${rows.map(({ project, session }, index) => {
 					const ts = this.sessionSortBy === "created" ? session.createdAt || session.modifiedAt : session.modifiedAt || session.createdAt;
 					const normalizedSessionPath = normalizePath(session.path);
 					const activeSession = normalizedSessionPath
@@ -3280,7 +3399,10 @@ export class Sidebar {
 					const runningSession = this.runningSessionPaths.has(normalizedSessionPath);
 					const attentionMessage = this.attentionSessionMessages.get(normalizedSessionPath) ?? null;
 					const pinnedSession = this.isSessionPinned(session.path);
+					const prevPinned = index > 0 ? this.isSessionPinned(rows[index - 1]?.session.path ?? "") : false;
+					const showPinnedDivider = prevPinned && !pinnedSession;
 					return html`
+						${showPinnedDivider ? html`<div class="sidebar-session-pin-divider" role="separator" aria-hidden="true"></div>` : nothing}
 						<button
 							class="sidebar-chrono-row ${activeSession ? "active-session" : ""} ${pinnedSession ? "pinned" : ""}"
 							@click=${() => {
@@ -3298,7 +3420,6 @@ export class Sidebar {
 							<span class="sidebar-session-leading">
 								${this.renderSessionPiIcon(runningSession)}
 							</span>
-							${pinnedSession ? html`<span class="sidebar-session-pin" title="Pinned session">📌</span>` : nothing}
 							<span class="sidebar-chrono-main">
 								<span class="sidebar-chrono-name sidebar-session-name ${attentionMessage ? "needs-attention" : ""}">${session.name}</span>
 								<span class="sidebar-chrono-project">${project.name}</span>
@@ -3408,7 +3529,7 @@ export class Sidebar {
 											: sessions.length === 0
 												? html`<div class="sidebar-empty">${this.sessionShow === "relevant" ? "No relevant sessions." : "No sessions yet."}</div>`
 												: sessions.map(
-                                                    (session) => {
+                                                    (session, index) => {
                                                         const normalizedSessionPath = normalizePath(session.path);
                                                         const activeSession = normalizedSessionPath
                                                             ? normalizedSessionPath === this.activeSessionPath
@@ -3416,16 +3537,18 @@ export class Sidebar {
                                                         const runningSession = this.runningSessionPaths.has(normalizedSessionPath);
                                                         const attentionMessage = this.attentionSessionMessages.get(normalizedSessionPath) ?? null;
                                                         const pinnedSession = this.isSessionPinned(session.path);
+                                                        const prevPinned = index > 0 ? this.isSessionPinned(sessions[index - 1]?.path ?? "") : false;
+                                                        const showPinnedDivider = prevPinned && !pinnedSession;
                                                         const sessionRenameActive =
                                                             Boolean(this.sessionRenameDraft) &&
                                                             this.sessionRenameDraft?.projectId === project.id &&
                                                             this.sessionRenameDraft?.sessionPath === normalizePath(session.path);
                                                         return html`
+                                                            ${showPinnedDivider ? html`<div class="sidebar-session-pin-divider" role="separator" aria-hidden="true"></div>` : nothing}
                                                             <div class="sidebar-session-row ${activeSession ? "active" : ""} ${pinnedSession ? "pinned" : ""}">
                                                                 <span class="sidebar-session-leading">
                                                                     ${this.renderSessionPiIcon(runningSession)}
                                                                 </span>
-                                                                ${pinnedSession ? html`<span class="sidebar-session-pin" title="Pinned session">📌</span>` : nothing}
                                                                 <button
                                                                     class="sidebar-session ${activeSession ? "active-session" : ""}"
                                                                     @click=${() => {
@@ -3660,32 +3783,32 @@ export class Sidebar {
 				class="sidebar-single"
 				@wheel=${(e: WheelEvent) => this.handleSidebarWheel(e)}
 				@click=${(e: Event) => {
-					const target = e.target as HTMLElement;
+					const target = e.target instanceof Element ? e.target : null;
 					let changed = false;
 
-					if (this.openProjectMenuId && !target.closest(".sidebar-project-menu") && !target.closest(".sidebar-project-action.menu")) {
+					if (this.openProjectMenuId && !target?.closest(".sidebar-project-menu") && !target?.closest(".sidebar-project-action.menu")) {
 						this.openProjectMenuId = null;
 						changed = true;
 					}
 
-					if (this.modeFilterMenuOpen && !target.closest(".sidebar-mode-filter-menu") && !target.closest(".sidebar-mode-filter-btn")) {
+					if (this.modeFilterMenuOpen && !target?.closest(".sidebar-mode-filter-menu") && !target?.closest(".sidebar-mode-filter-btn")) {
 						this.modeFilterMenuOpen = false;
 						changed = true;
 					}
 
-					if ((this.pendingProjectDragId || this.draggingProjectId) && !target.closest(".sidebar-project-list")) {
+					if ((this.pendingProjectDragId || this.draggingProjectId) && !target?.closest(".sidebar-project-list")) {
 						this.cancelProjectPointerDrag(false);
 						changed = true;
 					}
 
-					if ((this.pendingWorkspaceDragId || this.draggingWorkspaceId) && !target.closest(".sidebar-workspace-dock")) {
+					if ((this.pendingWorkspaceDragId || this.draggingWorkspaceId) && !target?.closest(".sidebar-workspace-dock")) {
 						this.cancelWorkspacePointerDrag(false);
 						changed = true;
 					}
 
 					if (
 						this.workspaceRenameDraft &&
-						!target.closest(".sidebar-workspace-title-input")
+						!target?.closest(".sidebar-workspace-title-input")
 					) {
 						this.commitWorkspaceRename();
 						return;
@@ -3693,8 +3816,8 @@ export class Sidebar {
 
 					if (
 						this.workspaceCreateDialogOpen &&
-						!target.closest(".sidebar-space-dialog") &&
-						!target.closest(".sidebar-workspace-dock-add")
+						!target?.closest(".sidebar-space-dialog") &&
+						!target?.closest(".sidebar-workspace-dock-add")
 					) {
 						this.closeWorkspaceCreateDialog(false);
 						changed = true;
@@ -3702,8 +3825,8 @@ export class Sidebar {
 
 					if (
 						this.workspaceCreateEmojiPickerOpen &&
-						!target.closest(".sidebar-space-emoji-picker") &&
-						!target.closest(".sidebar-space-emoji-trigger")
+						!target?.closest(".sidebar-space-emoji-picker") &&
+						!target?.closest(".sidebar-space-emoji-trigger")
 					) {
 						this.workspaceCreateEmojiPickerOpen = false;
 						this.workspaceCreateEmojiQuery = "";
@@ -3712,8 +3835,8 @@ export class Sidebar {
 
 					if (
 						this.emojiPickerWorkspaceId &&
-						!target.closest(".workspace-emoji-picker") &&
-						!target.closest(".sidebar-workspace-header-emoji")
+						!target?.closest(".workspace-emoji-picker") &&
+						!target?.closest(".sidebar-workspace-header-emoji")
 					) {
 						this.closeWorkspaceEmojiPicker(false);
 						changed = true;
@@ -3721,14 +3844,14 @@ export class Sidebar {
 
 					if (
 						this.projectEmojiPickerProjectId &&
-						!target.closest(".project-emoji-picker")
+						!target?.closest(".project-emoji-picker")
 					) {
 						this.closeProjectEmojiPicker(false);
 						changed = true;
 					}
 
-					if (this.contextMenu && !target.closest(".sidebar-context-menu")) {
-						this.contextMenu = null;
+					if (this.contextMenu && !target?.closest(".sidebar-context-menu")) {
+						this.closeContextMenu(false);
 						changed = true;
 					}
 
@@ -3808,11 +3931,11 @@ export class Sidebar {
 
 				${this.renderWorkspaceCreateDialog()}
 				${this.renderWorkspaceEmojiPicker()}
-				${this.renderProjectEmojiPicker()}
 				${this.renderContextMenu()}
 			</div>
 		`;
 
 		render(template, this.container);
+		this.renderProjectEmojiPickerPortal();
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,14 @@ import { TerminalPanel } from "./components/terminal-panel.js";
 import type { WorkspaceTabs } from "./components/workspace-tabs.js";
 import { fetchDesktopUpdateStatus, type DesktopUpdateStatus } from "./desktop-updates.js";
 import { type CliUpdateStatus, RpcBridge, type RpcSessionState, rpcBridge, setActiveRpcBridge } from "./rpc/bridge.js";
+import {
+	applyDesktopAppearanceProfileToRoot,
+	DESKTOP_APPEARANCE_PROFILE_CHANGED_EVENT,
+	loadDesktopAppearanceProfiles,
+} from "./theme/appearance-profiles.js";
+import { syncDesktopThemeWithPiTheme } from "./theme/pi-theme-bridge.js";
+import { DESKTOP_THEME_CHANGED_EVENT, getResolvedDesktopTheme, initializeDesktopTheme, toggleDesktopTheme } from "./theme/theme-manager.js";
+import { ensureBundledThemesInstalled } from "./theme/bundled-themes.js";
 import "./styles/app.css";
 
 interface WorkspaceSessionTab {
@@ -37,6 +45,8 @@ interface WorkspaceFileTab {
 	projectPath: string | null;
 	path: string | null;
 	title: string;
+	draftDirectoryPath: string | null;
+	draftAnchorPath: string | null;
 }
 
 interface WorkspaceState {
@@ -46,7 +56,7 @@ interface WorkspaceState {
 	emoji: string | null;
 	pinned: boolean;
 	leftMode: SidebarMode;
-	pane: "chat" | "file" | "packages" | "terminal";
+	pane: "chat" | "file" | "packages" | "settings" | "terminal";
 	activeProjectId: string | null;
 	activeProjectPath: string | null;
 	filePath: string | null;
@@ -643,12 +653,19 @@ function ensureWorkspaceContentState(workspace: WorkspaceState): void {
 		.map((tab) => {
 			const path = normalizeStoredPath(tab.path);
 			const fallbackTitle = path ? baseName(path) : NEW_FILE_TAB_TITLE;
+			const projectPath = normalizeStoredPath((tab as Partial<WorkspaceFileTab>).projectPath);
+			const draftDirectoryPath = path
+				? null
+				: normalizeStoredPath((tab as Partial<WorkspaceFileTab>).draftDirectoryPath) ?? projectPath;
+			const draftAnchorPath = path ? null : normalizeStoredPath((tab as Partial<WorkspaceFileTab>).draftAnchorPath);
 			return {
 				id: tab.id,
 				projectId: normalizeStoredId((tab as Partial<WorkspaceFileTab>).projectId),
-				projectPath: normalizeStoredPath((tab as Partial<WorkspaceFileTab>).projectPath),
+				projectPath,
 				path,
 				title: typeof tab.title === "string" && tab.title.trim().length > 0 ? tab.title.trim() : fallbackTitle,
+				draftDirectoryPath,
+				draftAnchorPath,
 			};
 		});
 
@@ -664,6 +681,13 @@ function ensureWorkspaceContentState(workspace: WorkspaceState): void {
 	}
 	if (activeFile && isDraftFileTab(activeFile) && !activeFile.projectPath && workspace.activeProjectPath) {
 		setFileTabProject(activeFile, workspace.activeProjectId, workspace.activeProjectPath);
+	}
+	if (activeFile && isDraftFileTab(activeFile) && !activeFile.draftDirectoryPath) {
+		activeFile.draftDirectoryPath = activeFile.projectPath ?? workspace.activeProjectPath;
+	}
+	if (activeFile && !isDraftFileTab(activeFile)) {
+		activeFile.draftDirectoryPath = null;
+		activeFile.draftAnchorPath = null;
 	}
 
 	workspace.activeProjectId = getWorkspaceActiveProjectId(workspace);
@@ -829,10 +853,14 @@ function openOrActivateFileTab(
 			projectPath: normalizeStoredPath(projectPath),
 			path: filePath,
 			title: baseName(filePath),
+			draftDirectoryPath: null,
+			draftAnchorPath: null,
 		};
 		workspace.fileTabs.push(tab);
 	} else {
 		setFileTabProject(tab, projectId, projectPath);
+		tab.draftDirectoryPath = null;
+		tab.draftAnchorPath = null;
 	}
 	workspace.activeFileTabId = tab.id;
 	workspace.filePath = tab.path;
@@ -846,12 +874,18 @@ function createAndActivateEmptyFileTab(
 	title = NEW_FILE_TAB_TITLE,
 	projectId: string | null = workspace.activeProjectId,
 	projectPath: string | null = workspace.activeProjectPath,
+	draftDirectoryPath: string | null = projectPath,
+	draftAnchorPath: string | null = null,
 ): WorkspaceFileTab {
 	ensureWorkspaceContentState(workspace);
+	const normalizedDraftDirectoryPath = normalizeStoredPath(draftDirectoryPath) ?? normalizeStoredPath(projectPath);
+	const normalizedDraftAnchorPath = normalizeStoredPath(draftAnchorPath);
 	const activeDraft = workspace.fileTabs.find((entry) => entry.id === workspace.activeFileTabId && isDraftFileTab(entry));
 	if (activeDraft) {
 		activeDraft.title = title.trim() || NEW_FILE_TAB_TITLE;
 		setFileTabProject(activeDraft, projectId, projectPath);
+		activeDraft.draftDirectoryPath = normalizedDraftDirectoryPath;
+		activeDraft.draftAnchorPath = normalizedDraftAnchorPath;
 		workspace.activeFileTabId = activeDraft.id;
 		workspace.filePath = null;
 		setWorkspaceActiveProject(workspace, { id: activeDraft.projectId, path: activeDraft.projectPath });
@@ -864,6 +898,8 @@ function createAndActivateEmptyFileTab(
 		projectPath: normalizeStoredPath(projectPath),
 		path: null,
 		title: title.trim() || NEW_FILE_TAB_TITLE,
+		draftDirectoryPath: normalizedDraftDirectoryPath,
+		draftAnchorPath: normalizedDraftAnchorPath,
 	};
 	workspace.fileTabs.push(tab);
 	workspace.activeFileTabId = tab.id;
@@ -1388,10 +1424,11 @@ function loadWorkspaces(): void {
 						.filter((tab) => typeof tab.id === "string" && tab.id.length > 0)
 						.map((tab) => {
 							const path = normalizeStoredPath(tab.path);
+							const projectPath = normalizeStoredPath(tab.projectPath);
 							return {
 								id: tab.id!,
 								projectId: normalizeStoredId(tab.projectId),
-								projectPath: normalizeStoredPath(tab.projectPath),
+								projectPath,
 								path,
 								title:
 									typeof tab.title === "string" && tab.title.trim().length > 0
@@ -1399,6 +1436,8 @@ function loadWorkspaces(): void {
 										: path
 											? baseName(path)
 											: NEW_FILE_TAB_TITLE,
+								draftDirectoryPath: path ? null : normalizeStoredPath(tab.draftDirectoryPath) ?? projectPath,
+								draftAnchorPath: path ? null : normalizeStoredPath(tab.draftAnchorPath),
 							};
 						});
 
@@ -1409,6 +1448,8 @@ function loadWorkspaces(): void {
 							projectPath: normalizeStoredPath(w.activeProjectPath),
 							path: w.filePath,
 							title: baseName(w.filePath),
+							draftDirectoryPath: null,
+							draftAnchorPath: null,
 						});
 					}
 
@@ -1419,7 +1460,7 @@ function loadWorkspaces(): void {
 						emoji: typeof w.emoji === "string" && w.emoji.trim().length > 0 ? w.emoji.trim() : null,
 						pinned: false,
 						leftMode: w.leftMode === "files" ? "files" : "projects",
-						pane: w.pane === "file" || w.pane === "packages" || w.pane === "terminal" ? w.pane : "chat",
+						pane: w.pane === "file" || w.pane === "packages" || w.pane === "settings" || w.pane === "terminal" ? w.pane : "chat",
 						activeProjectId: normalizeStoredId(w.activeProjectId),
 						activeProjectPath: normalizeStoredPath(w.activeProjectPath),
 						filePath: typeof w.filePath === "string" ? w.filePath : null,
@@ -1652,10 +1693,11 @@ function syncContentTabsBar(workspace: WorkspaceState | null = getActiveWorkspac
 	const hasProject = Boolean(workspace && getWorkspaceActiveProjectPath(workspace));
 	const tabsContainer = document.getElementById("content-tabs-container");
 	if (tabsContainer) {
-		tabsContainer.classList.toggle("hidden", workspace?.pane === "packages" || !hasProject);
+		tabsContainer.classList.toggle("hidden", workspace?.pane === "packages" || workspace?.pane === "settings" || !hasProject);
 	}
 
-	if (!contentTabsBar || !workspace || workspace.pane === "packages" || !hasProject) {
+	if (!contentTabsBar || !workspace || workspace.pane === "packages" || workspace.pane === "settings" || !hasProject) {
+		contentTabsBar?.setTerminalActive(false);
 		contentTabsBar?.setTabs([], null);
 		return;
 	}
@@ -1698,6 +1740,7 @@ function syncContentTabsBar(workspace: WorkspaceState | null = getActiveWorkspac
 				? "terminal"
 				: workspace.activeSessionTabId;
 
+	contentTabsBar.setTerminalActive(workspace.pane === "terminal");
 	contentTabsBar.setTabs(tabs, activeTabId);
 }
 
@@ -1706,12 +1749,14 @@ function setPaneVisibility(pane: WorkspaceState["pane"]): void {
 	const filePane = document.getElementById("file-pane");
 	const terminalPane = document.getElementById("terminal-pane");
 	const packagesPane = document.getElementById("packages-pane");
-	if (!sessionPane || !filePane || !terminalPane || !packagesPane) return;
+	const settingsPane = document.getElementById("settings-pane");
+	if (!sessionPane || !filePane || !terminalPane || !packagesPane || !settingsPane) return;
 
 	sessionPane.classList.toggle("hidden-pane", pane !== "chat");
 	filePane.classList.toggle("hidden-pane", pane !== "file");
 	terminalPane.classList.toggle("hidden-pane", pane !== "terminal");
 	packagesPane.classList.toggle("hidden-pane", pane !== "packages");
+	settingsPane.classList.toggle("hidden-pane", pane !== "settings");
 }
 
 async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWorkspace()): Promise<void> {
@@ -1720,6 +1765,12 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 	syncContentTabsBar(workspace);
 
 	if (!workspace) {
+		const resolved = getResolvedDesktopTheme();
+		const profiles = loadDesktopAppearanceProfiles();
+		void syncDesktopThemeWithPiTheme(null).finally(() => {
+			applyDesktopAppearanceProfileToRoot(resolved, profiles);
+		});
+		settingsPanel?.close(false);
 		syncRunningSessionIndicators();
 		setPaneVisibility("chat");
 		return;
@@ -1727,16 +1778,25 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 
 	ensureWorkspaceContentState(workspace);
 	const workspaceProjectPath = getWorkspaceActiveProjectPath(workspace);
+	const resolved = getResolvedDesktopTheme();
+	const profiles = loadDesktopAppearanceProfiles();
+	void syncDesktopThemeWithPiTheme(workspaceProjectPath).finally(() => {
+		applyDesktopAppearanceProfileToRoot(resolved, profiles);
+	});
 	chatView?.setProjectPath(workspaceProjectPath);
 	packagesView?.setProjectPath(workspaceProjectPath);
 	terminalPanel?.setProjectPath(workspaceProjectPath);
+	if (workspace.pane !== "settings") {
+		settingsPanel?.close(false);
+	}
 	if (workspace.pane !== "file") {
 		fileViewer?.setProjectPath(workspaceProjectPath);
 	}
 
 	if (workspace.pane === "file") {
 		const activeFileTab = getActiveFileTab(workspace);
-		fileViewer?.setProjectPath(getFileTabProjectPath(activeFileTab) ?? getWorkspaceActiveProjectPath(workspace));
+		const draftBasePath = activeFileTab && isDraftFileTab(activeFileTab) ? normalizeStoredPath(activeFileTab.draftDirectoryPath) : null;
+		fileViewer?.setProjectPath(draftBasePath ?? getFileTabProjectPath(activeFileTab) ?? getWorkspaceActiveProjectPath(workspace));
 		setPaneVisibility("file");
 		if (activeFileTab?.path) {
 			await fileViewer?.openFile(activeFileTab.path);
@@ -1756,6 +1816,7 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 	}
 
 	if (workspace.pane === "packages") {
+		settingsPanel?.close(false);
 		packagesView?.setProjectPath(getWorkspaceActiveProjectPath(workspace));
 		setPaneVisibility("packages");
 		await packagesView?.open();
@@ -1764,6 +1825,19 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 		return;
 	}
 
+	if (workspace.pane === "settings") {
+		setPaneVisibility("settings");
+		const panel = mountSettingsPanel();
+		if (!panel.isVisible()) {
+			await panel.open();
+		} else {
+			panel.render();
+		}
+		syncDebugOverlay();
+		return;
+	}
+
+	settingsPanel?.close(false);
 	syncActiveChatRuntimeBinding(workspace);
 	setPaneVisibility("chat");
 	chatView?.focusInput();
@@ -2042,9 +2116,22 @@ function closeWorkspace(workspaceId: string): void {
 }
 
 function applyInitialTheme(): void {
-	const theme = (localStorage.getItem("pi-theme") as "dark" | "light" | null) ?? "dark";
-	document.documentElement.classList.remove("dark", "light");
-	document.documentElement.classList.add(theme);
+	initializeDesktopTheme();
+	const resolved = getResolvedDesktopTheme();
+	const profiles = loadDesktopAppearanceProfiles();
+	void syncDesktopThemeWithPiTheme(null).finally(() => {
+		applyDesktopAppearanceProfileToRoot(resolved, profiles);
+	});
+}
+
+async function applyNativeWindowVisualFixes(): Promise<void> {
+	try {
+		const { getCurrentWindow } = await import("@tauri-apps/api/window");
+		const win = getCurrentWindow();
+		await win.setBackgroundColor({ red: 0, green: 0, blue: 0, alpha: 0 });
+	} catch {
+		// Ignore in web / non-tauri runtimes
+	}
 }
 
 async function runStartupCompatibilityCheck(): Promise<void> {
@@ -2154,10 +2241,12 @@ async function initialize(): Promise<void> {
 	loadWorkspaces();
 	loadSidebarWidth();
 	applySidebarWidth();
+	await ensureBundledThemesInstalled();
 
 	try {
 		connectionError = null;
 		renderApp();
+		mountSettingsPanel();
 		// Ensure creatorskill exists on first run (copied from packaged assets if available)
 		await packagesView?.ensureCreatorSkillInstalled();
 		// Refresh discovered resources so Packages view shows the new skill immediately
@@ -2314,13 +2403,11 @@ async function initialize(): Promise<void> {
 }
 
 function mountSettingsPanel(): SettingsPanel {
-	settingsPanel?.destroy();
-	const existing = document.getElementById("settings-container");
-	existing?.remove();
-
-	const settingsContainer = document.createElement("div");
-	settingsContainer.id = "settings-container";
-	document.body.appendChild(settingsContainer);
+	if (settingsPanel) return settingsPanel;
+	const settingsContainer = document.getElementById("settings-pane");
+	if (!settingsContainer) {
+		throw new Error("Settings pane container not found");
+	}
 	const panel = new SettingsPanel(settingsContainer);
 	panel.setOnDesktopStatusChange((status) => {
 		desktopUpdateStatus = status;
@@ -2330,6 +2417,14 @@ function mountSettingsPanel(): SettingsPanel {
 		cliUpdateStatus = status;
 		syncCliUpdateUiHint();
 	});
+	panel.setOnClose(() => {
+		const workspace = getActiveWorkspace();
+		if (!workspace || workspace.pane !== "settings") return;
+		workspace.pane = "chat";
+		persistWorkspaces();
+		syncWorkspaceTabsBar();
+		void applyWorkspacePane(workspace);
+	});
 	settingsPanel = panel;
 	return panel;
 }
@@ -2338,8 +2433,6 @@ function initializeComponents(): void {
 	if (commandPalette || sessionBrowser || shortcutsPanel || extensionUiHandler) {
 		return;
 	}
-
-	mountSettingsPanel();
 
 	const commandPaletteContainer = document.createElement("div");
 	commandPaletteContainer.id = "command-palette-container";
@@ -2523,8 +2616,13 @@ function wireCommandPaletteBuiltins(): void {
 }
 
 function requestOpenSettingsPanel(): void {
-	const panel = mountSettingsPanel();
-	void panel.open();
+	const workspace = getActiveWorkspace();
+	if (!workspace) return;
+	mountSettingsPanel();
+	workspace.pane = "settings";
+	persistWorkspaces();
+	syncWorkspaceTabsBar();
+	void applyWorkspacePane(workspace);
 }
 
 function openSettings(): void {
@@ -2544,11 +2642,7 @@ function openShortcuts(): void {
 }
 
 function toggleThemeQuickly(): void {
-	const current = (localStorage.getItem("pi-theme") as "dark" | "light" | null) ?? "dark";
-	const next = current === "dark" ? "light" : "dark";
-	document.documentElement.classList.remove("light", "dark");
-	document.documentElement.classList.add(next);
-	localStorage.setItem("pi-theme", next);
+	toggleDesktopTheme();
 }
 
 (window as any).openSettings = openSettings;
@@ -2768,6 +2862,7 @@ function renderApp(): void {
 						<div id="file-pane" class="hidden-pane"></div>
 						<div id="terminal-pane" class="hidden-pane"></div>
 						<div id="packages-pane" class="hidden-pane"></div>
+						<div id="settings-pane" class="hidden-pane"></div>
 					</div>
 				</div>
 			</div>
@@ -2839,6 +2934,15 @@ function renderApp(): void {
 					chatView?.notify("Failed to switch session tab", "error");
 				},
 			);
+		});
+		contentTabsBar.setOnOpenTerminal(() => {
+			const workspace = getActiveWorkspace();
+			if (!workspace) return;
+			workspace.terminalOpen = true;
+			workspace.pane = "terminal";
+			persistWorkspaces();
+			syncWorkspaceTabsBar();
+			void applyWorkspacePane(workspace);
 		});
 		contentTabsBar.setOnRename((tabId, nextTitle) => {
 			const workspace = getActiveWorkspace();
@@ -2983,9 +3087,15 @@ function renderApp(): void {
 
 			const activeFileTab = workspace.fileTabs.find((tab) => tab.id === workspace.activeFileTabId) ?? null;
 			if (activeFileTab && !activeFileTab.path) {
+				const anchorPath = normalizeStoredPath(activeFileTab.draftAnchorPath);
 				activeFileTab.path = filePath;
 				activeFileTab.title = baseName(filePath);
+				activeFileTab.draftDirectoryPath = null;
+				activeFileTab.draftAnchorPath = null;
 				setFileTabProject(activeFileTab, activeFileTab.projectId ?? workspace.activeProjectId, activeFileTab.projectPath ?? workspace.activeProjectPath);
+				if (anchorPath && activeFileTab.projectId) {
+					sidebar?.setNewFilePlacementHint(activeFileTab.projectId, filePath, anchorPath);
+				}
 			} else {
 				openOrActivateFileTab(workspace, filePath, workspace.activeProjectId, workspace.activeProjectPath);
 			}
@@ -3281,13 +3391,15 @@ function renderApp(): void {
 		const switchingProject = normalizeProjectPath(getWorkspaceActiveProjectPath(workspace)) !== normalizeProjectPath(project.path);
 		const oldRuntimeKeys = switchingProject ? listRuntimeKeysForWorkspace(workspace.id) : [];
 		const discardedSessionTabs = switchingProject ? [...workspace.sessionTabs] : [];
+		const draftDirectoryPath = normalizeStoredPath(project.directoryPath) ?? normalizeStoredPath(project.path);
+		const draftAnchorPath = normalizeStoredPath(project.anchorPath);
 		setWorkspaceActiveProject(workspace, project);
 		if (switchingProject) {
 			scheduleDiscardEphemeralSessionTabs(discardedSessionTabs);
 			resetWorkspaceContentTabs(workspace, project);
 		}
-		createAndActivateEmptyFileTab(workspace, NEW_FILE_TAB_TITLE, project.id, project.path);
-		fileViewer?.setProjectPath(project.path);
+		createAndActivateEmptyFileTab(workspace, NEW_FILE_TAB_TITLE, project.id, project.path, draftDirectoryPath, draftAnchorPath);
+		fileViewer?.setProjectPath(draftDirectoryPath ?? project.path);
 		persistWorkspaces();
 		syncWorkspaceTabsBar();
 		syncContentTabsBar(workspace);
@@ -3623,6 +3735,22 @@ function renderApp(): void {
 	syncWorkspaceContextChrome(getActiveWorkspace());
 }
 
+function setupThemeSyncListeners(): void {
+	const refreshThemeProjection = () => {
+		const resolved = getResolvedDesktopTheme();
+		const profiles = loadDesktopAppearanceProfiles();
+		const workspace = getActiveWorkspace();
+		const projectPath = workspace ? getWorkspaceActiveProjectPath(workspace) : null;
+		void syncDesktopThemeWithPiTheme(projectPath).finally(() => {
+			applyDesktopAppearanceProfileToRoot(resolved, profiles);
+		});
+	};
+	window.addEventListener(DESKTOP_THEME_CHANGED_EVENT, refreshThemeProjection);
+	window.addEventListener(DESKTOP_APPEARANCE_PROFILE_CHANGED_EVENT, refreshThemeProjection);
+}
+
 applyInitialTheme();
+void applyNativeWindowVisualFixes();
+setupThemeSyncListeners();
 setupKeyboardShortcuts();
 void initialize();

--- a/src/recommended-packages.ts
+++ b/src/recommended-packages.ts
@@ -13,6 +13,18 @@ export interface RecommendedPackageDefinition {
 
 export const RECOMMENDED_PACKAGES: RecommendedPackageDefinition[] = [
 	{
+		id: "pi-desktop-themes",
+		name: "Pi Desktop Themes",
+		description: "Default Pi Desktop light/dark themes for desktop + TUI (Notion, Catppuccin, GitHub, VSCode Plus).",
+		installScopeHint: "global",
+		source: "local:pi-desktop-themes",
+		sourceKind: "local",
+		publisher: "first-party",
+		resourcesLabel: "8 themes",
+		installSourceHint: "~/.pi/agent/themes/pi-desktop-*.json",
+		aliases: ["pi-desktop-themes"],
+	},
+	{
 		id: "pi-desktop-notify",
 		name: "Pi Desktop Notify",
 		description: "Focus-aware desktop notifications for Pi Desktop and other RPC hosts via ctx.ui.notify().",

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,45 +1,38 @@
 @import "tailwindcss";
 @import "@mariozechner/mini-lit/styles/themes/default.css";
 @import "@xterm/xterm/css/xterm.css";
+@import "./tokens.css";
+@import "./theme.css";
 
 :root {
-	--bg: #0d0d0f;
-	--bg-elev: #141417;
-	--bg-muted: #1b1b1f;
-	--bg-soft: #202026;
-	--sidebar: #17171b;
-	--workspace-chrome: #15161b;
-	--workspace-chrome-soft: #1c1d24;
-	--border: rgba(255, 255, 255, 0.08);
-	--text: #f5f5f7;
-	--muted: #9a9aa3;
-	--muted-2: #6f7078;
-	--accent: #7a818f;
-	--accent-soft: rgba(122, 129, 143, 0.2);
-	--danger: #ef4444;
-	--success: #22c55e;
-	--warning: #f59e0b;
-	--workspace-topbar-offset: 0px;
-	--top-chrome-height: 44px;
-}
+	/* Backward-compatible aliases while we migrate app.css to semantic tokens */
+	--bg: var(--color-bg-app);
+	--bg-elev: var(--color-bg-elevated);
+	--bg-muted: var(--color-bg-muted);
+	--bg-soft: var(--color-bg-soft);
+	--sidebar: var(--color-bg-sidebar);
+	--workspace-chrome: var(--color-bg-workspace-chrome);
+	--workspace-chrome-soft: var(--color-bg-workspace-chrome-soft);
+	--border: var(--color-border-default);
+	--text: var(--color-text-primary);
+	--muted: var(--color-text-secondary);
+	--muted-2: var(--color-text-tertiary);
+	--accent: var(--color-accent-primary);
+	--accent-soft: var(--color-accent-soft);
+	--danger: var(--color-state-danger);
+	--success: var(--color-state-success);
+	--warning: var(--color-state-warning);
 
-:root.light {
-	--bg: #f3f3f5;
-	--bg-elev: #ffffff;
-	--bg-muted: #f6f6f8;
-	--bg-soft: #ececf0;
-	--sidebar: #f7f7fa;
-	--workspace-chrome: #f5f6fa;
-	--workspace-chrome-soft: #ebedf4;
-	--border: rgba(12, 12, 12, 0.12);
-	--text: #151518;
-	--muted: #555863;
-	--muted-2: #80838f;
-	--accent: #6b7280;
-	--accent-soft: rgba(107, 114, 128, 0.16);
-	--danger: #dc2626;
-	--success: #16a34a;
-	--warning: #d97706;
+	--workspace-topbar-offset: 0px;
+	--top-chrome-height: var(--size-top-chrome);
+	--desktop-sidebar-opacity: 100%;
+	--desktop-sidebar-blur: 0px;
+	--desktop-sidebar-tint-color: var(--color-text-primary);
+	--desktop-sidebar-tint-strength: 0%;
+	--desktop-chrome-opacity: 100%;
+	--desktop-chrome-blur: 0px;
+	--desktop-chrome-tint-strength: 0%;
+	--desktop-contrast: 50;
 }
 
 * {
@@ -51,17 +44,28 @@ body {
 	margin: 0;
 	padding: 0;
 	height: 100%;
-	background: var(--bg);
+	background: transparent;
 	color: var(--text);
-	font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, sans-serif;
+	font-family: var(--font-family-sans);
+	overflow: hidden;
+}
+
+code,
+pre,
+kbd,
+samp {
+	font-family: var(--font-family-mono);
 }
 
 #app {
 	height: 100%;
+	border-radius: 14px;
+	overflow: hidden;
+	background: var(--bg);
 }
 
 .app-shell {
-	height: 100vh;
+	height: 100%;
 	display: flex;
 	flex-direction: column;
 	background: var(--bg);
@@ -87,7 +91,7 @@ body {
 }
 
 .error-shell {
-	height: 100vh;
+	height: 100%;
 	display: grid;
 	place-items: center;
 	background: radial-gradient(circle at 20% 20%, color-mix(in srgb, var(--accent) 20%, transparent), transparent 55%), var(--bg);
@@ -213,8 +217,12 @@ body {
 	gap: 10px;
 	padding: 0 10px;
 	border-bottom: 1px solid var(--border);
-	background: color-mix(in srgb, var(--bg) 80%, transparent);
-	backdrop-filter: blur(14px);
+	background: color-mix(
+		in srgb,
+		var(--workspace-chrome) var(--desktop-chrome-opacity),
+		var(--desktop-sidebar-tint-color) var(--desktop-chrome-tint-strength)
+	);
+	backdrop-filter: blur(var(--desktop-chrome-blur));
 }
 
 .titlebar-left,
@@ -334,7 +342,7 @@ body {
 
 #workspace-tabs-container {
 	height: 44px;
-	background: var(--workspace-chrome);
+	background: var(--bg);
 	border-top-left-radius: 14px;
 	border-top-right-radius: 14px;
 }
@@ -346,7 +354,7 @@ body {
 	gap: 10px;
 	padding: 0 12px;
 	box-sizing: border-box;
-	background: var(--workspace-chrome);
+	background: var(--bg);
 }
 
 .workspace-tabs-left {
@@ -359,14 +367,14 @@ body {
 .workspace-tabs-main {
 	flex: 1;
 	min-width: 0;
-	height: 34px;
+	height: 100%;
 	display: flex;
 	align-items: stretch;
 	gap: 0;
 	padding: 0;
-	border-radius: 12px;
+	border-radius: 0;
 	overflow: hidden;
-	background: color-mix(in srgb, var(--workspace-chrome-soft) 86%, var(--workspace-chrome));
+	background: transparent;
 	margin-left: max(0px, calc(var(--workspace-topbar-offset) - var(--workspace-topbar-main-start-base, 0px)));
 }
 
@@ -465,7 +473,9 @@ body {
 .sidebar-space-dialog *,
 .content-tab,
 .content-tab-context-menu,
-.content-tab-context-menu * {
+.content-tab-context-menu *,
+.content-tabs-trailing,
+.content-tabs-terminal-btn {
 	-webkit-app-region: no-drag;
 }
 
@@ -483,8 +493,8 @@ body {
 }
 
 .workspace-sidebar-toggle svg {
-	width: 14px;
-	height: 14px;
+	width: 15px;
+	height: 15px;
 	fill: none;
 	stroke: currentColor;
 	stroke-width: 1.3;
@@ -492,13 +502,13 @@ body {
 }
 
 .workspace-sidebar-toggle:hover {
-	background: color-mix(in srgb, var(--workspace-chrome-soft) 76%, var(--workspace-chrome));
+	background: color-mix(in srgb, var(--bg-soft) 76%, var(--bg));
 	color: var(--text);
 }
 
 .workspace-sidebar-toggle.collapsed {
 	color: var(--accent);
-	background: color-mix(in srgb, var(--accent) 14%, var(--workspace-chrome));
+	background: color-mix(in srgb, var(--accent) 14%, var(--bg));
 }
 
 .workspace-tabs-scroll {
@@ -541,7 +551,7 @@ body {
 }
 
 .workspace-tab.has-color {
-	background: color-mix(in srgb, var(--workspace-tab-fill) 12%, var(--workspace-chrome));
+	background: color-mix(in srgb, var(--workspace-tab-fill) 12%, var(--bg));
 }
 
 .workspace-tab.active {
@@ -549,11 +559,23 @@ body {
 }
 
 .workspace-tab.active.has-color {
-	background: color-mix(in srgb, var(--workspace-tab-fill) 12%, var(--workspace-chrome));
+	background: color-mix(in srgb, var(--workspace-tab-fill) 12%, var(--bg));
 }
 
 .workspace-tab.pinned-boundary {
-	box-shadow: inset -1px 0 0 0 color-mix(in srgb, var(--text) 15%, transparent);
+	box-shadow: none;
+}
+
+.workspace-tab.pinned-boundary::after {
+	content: "";
+	position: absolute;
+	right: 0;
+	top: 5px;
+	bottom: 5px;
+	width: 1px;
+	background: color-mix(in srgb, var(--text) 24%, transparent);
+	pointer-events: none;
+	z-index: 2;
 }
 
 .workspace-tab-placeholder {
@@ -638,7 +660,7 @@ body {
 
 .workspace-tab-emoji-button:hover,
 .workspace-tab-emoji-button.open {
-	background: color-mix(in srgb, var(--workspace-chrome-soft) 84%, transparent);
+	background: color-mix(in srgb, var(--bg-soft) 84%, transparent);
 	color: var(--text);
 }
 
@@ -670,7 +692,7 @@ body {
 
 .workspace-tab-close:hover,
 .workspace-tab-add:hover {
-	background: color-mix(in srgb, var(--workspace-chrome-soft) 84%, transparent);
+	background: color-mix(in srgb, var(--bg-soft) 84%, transparent);
 	color: var(--text);
 }
 
@@ -715,7 +737,7 @@ body {
 
 .workspace-emoji-picker {
 	position: fixed;
-	z-index: 80;
+	z-index: 1300;
 	width: 272px;
 	padding: 10px;
 	border-radius: 14px;
@@ -724,6 +746,29 @@ body {
 	box-shadow: 0 18px 40px rgba(0, 0, 0, 0.34);
 	display: grid;
 	gap: 10px;
+}
+
+.sidebar-project-emoji-portal-host {
+	position: fixed;
+	inset: 0;
+	z-index: 2600;
+	pointer-events: none;
+}
+
+.project-emoji-picker-backdrop {
+	position: fixed;
+	inset: 0;
+	border: none;
+	padding: 0;
+	margin: 0;
+	background: transparent;
+	cursor: default;
+	pointer-events: auto;
+}
+
+.workspace-emoji-picker.project-emoji-picker {
+	z-index: 2601;
+	pointer-events: auto;
 }
 
 .workspace-emoji-search {
@@ -857,8 +902,15 @@ body {
 	width: var(--sidebar-width, 320px);
 	min-width: var(--sidebar-width, 320px);
 	max-width: var(--sidebar-width, 320px);
-	background: var(--sidebar);
-	overflow: hidden;
+	background: color-mix(
+		in srgb,
+		var(--sidebar) var(--desktop-sidebar-opacity),
+		var(--desktop-sidebar-tint-color) var(--desktop-sidebar-tint-strength)
+	);
+	backdrop-filter: blur(var(--desktop-sidebar-blur));
+	overflow-x: visible;
+	overflow-y: hidden;
+	position: relative;
 	transition: width 0.2s ease, min-width 0.2s ease, max-width 0.2s ease;
 	box-shadow: none;
 	border-bottom-left-radius: 14px;
@@ -868,13 +920,18 @@ body {
 	width: 0;
 	min-width: 0;
 	max-width: 0;
+	overflow: hidden;
 	box-shadow: none;
 }
 
 #sidebar-resize-handle {
 	width: 6px;
 	cursor: col-resize;
-	background: var(--sidebar);
+	background: color-mix(
+		in srgb,
+		var(--sidebar) var(--desktop-sidebar-opacity),
+		var(--desktop-sidebar-tint-color) var(--desktop-sidebar-tint-strength)
+	);
 	position: relative;
 	flex-shrink: 0;
 }
@@ -932,9 +989,9 @@ body.sidebar-resizing {
 
 #content-tabs-container {
 	height: var(--top-chrome-height);
-	padding-top: 6px;
+	padding-top: 0;
 	box-sizing: border-box;
-	background: var(--workspace-chrome);
+	background: var(--bg);
 	border-top-right-radius: 10px;
 }
 
@@ -948,17 +1005,84 @@ body.sidebar-resizing {
 	align-items: stretch;
 	gap: 0;
 	padding: 0;
+	overflow: hidden;
+	position: relative;
+}
+
+.content-tabs-scroll {
+	flex: 1;
+	min-width: 0;
+	height: 100%;
+	display: flex;
+	align-items: stretch;
+	gap: 0;
 	overflow-x: auto;
 	scrollbar-width: none;
 	position: relative;
 }
 
-.content-tabs-root::-webkit-scrollbar {
+.content-tabs-scroll::-webkit-scrollbar {
 	display: none;
 }
 
-.content-tabs-root.is-dragging {
+.content-tabs-root.is-dragging,
+.content-tabs-root.is-dragging .content-tabs-scroll {
 	cursor: grabbing;
+}
+
+.content-tabs-trailing {
+	width: 44px;
+	min-width: 44px;
+	height: 100%;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	background: var(--bg);
+	flex-shrink: 0;
+	position: relative;
+}
+
+.content-tabs-trailing::before {
+	content: "";
+	position: absolute;
+	left: 0;
+	top: 7px;
+	bottom: 7px;
+	width: 1px;
+	background: color-mix(in srgb, var(--text) 24%, transparent);
+	pointer-events: none;
+}
+
+.content-tabs-terminal-btn {
+	width: 28px;
+	height: 28px;
+	border: none;
+	border-radius: 8px;
+	padding: 0;
+	display: grid;
+	place-items: center;
+	background: transparent;
+	color: var(--muted);
+	cursor: pointer;
+}
+
+.content-tabs-terminal-btn svg {
+	width: 15px;
+	height: 15px;
+	fill: none;
+	stroke: currentColor;
+	stroke-width: 1.3;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+}
+
+.content-tabs-terminal-btn:hover {
+	background: color-mix(in srgb, var(--bg-soft) 76%, var(--bg));
+	color: var(--text);
+}
+
+.content-tabs-terminal-btn.active {
+	color: var(--text);
 }
 
 .content-tab {
@@ -970,19 +1094,39 @@ body.sidebar-resizing {
 	align-items: center;
 	gap: 2px;
 	padding-right: 4px;
-	background: color-mix(in srgb, var(--content-tab-fill, var(--workspace-chrome-soft)) 7%, var(--workspace-chrome));
+	background: transparent;
 	flex-shrink: 0;
 	position: relative;
 }
 
 .content-tab.active {
-	background: color-mix(in srgb, var(--content-tab-fill, var(--workspace-chrome-soft)) 10%, var(--workspace-chrome));
+	background: transparent;
+}
+
+.content-tab.has-color {
+	background: color-mix(in srgb, var(--content-tab-fill) 8%, var(--bg));
+}
+
+.content-tab.active.has-color {
+	background: color-mix(in srgb, var(--content-tab-fill) 8%, var(--bg));
 }
 
 .content-tab.pinned-boundary {
-	box-shadow: inset -1px 0 0 color-mix(in srgb, var(--border) 85%, transparent);
-	margin-right: 6px;
-	padding-right: 10px;
+	box-shadow: none;
+	margin-right: 0;
+	padding-right: 4px;
+}
+
+.content-tab.pinned-boundary::after {
+	content: "";
+	position: absolute;
+	right: 0;
+	top: 5px;
+	bottom: 5px;
+	width: 1px;
+	background: color-mix(in srgb, var(--text) 24%, transparent);
+	pointer-events: none;
+	z-index: 2;
 }
 
 .content-tab.content-tab-placeholder {
@@ -1081,7 +1225,7 @@ body.sidebar-resizing {
 
 .content-tab-context-menu {
 	position: fixed;
-	z-index: 70;
+	z-index: 1300;
 	width: 252px;
 	padding: 10px;
 	border-radius: 10px;
@@ -1179,6 +1323,7 @@ body.sidebar-resizing {
 #file-pane,
 #terminal-pane,
 #packages-pane,
+#settings-pane,
 #chat-container {
 	flex: 1;
 	min-width: 0;
@@ -1194,7 +1339,8 @@ body.sidebar-resizing {
 #file-pane.hidden-pane,
 #session-pane.hidden-pane,
 #terminal-pane.hidden-pane,
-#packages-pane.hidden-pane {
+#packages-pane.hidden-pane,
+#settings-pane.hidden-pane {
 	display: none;
 }
 
@@ -1542,7 +1688,7 @@ body.sidebar-resizing {
 	justify-content: space-between;
 	gap: 12px;
 	padding: 10px 18px;
-	border-bottom: 1px solid color-mix(in srgb, var(--border) 92%, transparent);
+	border-bottom: none;
 	background: color-mix(in srgb, var(--bg) 94%, transparent);
 }
 
@@ -1651,6 +1797,10 @@ body.sidebar-resizing {
 	border: none;
 	display: grid;
 	gap: 12px;
+}
+
+.packages-section-discover {
+	margin-top: 14px;
 }
 
 .packages-top-strip {
@@ -2248,6 +2398,39 @@ body.sidebar-resizing {
 	color: var(--danger);
 }
 
+.packages-theme-preview-grid {
+	display: grid;
+	gap: 8px;
+}
+
+.packages-theme-preview-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	font-size: 12px;
+}
+
+.packages-theme-color-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 5px 10px;
+	border-radius: 999px;
+	border: 1px solid var(--border);
+	background: var(--bg-muted);
+	font-family: var(--font-family-mono);
+	font-size: 11px;
+}
+
+.packages-theme-color-dot {
+	width: 12px;
+	height: 12px;
+	border-radius: 999px;
+	border: 1px solid color-mix(in srgb, var(--border) 85%, transparent);
+	flex-shrink: 0;
+}
+
 .packages-diagnostics {
 	border-radius: 12px;
 	border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
@@ -2314,7 +2497,12 @@ body.sidebar-resizing {
 	height: 100%;
 	display: flex;
 	flex-direction: column;
-	background: var(--sidebar);
+	background: color-mix(
+		in srgb,
+		var(--sidebar) var(--desktop-sidebar-opacity),
+		var(--desktop-sidebar-tint-color) var(--desktop-sidebar-tint-strength)
+	);
+	backdrop-filter: blur(var(--desktop-sidebar-blur));
 	position: relative;
 }
 
@@ -2654,10 +2842,10 @@ body.sidebar-resizing {
 
 .sidebar-workspace-header {
 	display: grid;
-	grid-template-columns: auto minmax(0, 1fr);
+	grid-template-columns: minmax(0, 1fr);
 	align-items: center;
-	gap: 6px;
-	padding: 1px 2px 0;
+	gap: 0;
+	padding: 1px 9px 0;
 	min-height: 30px;
 }
 
@@ -2682,10 +2870,10 @@ body.sidebar-resizing {
 }
 
 .sidebar-workspace-header-title {
-	font-size: 15px;
-	font-weight: 610;
+	font-size: 14px;
+	font-weight: 600;
 	line-height: 1.22;
-	letter-spacing: -0.005em;
+	letter-spacing: -0.003em;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -2707,14 +2895,16 @@ body.sidebar-resizing {
 	display: grid;
 	gap: 8px;
 	padding: 6px 8px 10px;
-	background: color-mix(in srgb, var(--sidebar) 92%, transparent);
+	background: color-mix(
+		in srgb,
+		var(--sidebar) var(--desktop-sidebar-opacity),
+		var(--desktop-sidebar-tint-color) var(--desktop-sidebar-tint-strength)
+	);
+	backdrop-filter: blur(var(--desktop-sidebar-blur));
 }
 
 .sidebar-section-divider {
-	height: 1px;
-	margin: 6px 12px 10px;
-	background: color-mix(in srgb, var(--border) 86%, transparent);
-	border-radius: 999px;
+	display: none;
 }
 
 .sidebar-cli-update-banner {
@@ -2752,7 +2942,7 @@ body.sidebar-resizing {
 	grid-template-columns: 1fr auto;
 	gap: 8px;
 	align-items: start;
-	padding: 0 8px 8px;
+	padding: 12px 8px 10px;
 }
 
 .sidebar-mode-meta {
@@ -2783,8 +2973,9 @@ body.sidebar-resizing {
 }
 
 .sidebar-mode-current {
-	font-size: 12px;
-	color: var(--muted);
+	font-size: 13px;
+	color: var(--text);
+	font-weight: 600;
 	padding-left: 9px;
 	line-height: 1.2;
 }
@@ -2844,12 +3035,12 @@ body.sidebar-resizing {
 
 .sidebar-mode-create-btn,
 .sidebar-mode-filter-btn {
-	width: 28px;
-	height: 28px;
+	width: 30px;
+	height: 30px;
 	border-radius: 8px;
 	border: none;
 	background: transparent;
-	color: var(--muted);
+	color: var(--text);
 	display: grid;
 	place-items: center;
 	cursor: pointer;
@@ -2858,9 +3049,9 @@ body.sidebar-resizing {
 
 .sidebar-mode-create-btn .sidebar-icon-svg,
 .sidebar-mode-filter-btn .sidebar-icon-svg {
-	width: 15px;
-	height: 15px;
-	stroke-width: 1.25;
+	width: 16px;
+	height: 16px;
+	stroke-width: 1.35;
 }
 
 .sidebar-mode-create-btn:disabled,
@@ -2965,7 +3156,7 @@ body.sidebar-resizing {
 }
 
 .sidebar-top-action-btn.active {
-	background: color-mix(in srgb, var(--accent) 16%, var(--sidebar));
+	background: var(--bg-soft);
 	color: var(--text);
 }
 
@@ -3286,7 +3477,7 @@ body.sidebar-resizing {
 
 .sidebar-project-list {
 	display: grid;
-	gap: 6px;
+	gap: 8px;
 	min-width: 0;
 }
 
@@ -3317,6 +3508,9 @@ body.sidebar-resizing {
 	align-items: center;
 	padding: 2px 4px;
 	min-width: 0;
+	border-radius: 8px;
+	transition: background 120ms ease;
+	margin-bottom: 2px;
 }
 
 .sidebar-project-main-wrap {
@@ -3342,7 +3536,7 @@ body.sidebar-resizing {
 }
 
 .sidebar-project-indicator-btn:hover {
-	background: var(--bg-soft);
+	background: transparent;
 	color: var(--text);
 }
 
@@ -3362,6 +3556,7 @@ body.sidebar-resizing {
 .sidebar-project-row:hover .sidebar-project-toggle-icon,
 .sidebar-project-row.menu-open .sidebar-project-toggle-icon {
 	opacity: 1;
+	color: var(--text);
 }
 
 .sidebar-project-leading-emoji {
@@ -3403,6 +3598,12 @@ body.sidebar-resizing {
 	overflow: hidden;
 	flex: 1;
 }
+
+.sidebar-project-head:hover,
+.sidebar-project-row.menu-open .sidebar-project-head {
+	background: color-mix(in srgb, var(--bg-soft) 65%, transparent);
+}
+
 
 .sidebar-project-title-wrap {
 	display: inline-flex;
@@ -3468,6 +3669,13 @@ body.sidebar-resizing {
 	pointer-events: auto;
 }
 
+.sidebar-project-row:hover .sidebar-project-action,
+.sidebar-project-row.menu-open .sidebar-project-action,
+.sidebar-project-row:hover .sidebar-project-indicator-btn,
+.sidebar-project-row.menu-open .sidebar-project-indicator-btn {
+	color: var(--text);
+}
+
 .sidebar-project-action {
 	width: 22px;
 	height: 22px;
@@ -3491,7 +3699,7 @@ body.sidebar-resizing {
 }
 
 .sidebar-project-action:hover {
-	background: var(--bg-soft);
+	background: transparent;
 	color: var(--text);
 }
 
@@ -3626,7 +3834,7 @@ body.sidebar-resizing {
 .sidebar-project-files {
 	display: grid;
 	gap: 2px;
-	padding: 0 0 2px 24px;
+	padding: 4px 0 2px 24px;
 	min-width: 0;
 }
 
@@ -3667,6 +3875,12 @@ body.sidebar-resizing {
 	align-items: center;
 	gap: 4px;
 	min-width: 0;
+}
+
+.sidebar-session-pin-divider {
+	height: 1px;
+	margin: 3px 8px 2px 8px;
+	background: color-mix(in srgb, var(--border) 84%, transparent);
 }
 
 .sidebar-session-row.pinned .sidebar-session-name,
@@ -3761,13 +3975,6 @@ body.sidebar-resizing {
 	margin-left: -16px;
 }
 
-.sidebar-session-pin {
-	font-size: 10px;
-	line-height: 1;
-	color: color-mix(in srgb, var(--accent) 70%, var(--text));
-	opacity: 0.9;
-	flex-shrink: 0;
-}
 
 .sidebar-session-pi {
 	width: 12px;
@@ -3883,7 +4090,7 @@ body.sidebar-resizing {
 
 .sidebar-files-tree {
 	display: grid;
-	gap: 2px;
+	gap: 3px;
 }
 
 .sidebar-file-row {
@@ -3897,30 +4104,32 @@ body.sidebar-resizing {
 .sidebar-file-main {
 	width: auto;
 	flex: 1;
-	height: 26px;
+	height: 24px;
 	border: none;
 	background: transparent;
 	display: flex;
 	align-items: center;
 	gap: 5px;
 	padding: 0 6px 0 calc(var(--indent, 0px) + 6px);
-	border-radius: 7px;
+	border-radius: 6px;
 	text-align: left;
 	cursor: pointer;
-	color: var(--text);
+	color: var(--muted);
 	min-width: 0;
 }
 
 .sidebar-file-main:hover {
-	background: var(--bg-soft);
+	background: color-mix(in srgb, var(--bg-soft) 65%, transparent);
+	color: var(--text);
 }
 
 .sidebar-file-main.active-file {
-	background: var(--bg-soft);
+	background: color-mix(in srgb, var(--bg-soft) 65%, transparent);
+	color: var(--text);
 }
 
 .sidebar-file-row.dir .sidebar-file-main {
-	color: color-mix(in srgb, var(--text) 95%, var(--accent));
+	color: var(--muted);
 }
 
 .sidebar-file-caret {
@@ -3931,8 +4140,8 @@ body.sidebar-resizing {
 }
 
 .sidebar-file-icon {
-	width: 14px;
-	height: 14px;
+	width: 15px;
+	height: 15px;
 	flex-shrink: 0;
 	display: inline-flex;
 	align-items: center;
@@ -3940,8 +4149,8 @@ body.sidebar-resizing {
 }
 
 .sidebar-file-icon svg {
-	width: 14px;
-	height: 14px;
+	width: 15px;
+	height: 15px;
 }
 
 .sidebar-file-icon.folder-icon .folder-tab,
@@ -3953,8 +4162,8 @@ body.sidebar-resizing {
 
 .sidebar-file-icon.folder-icon.open .folder-tab,
 .sidebar-file-icon.folder-icon.open .folder-body {
-	fill: color-mix(in srgb, var(--accent) 20%, var(--bg-elev));
-	stroke: color-mix(in srgb, var(--accent) 62%, var(--muted));
+	fill: color-mix(in srgb, var(--bg-elev) 72%, var(--bg-soft));
+	stroke: color-mix(in srgb, var(--text) 44%, var(--muted));
 }
 
 .sidebar-file-icon.file-icon {
@@ -4122,9 +4331,9 @@ body.sidebar-resizing {
 }
 
 .chat-row {
-	width: min(1020px, calc(100% - 30px));
+	width: min(760px, calc(100% - 24px));
 	margin: 0 auto 16px;
-	padding: 0 8px;
+	padding: 0 14px;
 }
 
 .user-row {
@@ -4887,13 +5096,13 @@ body.sidebar-resizing {
 	left: 0;
 	right: 0;
 	bottom: 0;
-	padding: 0 24px 24px;
+	padding: 0 56px 24px;
 	background: linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--bg) 76%, transparent) 36%, var(--bg) 100%);
 	pointer-events: none;
 }
 
 .composer-inner {
-	max-width: 960px;
+	max-width: 760px;
 	margin: 0 auto;
 	display: grid;
 	gap: 0;
@@ -4901,30 +5110,33 @@ body.sidebar-resizing {
 }
 
 .composer-panel {
-	padding: 6px 10px 4px;
-	border-radius: 20px;
-	border: 1px solid color-mix(in srgb, var(--border) 52%, transparent);
-	background: color-mix(in srgb, var(--bg-elev) 66%, var(--bg));
-	box-shadow: 0 6px 14px rgba(0, 0, 0, 0.18);
+	padding: 12px 14px 10px;
+	border-radius: 24px;
+	border: 1px solid color-mix(in srgb, var(--border) 46%, transparent);
+	background: color-mix(in srgb, var(--bg-elev) 72%, var(--bg));
+	box-shadow: 0 8px 18px rgba(0, 0, 0, 0.2);
 	backdrop-filter: blur(10px);
 }
 
 .composer-row {
-	display: block;
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
 }
 
 .chat-input {
 	width: 100%;
-	min-height: 30px;
-	max-height: 140px;
+	flex: 1;
+	min-height: 54px;
+	max-height: 160px;
 	resize: none;
-	padding: 4px 10px 2px;
+	padding: 8px 12px 8px;
 	border-radius: 14px;
 	border: none;
 	background: transparent;
 	color: var(--text);
-	font-size: 13px;
-	line-height: 1.35;
+	font-size: 14px;
+	line-height: 1.4;
 }
 
 .chat-input::placeholder {
@@ -4940,16 +5152,16 @@ body.sidebar-resizing {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
-	gap: 6px;
-	padding: 4px 2px 0;
+	gap: 8px;
+	padding: 6px 2px 0;
 	margin-top: 0;
-	border-top: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+	border-top: 1px solid color-mix(in srgb, var(--border) 52%, transparent);
 }
 
 .control-group {
 	display: flex;
 	align-items: center;
-	gap: 3px;
+	gap: 6px;
 	min-width: 0;
 }
 
@@ -4959,10 +5171,10 @@ body.sidebar-resizing {
 }
 
 .composer-icon-btn {
-	width: 26px;
-	height: 26px;
+	width: 30px;
+	height: 30px;
 	border: none;
-	border-radius: 7px;
+	border-radius: 999px;
 	background: transparent;
 	color: var(--muted);
 	display: grid;
@@ -4971,11 +5183,11 @@ body.sidebar-resizing {
 }
 
 .composer-icon-btn svg {
-	width: 12px;
-	height: 12px;
+	width: 16px;
+	height: 16px;
 	fill: none;
 	stroke: currentColor;
-	stroke-width: 1.3;
+	stroke-width: 1.5;
 	stroke-linecap: round;
 	stroke-linejoin: round;
 }
@@ -4985,67 +5197,170 @@ body.sidebar-resizing {
 	color: var(--text);
 }
 
-.model-select-wrap {
+.model-picker-root {
 	position: relative;
-	height: 26px;
-	width: 170px;
-	min-width: 120px;
-	max-width: 170px;
-	flex: 0 0 170px;
-	display: inline-flex;
-	align-items: center;
-	border-radius: 999px;
-	background: transparent;
 }
 
-.model-select-wrap:hover {
+.model-picker-trigger {
+	position: relative;
+	height: 30px;
+	max-width: 300px;
+	padding: 0 20px 0 8px;
+	border: none;
+	border-radius: 10px;
+	background: transparent;
+	color: var(--text);
+	font-size: 13px;
+	font-weight: 500;
+	display: inline-flex;
+	align-items: center;
+	cursor: pointer;
+}
+
+.model-picker-trigger:hover {
 	background: color-mix(in srgb, var(--bg-soft) 70%, transparent);
 }
 
-.model-select-wrap:focus-within {
+.model-picker-trigger:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.model-picker-trigger:disabled:hover {
+	background: transparent;
+}
+
+.model-picker-trigger:focus-visible,
+.model-picker-root:focus-within .model-picker-trigger {
+	outline: none;
 	box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 44%, transparent);
 }
 
-.composer-select {
-	height: 26px;
-	width: 100%;
-	min-width: 0;
-	max-width: none;
-	padding: 0 20px 0 6px;
-	border-radius: 999px;
-	border: none;
-	background: transparent;
-	color: var(--muted);
-	font-size: 11px;
-	appearance: none;
-	-webkit-appearance: none;
-	-moz-appearance: none;
-	background-image: none;
+.model-picker-trigger-label {
+	max-width: 270px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	padding-right: 2px;
 }
 
 .composer-select-caret {
 	position: absolute;
 	right: 6px;
-	font-size: 12px;
+	font-size: 16px;
 	line-height: 1;
-	color: var(--muted-2);
+	color: var(--muted);
 	pointer-events: none;
 }
 
-.model-select {
-	max-width: none;
+.model-picker-popover {
+	position: absolute;
+	left: 0;
+	bottom: calc(100% + 8px);
+	z-index: 35;
+	display: grid;
+	grid-template-columns: minmax(132px, 176px) minmax(188px, 270px);
+	min-width: 340px;
+	max-width: min(92vw, 470px);
+	border-radius: 12px;
+	border: 1px solid color-mix(in srgb, var(--border) 90%, transparent);
+	background: color-mix(in srgb, var(--bg-elev) 94%, var(--bg));
+	box-shadow: 0 14px 28px rgba(0, 0, 0, 0.32);
+	overflow: hidden;
+}
+
+.model-picker-providers {
+	display: grid;
+	gap: 1px;
+	padding: 4px;
+	grid-auto-rows: min-content;
+	align-content: start;
+	border-right: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+	background: color-mix(in srgb, var(--bg-soft) 42%, transparent);
+}
+
+.model-picker-provider {
+	height: 27px;
+	border: none;
+	border-radius: 8px;
+	background: transparent;
+	color: var(--muted);
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 0 8px;
+	font-size: 12px;
+	cursor: pointer;
+}
+
+.model-picker-provider-label {
+	flex: 1;
+	min-width: 0;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	text-align: left;
+}
+
+.model-picker-provider-caret {
+	flex-shrink: 0;
+}
+
+.model-picker-provider:hover,
+.model-picker-provider.active {
+	background: color-mix(in srgb, var(--bg-soft) 84%, transparent);
+	color: var(--text);
+}
+
+.model-picker-models {
+	display: grid;
+	gap: 1px;
+	padding: 4px;
+	grid-auto-rows: min-content;
+	align-content: start;
+	max-height: 224px;
+	overflow-y: auto;
+}
+
+.model-picker-model {
+	height: 27px;
+	border: none;
+	border-radius: 8px;
+	background: transparent;
+	color: var(--muted);
+	text-align: left;
+	padding: 0 8px;
+	font-size: 12px;
+	cursor: pointer;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.model-picker-model:hover,
+.model-picker-model.active {
+	background: color-mix(in srgb, var(--bg-soft) 82%, transparent);
+	color: var(--text);
+}
+
+.model-picker-empty {
+	padding: 10px 12px;
+	font-size: 12px;
+	color: var(--muted-2);
 }
 
 .thinking-select-wrap {
 	position: relative;
-	height: 26px;
-	min-width: 100px;
-	padding: 0 20px 0 8px;
-	border-radius: 999px;
+	height: 30px;
+	min-width: 0;
+	padding: 0 18px 0 8px;
+	border-radius: 10px;
 	display: inline-flex;
 	align-items: center;
 	background: transparent;
 	color: var(--muted);
+	flex: 0 0 auto;
 }
 
 .thinking-select-wrap:hover {
@@ -5057,8 +5372,9 @@ body.sidebar-resizing {
 }
 
 .thinking-select-label {
-	font-size: 11px;
-	font-style: italic;
+	font-size: 13px;
+	font-style: normal;
+	font-weight: 500;
 	color: var(--muted);
 	pointer-events: none;
 }
@@ -5077,9 +5393,9 @@ body.sidebar-resizing {
 .thinking-select-caret {
 	position: absolute;
 	right: 6px;
-	font-size: 12px;
+	font-size: 16px;
 	line-height: 1;
-	color: var(--muted-2);
+	color: var(--muted);
 	pointer-events: none;
 }
 
@@ -5093,41 +5409,94 @@ body.sidebar-resizing {
 }
 
 .send-btn {
-	width: 30px;
-	height: 30px;
+	width: 38px;
+	height: 38px;
 	padding: 0;
 	border-radius: 999px;
 	display: grid;
 	place-items: center;
-	border: 1px solid color-mix(in srgb, var(--border) 88%, transparent);
-	background: color-mix(in srgb, var(--bg-soft) 70%, transparent);
-	color: var(--text);
+	border: none;
+	background: color-mix(in srgb, var(--bg-soft) 84%, var(--bg-elev));
+	color: color-mix(in srgb, var(--text) 90%, var(--bg));
 	font-weight: 600;
+	transition: background-color 140ms ease, color 140ms ease, transform 140ms ease;
 }
 
 .send-btn svg {
-	width: 12px;
-	height: 12px;
+	width: 15px;
+	height: 15px;
 	fill: none;
 	stroke: currentColor;
-	stroke-width: 1.5;
+	stroke-width: 1.7;
 	stroke-linecap: round;
 	stroke-linejoin: round;
 }
 
+.primary-send .send-arrow-icon {
+	width: 15px;
+	height: 15px;
+	stroke-width: 1.65;
+}
+
+.primary-send {
+	background: color-mix(in srgb, var(--text) 66%, var(--bg) 34%);
+	color: color-mix(in srgb, var(--bg) 90%, #000 10%);
+}
+
 .primary-send:hover:not(:disabled) {
-	background: color-mix(in srgb, var(--bg-soft) 90%, var(--bg-muted));
+	background: color-mix(in srgb, var(--text) 76%, var(--bg) 24%);
+}
+
+.primary-send:active:not(:disabled) {
+	transform: translateY(0.5px);
 }
 
 .primary-send:disabled {
-	opacity: 0.34;
+	background: color-mix(in srgb, var(--bg-soft) 90%, var(--bg-elev));
+	color: var(--muted-2);
 	cursor: not-allowed;
+	opacity: 1;
+}
+
+.pending-send {
+	background: color-mix(in srgb, var(--bg-soft) 90%, var(--bg-elev));
+	color: var(--muted);
+	cursor: progress;
+}
+
+.pending-send .spinner-icon {
+	animation: composerSendSpin 0.9s linear infinite;
+}
+
+.pending-send .spinner-track {
+	opacity: 0.26;
+}
+
+.pending-send .spinner-arc {
+	stroke-linecap: round;
 }
 
 .stop-btn {
-	background: color-mix(in srgb, var(--danger) 14%, var(--bg-elev));
-	border-color: color-mix(in srgb, var(--danger) 36%, var(--border));
-	color: var(--danger);
+	background: color-mix(in srgb, var(--text) 92%, var(--bg) 8%);
+	color: color-mix(in srgb, var(--bg) 94%, #000 6%);
+}
+
+.stop-btn:hover:not(:disabled) {
+	background: color-mix(in srgb, var(--text) 98%, var(--bg) 2%);
+}
+
+.stop-btn .stop-square-icon {
+	stroke-width: 0;
+	fill: currentColor;
+}
+
+@keyframes composerSendSpin {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
 }
 
 .session-stats-wrap {
@@ -5187,7 +5556,7 @@ body.sidebar-resizing {
 
 .session-stats-popover {
 	position: absolute;
-	left: 32px;
+	right: 0;
 	bottom: -4px;
 	z-index: 20;
 	min-width: 170px;
@@ -5214,7 +5583,7 @@ body.sidebar-resizing {
 	align-items: center;
 	gap: 6px;
 	max-width: 100%;
-	padding: 4px 9px;
+	padding: 3px 8px;
 	border-radius: 999px;
 	border: 1px solid color-mix(in srgb, var(--accent) 36%, transparent);
 	background: color-mix(in srgb, var(--accent) 14%, transparent);
@@ -5223,9 +5592,24 @@ body.sidebar-resizing {
 	line-height: 1;
 }
 
-.composer-skill-draft-label {
-	opacity: 0.9;
-	font-weight: 550;
+.composer-skill-draft-pill.inline {
+	margin-top: 5px;
+	flex-shrink: 0;
+	max-width: 250px;
+}
+
+.composer-skill-draft-icon {
+	display: inline-grid;
+	place-items: center;
+	color: var(--accent);
+	flex-shrink: 0;
+}
+
+.composer-skill-draft-icon svg {
+	width: 12px;
+	height: 12px;
+	fill: currentColor;
+	stroke: none;
 }
 
 .composer-skill-draft-name {
@@ -5301,6 +5685,15 @@ body.sidebar-resizing {
 	background: color-mix(in srgb, var(--bg-soft) 72%, transparent);
 }
 
+.composer-slash-menu.keyboard-nav .composer-slash-item:hover {
+	background: transparent;
+}
+
+.composer-slash-menu.keyboard-nav .composer-slash-item.active,
+.composer-slash-menu.keyboard-nav .composer-slash-item.active:hover {
+	background: color-mix(in srgb, var(--bg-soft) 72%, transparent);
+}
+
 .composer-slash-item-label {
 	font-weight: 560;
 }
@@ -5367,9 +5760,9 @@ body.sidebar-resizing {
 .composer-under-row {
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
-	gap: 8px;
-	padding: 8px 12px 0;
+	justify-content: flex-end;
+	gap: 10px;
+	padding: 8px 2px 0 12px;
 }
 
 .composer-stats-slot {
@@ -5391,7 +5784,9 @@ body.sidebar-resizing {
 	padding: 0 9px;
 	font-size: 11px;
 	cursor: pointer;
-	margin-left: auto;
+	margin-left: 0;
+	position: relative;
+	top: -3px;
 }
 
 .composer-repo-btn svg {
@@ -5412,7 +5807,7 @@ body.sidebar-resizing {
 }
 
 .composer-repo-btn:hover {
-	background: color-mix(in srgb, var(--bg-soft) 70%, transparent);
+	background: transparent;
 	color: var(--text);
 }
 
@@ -5423,16 +5818,17 @@ body.sidebar-resizing {
 
 .git-branch-wrap {
 	position: relative;
-	margin-left: auto;
+	margin-left: 0;
 	display: inline-flex;
 	align-items: center;
+	top: -3px;
 }
 
 .git-branch-pill {
 	height: 28px;
 	border: none;
 	border-radius: 999px;
-	background: color-mix(in srgb, var(--bg-soft) 64%, transparent);
+	background: transparent;
 	color: var(--muted);
 	display: inline-flex;
 	align-items: center;
@@ -5455,7 +5851,7 @@ body.sidebar-resizing {
 
 .git-branch-pill:hover,
 .git-branch-pill.open {
-	background: color-mix(in srgb, var(--bg-soft) 80%, var(--bg-muted));
+	background: transparent;
 	color: var(--text);
 }
 
@@ -5667,11 +6063,8 @@ body.sidebar-resizing {
 		justify-content: flex-end;
 	}
 
-	.model-select-wrap {
-		width: 156px;
-		min-width: 132px;
-		max-width: 156px;
-		flex-basis: 156px;
+	.model-picker-trigger {
+		max-width: 220px;
 	}
 }
 
@@ -5701,10 +6094,8 @@ body.sidebar-resizing {
 		padding: 0 12px 12px;
 	}
 
-	.model-select-wrap {
-		width: auto;
-		max-width: none;
-		flex: 1;
+	.model-picker-trigger {
+		max-width: min(58vw, 260px);
 	}
 }
 
@@ -5715,7 +6106,7 @@ body.sidebar-resizing {
 .overlay {
 	position: fixed;
 	inset: 0;
-	z-index: 90;
+	z-index: 2400;
 	display: grid;
 	place-items: center;
 	background: rgba(0, 0, 0, 0.48);
@@ -6186,18 +6577,94 @@ body.sidebar-resizing {
 
 /* Settings */
 
-.settings-card {
-	max-width: 620px;
+.settings-view-root {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-height: 0;
+	width: 100%;
+	background: var(--bg);
 }
 
-.settings-header h2 {
-	margin: 0;
-	font-size: 18px;
+.settings-view-header {
+	min-height: 54px;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	padding: 10px 18px;
+	border-bottom: none;
+	background: color-mix(in srgb, var(--bg) 94%, transparent);
+}
+
+.settings-view-title-wrap {
+	min-width: 0;
+	display: grid;
+	gap: 2px;
+}
+
+.settings-view-title {
+	font-size: 19px;
+	font-weight: 620;
+	letter-spacing: -0.02em;
+}
+
+.settings-view-meta {
+	font-size: 11px;
+	color: var(--muted);
+}
+
+.settings-view-header-actions {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.settings-back-btn {
+	height: 30px;
+	padding: 0 10px;
+	border-radius: 999px;
+	border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+	background: color-mix(in srgb, var(--bg-soft) 62%, transparent);
+	color: var(--text);
+	font-size: 11px;
+	cursor: pointer;
+}
+
+.settings-back-btn:hover {
+	background: color-mix(in srgb, var(--bg-soft) 84%, transparent);
+}
+
+.settings-view-body {
+	flex: 1;
+	min-height: 0;
+	overflow: auto;
+	padding: 22px 22px 18px;
+	width: min(1180px, 100%);
+	margin: 0 auto;
+}
+
+.settings-view-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 14px;
+	align-content: start;
+}
+
+.settings-group {
+	border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+	border-radius: 14px;
+	background: color-mix(in srgb, var(--bg-elev) 96%, transparent);
+	overflow: hidden;
+}
+
+.settings-group-full {
+	grid-column: 1 / -1;
 }
 
 .settings-section {
 	padding: 14px 16px;
-	border-bottom: 1px solid var(--border);
+	border-bottom: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
 }
 
 .settings-section:last-child {
@@ -6212,9 +6679,59 @@ body.sidebar-resizing {
 	margin-bottom: 10px;
 }
 
+.settings-subdialog-backdrop {
+	position: fixed;
+	inset: 0;
+	background: color-mix(in srgb, var(--bg) 30%, transparent);
+	display: grid;
+	place-items: center;
+	z-index: 1200;
+}
+
+.settings-subdialog-card {
+	width: min(520px, calc(100vw - 48px));
+	border-radius: 14px;
+	border: 1px solid var(--border);
+	background: var(--bg-elev);
+	padding: 14px;
+	display: grid;
+	gap: 10px;
+	box-shadow: 0 20px 50px rgba(0, 0, 0, 0.34);
+}
+
+.settings-subdialog-title {
+	font-size: 14px;
+	font-weight: 600;
+}
+
+.settings-subdialog-desc {
+	font-size: 12px;
+	color: var(--muted);
+}
+
+.settings-subdialog-input {
+	height: 36px;
+	padding: 0 10px;
+	border-radius: 10px;
+	border: 1px solid var(--border);
+	background: var(--bg-muted);
+	color: var(--text);
+}
+
+.settings-subdialog-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+}
+
+.settings-subdialog-error {
+	font-size: 12px;
+	color: var(--danger);
+}
+
 .theme-grid {
 	display: grid;
-	grid-template-columns: 1fr 1fr;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
 	gap: 8px;
 }
 
@@ -6230,6 +6747,202 @@ body.sidebar-resizing {
 .theme-btn.active {
 	border-color: color-mix(in srgb, var(--accent) 72%, var(--border));
 	background: var(--accent-soft);
+}
+
+.appearance-theme-block {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+}
+
+.appearance-theme-header-row {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+	gap: 12px;
+}
+
+.appearance-profile-card {
+	border: 1px solid var(--border);
+	border-radius: 16px;
+	overflow: hidden;
+	background: color-mix(in srgb, var(--bg-elev) 95%, transparent);
+}
+
+.appearance-profile-header {
+	display: grid;
+	grid-template-columns: 1fr auto minmax(210px, 300px);
+	align-items: center;
+	gap: 8px;
+	padding: 10px 12px;
+	border-bottom: 1px solid var(--border);
+}
+
+.appearance-profile-title {
+	font-size: 14px;
+	font-weight: 600;
+}
+
+.appearance-profile-actions {
+	font-size: 12px;
+	color: var(--muted);
+}
+
+.appearance-profile-action-btn {
+	height: 30px;
+	padding: 0 10px;
+	border-radius: 10px;
+	border: 1px solid var(--border);
+	background: var(--bg-muted);
+	color: var(--text);
+	font-size: 12px;
+	cursor: pointer;
+}
+
+.appearance-profile-action-btn:hover {
+	background: var(--bg-soft);
+}
+
+.appearance-profile-action-btn:disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
+}
+
+.appearance-profile-action-btn:disabled:hover {
+	background: var(--bg-muted);
+}
+
+.appearance-theme-select-wrap {
+	display: flex;
+	justify-content: flex-end;
+}
+
+.appearance-theme-select {
+	min-width: 220px;
+	height: 36px;
+	border-radius: 12px;
+	border: 1px solid var(--border);
+	background: var(--bg-muted);
+	color: var(--text);
+	padding: 0 10px;
+}
+
+.appearance-profile-row {
+	display: grid;
+	grid-template-columns: 1fr auto;
+	align-items: center;
+	gap: 12px;
+	padding: 10px 12px;
+	border-bottom: 1px solid var(--border);
+}
+
+.appearance-profile-row:last-child {
+	border-bottom: none;
+}
+
+.appearance-profile-row > span:first-child {
+	font-size: 13px;
+	font-weight: 600;
+}
+
+.appearance-profile-row code {
+	font-family: var(--font-family-mono);
+	font-size: 12px;
+	padding: 6px 10px;
+	border: 1px solid var(--border);
+	border-radius: 10px;
+	background: var(--bg-muted);
+	max-width: 360px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.appearance-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	padding: 6px 10px;
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	background: var(--bg-muted);
+	font-size: 12px;
+	font-family: var(--font-family-mono);
+}
+
+.appearance-pill-button {
+	position: relative;
+	cursor: pointer;
+}
+
+.appearance-pill-button:hover {
+	background: var(--bg-soft);
+}
+
+.appearance-color-input {
+	position: absolute;
+	inset: 0;
+	opacity: 0;
+	cursor: pointer;
+	width: 100%;
+	height: 100%;
+}
+
+.appearance-swatch {
+	width: 14px;
+	height: 14px;
+	border-radius: 999px;
+	border: 1px solid var(--border);
+	flex-shrink: 0;
+}
+
+.appearance-contrast-wrap {
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+	min-width: 220px;
+}
+
+.appearance-contrast-wrap input[type="range"] {
+	width: 160px;
+}
+
+.appearance-contrast-wrap span {
+	font-size: 13px;
+	font-weight: 600;
+	min-width: 26px;
+	text-align: right;
+}
+
+.appearance-font-input {
+	width: min(360px, 100%);
+	height: 36px;
+	padding: 0 10px;
+	border-radius: 10px;
+	border: 1px solid var(--border);
+	background: var(--bg-muted);
+	color: var(--text);
+	font-size: 12px;
+}
+
+@media (max-width: 920px) {
+	.settings-view-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.appearance-profile-header {
+		grid-template-columns: 1fr;
+		align-items: stretch;
+	}
+
+	.appearance-theme-select-wrap {
+		justify-content: flex-start;
+	}
+
+	.appearance-theme-select {
+		width: 100%;
+		max-width: 100%;
+	}
 }
 
 .settings-row {

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,0 +1,55 @@
+/*
+ * Semantic theme mapping.
+ *
+ * Keep this layer aligned with Pi theme tokens so custom Pi ecosystem themes
+ * can map into desktop semantic tokens later.
+ */
+
+:root,
+:root.dark {
+	color-scheme: dark;
+
+	--color-bg-app: #0d0d0f;
+	--color-bg-elevated: #141417;
+	--color-bg-muted: #1b1b1f;
+	--color-bg-soft: #202026;
+	--color-bg-sidebar: #0f1012;
+	--color-bg-workspace-chrome: #131419;
+	--color-bg-workspace-chrome-soft: #1a1b22;
+
+	--color-border-default: rgb(255 255 255 / 0.08);
+	--color-text-primary: #f5f5f7;
+	--color-text-secondary: #9a9aa3;
+	--color-text-tertiary: #6f7078;
+
+	--color-accent-primary: #7a818f;
+	--color-accent-soft: rgb(122 129 143 / 0.2);
+
+	--color-state-danger: #ef4444;
+	--color-state-success: #22c55e;
+	--color-state-warning: #f59e0b;
+}
+
+:root.light {
+	color-scheme: light;
+
+	--color-bg-app: #f3f3f5;
+	--color-bg-elevated: #ffffff;
+	--color-bg-muted: #f6f6f8;
+	--color-bg-soft: #ececf0;
+	--color-bg-sidebar: #ececf1;
+	--color-bg-workspace-chrome: #eff0f4;
+	--color-bg-workspace-chrome-soft: #e7e9f0;
+
+	--color-border-default: rgb(12 12 12 / 0.12);
+	--color-text-primary: #151518;
+	--color-text-secondary: #555863;
+	--color-text-tertiary: #80838f;
+
+	--color-accent-primary: #6b7280;
+	--color-accent-soft: rgb(107 114 128 / 0.16);
+
+	--color-state-danger: #dc2626;
+	--color-state-success: #16a34a;
+	--color-state-warning: #d97706;
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,126 @@
+/*
+ * Phase 1 foundation tokens (clean-room, Codex-inspired scale)
+ *
+ * These are desktop design-system primitives.
+ * Semantic theme mapping lives in theme.css.
+ */
+
+:root {
+	/* Spacing */
+	--space-unit: 0.25rem;
+	--space-0: 0;
+	--space-1: calc(var(--space-unit) * 1);
+	--space-2: calc(var(--space-unit) * 2);
+	--space-3: calc(var(--space-unit) * 3);
+	--space-4: calc(var(--space-unit) * 4);
+	--space-5: calc(var(--space-unit) * 5);
+	--space-6: calc(var(--space-unit) * 6);
+	--space-8: calc(var(--space-unit) * 8);
+	--space-10: calc(var(--space-unit) * 10);
+
+	/* Typography */
+	--font-family-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Segoe UI", Roboto, sans-serif;
+	--font-size-xs: 10px;
+	--font-size-sm: 12px;
+	--font-size-base: 13px;
+	--font-size-lg: 16px;
+	--font-size-xl: 20px;
+
+	/* Radius */
+	--radius-scale: 1;
+	--radius-sm-base: 0.375rem;
+	--radius-md-base: 0.5rem;
+	--radius-lg-base: 0.625rem;
+	--radius-xl-base: 0.75rem;
+	--radius-2xl-base: 1rem;
+	--radius-3xl-base: 1.25rem;
+	--radius-4xl-base: 1.5rem;
+	--radius-sm: calc(var(--radius-sm-base) * var(--radius-scale));
+	--radius-md: calc(var(--radius-md-base) * var(--radius-scale));
+	--radius-lg: calc(var(--radius-lg-base) * var(--radius-scale));
+	--radius-xl: calc(var(--radius-xl-base) * var(--radius-scale));
+	--radius-2xl: calc(var(--radius-2xl-base) * var(--radius-scale));
+	--radius-3xl: calc(var(--radius-3xl-base) * var(--radius-scale));
+	--radius-4xl: calc(var(--radius-4xl-base) * var(--radius-scale));
+
+	/* Sizing */
+	--size-toolbar: 46px;
+	--size-toolbar-sm: 36px;
+	--size-top-chrome: 44px;
+
+	/* Layout */
+	--layout-padding-row-y: calc(var(--space-unit) * 1.25);
+	--layout-padding-panel-base: calc(var(--space-unit) * 5);
+	--layout-padding-panel: var(--layout-padding-panel-base);
+	--layout-thread-content-max-width: 48rem;
+	--layout-thread-composer-max-width: calc(var(--layout-thread-content-max-width) + 1rem);
+	--layout-markdown-wide-max-width: 80rem;
+	--layout-markdown-wide-max-height: 80vh;
+
+	/* Motion */
+	--ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+	--ease-enter: cubic-bezier(0.19, 1, 0.22, 1);
+	--duration-fast: 140ms;
+	--duration-base: 180ms;
+	--duration-relaxed: 300ms;
+
+	/* Codex-like primitive palette */
+	--color-gray-0: #fff;
+	--color-gray-50: #f9f9f9;
+	--color-gray-100: #ededed;
+	--color-gray-300: #afafaf;
+	--color-gray-500: #5d5d5d;
+	--color-gray-600: #414141;
+	--color-gray-750: #282828;
+	--color-gray-800: #212121;
+	--color-gray-900: #181818;
+	--color-gray-1000: #0d0d0d;
+
+	--color-blue-50: #e5f3ff;
+	--color-blue-100: #99ceff;
+	--color-blue-300: #339cff;
+	--color-blue-400: #0285ff;
+
+	--color-red-50: #ffd9d9;
+	--color-red-300: #ff6764;
+	--color-red-400: #fa423e;
+	--color-red-500: #e02e2a;
+	--color-red-600: #ba2623;
+
+	--color-orange-50: #ffe7d9;
+	--color-orange-300: #ff8549;
+	--color-orange-400: #fb6a22;
+	--color-orange-500: #e25507;
+	--color-orange-700: #923b0f;
+
+	--color-green-300: #40c977;
+	--color-green-400: #04b84c;
+	--color-green-500: #00a240;
+
+	--color-purple-300: #ad7bf9;
+	--color-purple-400: #924ff7;
+
+	--color-yellow-300: #ffd240;
+	--color-yellow-400: #ffc300;
+
+	/* Semantic defaults (dark baseline; overridden in theme.css) */
+	--color-bg-app: #0d0d0f;
+	--color-bg-elevated: #141417;
+	--color-bg-muted: #1b1b1f;
+	--color-bg-soft: #202026;
+	--color-bg-sidebar: #17171b;
+	--color-bg-workspace-chrome: #15161b;
+	--color-bg-workspace-chrome-soft: #1c1d24;
+
+	--color-border-default: rgb(255 255 255 / 0.08);
+	--color-text-primary: #f5f5f7;
+	--color-text-secondary: #9a9aa3;
+	--color-text-tertiary: #6f7078;
+
+	--color-accent-primary: #7a818f;
+	--color-accent-soft: rgb(122 129 143 / 0.2);
+
+	--color-state-danger: #ef4444;
+	--color-state-success: #22c55e;
+	--color-state-warning: #f59e0b;
+}

--- a/src/theme/appearance-profiles.ts
+++ b/src/theme/appearance-profiles.ts
@@ -1,0 +1,173 @@
+import type { DesktopThemeResolved } from "./theme-manager.js";
+
+export type ThemeVariant = "light" | "dark";
+
+export interface DesktopAppearanceProfile {
+	themeName: string;
+	accent: string;
+	background: string;
+	foreground: string;
+	uiFont: string;
+	codeFont: string;
+	translucentSidebar: boolean;
+	contrast: number;
+}
+
+export interface DesktopAppearanceProfiles {
+	light: DesktopAppearanceProfile;
+	dark: DesktopAppearanceProfile;
+}
+
+export const DESKTOP_APPEARANCE_PROFILES_STORAGE_KEY = "pi-desktop.appearance.profiles.v1";
+export const DESKTOP_APPEARANCE_PROFILE_CHANGED_EVENT = "pi-desktop:appearance-profile-changed";
+
+const DEFAULT_UI_FONT = '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+const DEFAULT_CODE_FONT = 'ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace';
+
+export const DEFAULT_APPEARANCE_PROFILES: DesktopAppearanceProfiles = {
+	light: {
+		themeName: "pi-desktop-notion-light",
+		accent: "",
+		background: "",
+		foreground: "",
+		uiFont: DEFAULT_UI_FONT,
+		codeFont: DEFAULT_CODE_FONT,
+		translucentSidebar: false,
+		contrast: 45,
+	},
+	dark: {
+		themeName: "pi-desktop-notion-dark",
+		accent: "",
+		background: "",
+		foreground: "",
+		uiFont: DEFAULT_UI_FONT,
+		codeFont: DEFAULT_CODE_FONT,
+		translucentSidebar: false,
+		contrast: 60,
+	},
+};
+
+function clampContrast(value: number): number {
+	if (!Number.isFinite(value)) return 50;
+	return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function sanitizeFont(value: unknown, fallback: string): string {
+	if (typeof value !== "string") return fallback;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : fallback;
+}
+
+function sanitizeThemeName(value: unknown): string {
+	if (typeof value !== "string") return "";
+	const trimmed = value.trim();
+	if (!trimmed || trimmed === "dark" || trimmed === "light" || trimmed === "system") return "";
+	return trimmed;
+}
+
+function sanitizeProfile(value: unknown, fallback: DesktopAppearanceProfile): DesktopAppearanceProfile {
+	const input = value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+	const themeName = sanitizeThemeName(input.themeName) || fallback.themeName;
+	return {
+		themeName,
+		// Color overrides are intentionally ephemeral in Settings and only persisted via "Create theme".
+		accent: "",
+		background: "",
+		foreground: "",
+		uiFont: sanitizeFont(input.uiFont, fallback.uiFont),
+		codeFont: sanitizeFont(input.codeFont, fallback.codeFont),
+		translucentSidebar: typeof input.translucentSidebar === "boolean" ? input.translucentSidebar : fallback.translucentSidebar,
+		contrast: clampContrast(typeof input.contrast === "number" ? input.contrast : fallback.contrast),
+	};
+}
+
+export function loadDesktopAppearanceProfiles(): DesktopAppearanceProfiles {
+	try {
+		const raw = localStorage.getItem(DESKTOP_APPEARANCE_PROFILES_STORAGE_KEY);
+		if (!raw) {
+			return {
+				light: sanitizeProfile({}, DEFAULT_APPEARANCE_PROFILES.light),
+				dark: sanitizeProfile({}, DEFAULT_APPEARANCE_PROFILES.dark),
+			};
+		}
+		const parsed = JSON.parse(raw) as unknown;
+		const input = parsed && typeof parsed === "object" && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : {};
+		return {
+			light: sanitizeProfile(input.light, DEFAULT_APPEARANCE_PROFILES.light),
+			dark: sanitizeProfile(input.dark, DEFAULT_APPEARANCE_PROFILES.dark),
+		};
+	} catch {
+		return {
+			light: sanitizeProfile({}, DEFAULT_APPEARANCE_PROFILES.light),
+			dark: sanitizeProfile({}, DEFAULT_APPEARANCE_PROFILES.dark),
+		};
+	}
+}
+
+export function saveDesktopAppearanceProfiles(profiles: DesktopAppearanceProfiles): void {
+	try {
+		localStorage.setItem(DESKTOP_APPEARANCE_PROFILES_STORAGE_KEY, JSON.stringify(profiles));
+	} catch {
+		// ignore
+	}
+}
+
+export function getAppearanceProfileForResolvedTheme(
+	profiles: DesktopAppearanceProfiles,
+	resolved: DesktopThemeResolved,
+): DesktopAppearanceProfile {
+	return resolved === "light" ? profiles.light : profiles.dark;
+}
+
+export function applyDesktopAppearanceProfileToRoot(
+	resolved: DesktopThemeResolved,
+	profiles: DesktopAppearanceProfiles,
+): void {
+	const profile = getAppearanceProfileForResolvedTheme(profiles, resolved);
+	const root = document.documentElement;
+
+	if (profile.accent) {
+		root.style.setProperty("--color-accent-primary", profile.accent);
+		root.style.setProperty("--color-accent-soft", `color-mix(in srgb, ${profile.accent} 20%, transparent)`);
+	}
+
+	if (profile.background) {
+		const neutralLift = resolved === "dark" ? "white" : "black";
+		const sidebarBase = resolved === "dark" ? "86%" : "92%";
+		const sidebarShade = resolved === "dark" ? "14%" : "8%";
+		root.style.setProperty("--color-bg-app", profile.background);
+		root.style.setProperty("--color-bg-elevated", `color-mix(in srgb, ${profile.background} 94%, ${neutralLift} 6%)`);
+		root.style.setProperty("--color-bg-muted", `color-mix(in srgb, ${profile.background} 89%, ${neutralLift} 11%)`);
+		root.style.setProperty("--color-bg-soft", `color-mix(in srgb, ${profile.background} 84%, ${neutralLift} 16%)`);
+		root.style.setProperty("--color-bg-sidebar", `color-mix(in srgb, ${profile.background} ${sidebarBase}, black ${sidebarShade})`);
+		root.style.setProperty("--color-bg-workspace-chrome", `color-mix(in srgb, ${profile.background} 92%, ${neutralLift} 8%)`);
+		root.style.setProperty("--color-bg-workspace-chrome-soft", `color-mix(in srgb, ${profile.background} 86%, ${neutralLift} 14%)`);
+	}
+
+	if (profile.foreground) {
+		const bgForMix = profile.background || "transparent";
+		root.style.setProperty("--color-text-primary", profile.foreground);
+		root.style.setProperty("--color-text-secondary", `color-mix(in srgb, ${profile.foreground} 68%, ${bgForMix} 32%)`);
+		root.style.setProperty("--color-text-tertiary", `color-mix(in srgb, ${profile.foreground} 52%, ${bgForMix} 48%)`);
+		root.style.setProperty("--color-border-default", `color-mix(in srgb, ${profile.foreground} 12%, transparent)`);
+	}
+
+	root.style.setProperty("--font-family-sans", profile.uiFont);
+	root.style.setProperty("--font-family-mono", profile.codeFont);
+	root.style.setProperty("--desktop-sidebar-opacity", profile.translucentSidebar ? "88%" : "100%");
+	root.style.setProperty("--desktop-sidebar-blur", profile.translucentSidebar ? "14px" : "0px");
+	root.style.setProperty("--desktop-sidebar-tint-color", profile.foreground || "var(--color-text-primary)");
+	root.style.setProperty("--desktop-sidebar-tint-strength", profile.translucentSidebar ? "8%" : "0%");
+	root.style.setProperty("--desktop-chrome-opacity", profile.translucentSidebar ? "92%" : "100%");
+	root.style.setProperty("--desktop-chrome-blur", profile.translucentSidebar ? "12px" : "0px");
+	root.style.setProperty("--desktop-chrome-tint-strength", profile.translucentSidebar ? "5%" : "0%");
+	root.style.setProperty("--desktop-contrast", String(profile.contrast));
+
+	const borderMix = 40 + Math.round((profile.contrast / 100) * 60);
+	root.style.setProperty("--border", `color-mix(in srgb, var(--color-border-default) ${borderMix}%, transparent)`);
+	root.dataset.desktopContrast = String(profile.contrast);
+}
+
+export function notifyDesktopAppearanceProfileChanged(): void {
+	window.dispatchEvent(new CustomEvent(DESKTOP_APPEARANCE_PROFILE_CHANGED_EVENT));
+}

--- a/src/theme/bundled-themes.ts
+++ b/src/theme/bundled-themes.ts
@@ -1,0 +1,326 @@
+interface BundledThemeSpec {
+	fileName: string;
+	legacyFileName?: string;
+	name: string;
+	variant: "dark" | "light";
+	codeThemeId: string;
+	accent: string;
+	surface: string;
+	ink: string;
+	diffAdded: string;
+	diffRemoved: string;
+	skill: string;
+	contrast: number;
+}
+
+const BUNDLED_THEME_SPECS: readonly BundledThemeSpec[] = [
+	{
+		fileName: "pi-desktop-notion-dark.json",
+		legacyFileName: "codex-notion-dark.json",
+		name: "pi-desktop-notion-dark",
+		variant: "dark",
+		codeThemeId: "notion",
+		accent: "#3183d8",
+		surface: "#191919",
+		ink: "#d9d9d8",
+		diffAdded: "#4ec9b0",
+		diffRemoved: "#fa423e",
+		skill: "#3183d8",
+		contrast: 60,
+	},
+	{
+		fileName: "pi-desktop-catppuccin-dark.json",
+		legacyFileName: "codex-catppuccin-dark.json",
+		name: "pi-desktop-catppuccin-dark",
+		variant: "dark",
+		codeThemeId: "catppuccin",
+		accent: "#cba6f7",
+		surface: "#1e1e2e",
+		ink: "#cdd6f4",
+		diffAdded: "#a6e3a1",
+		diffRemoved: "#f38ba8",
+		skill: "#cba6f7",
+		contrast: 60,
+	},
+	{
+		fileName: "pi-desktop-github-dark.json",
+		legacyFileName: "codex-github-dark.json",
+		name: "pi-desktop-github-dark",
+		variant: "dark",
+		codeThemeId: "github",
+		accent: "#1f6feb",
+		surface: "#0d1117",
+		ink: "#e6edf3",
+		diffAdded: "#3fb950",
+		diffRemoved: "#f85149",
+		skill: "#bc8cff",
+		contrast: 60,
+	},
+	{
+		fileName: "pi-desktop-vscode-plus-dark.json",
+		legacyFileName: "codex-vscode-plus-dark.json",
+		name: "pi-desktop-vscode-plus-dark",
+		variant: "dark",
+		codeThemeId: "vscode-plus",
+		accent: "#007acc",
+		surface: "#1e1e1e",
+		ink: "#d4d4d4",
+		diffAdded: "#369432",
+		diffRemoved: "#f44747",
+		skill: "#000080",
+		contrast: 60,
+	},
+	{
+		fileName: "pi-desktop-notion-light.json",
+		legacyFileName: "codex-notion-light.json",
+		name: "pi-desktop-notion-light",
+		variant: "light",
+		codeThemeId: "notion",
+		accent: "#3183d8",
+		surface: "#ffffff",
+		ink: "#37352f",
+		diffAdded: "#008000",
+		diffRemoved: "#a31515",
+		skill: "#0000ff",
+		contrast: 45,
+	},
+	{
+		fileName: "pi-desktop-vscode-plus-light.json",
+		legacyFileName: "codex-vscode-plus-light.json",
+		name: "pi-desktop-vscode-plus-light",
+		variant: "light",
+		codeThemeId: "vscode-plus",
+		accent: "#007acc",
+		surface: "#ffffff",
+		ink: "#000000",
+		diffAdded: "#008000",
+		diffRemoved: "#ee0000",
+		skill: "#0000ff",
+		contrast: 45,
+	},
+	{
+		fileName: "pi-desktop-catppuccin-light.json",
+		legacyFileName: "codex-catppuccin-light.json",
+		name: "pi-desktop-catppuccin-light",
+		variant: "light",
+		codeThemeId: "catppuccin",
+		accent: "#8839ef",
+		surface: "#eff1f5",
+		ink: "#4c4f69",
+		diffAdded: "#40a02b",
+		diffRemoved: "#d20f39",
+		skill: "#8839ef",
+		contrast: 45,
+	},
+	{
+		fileName: "pi-desktop-github-light.json",
+		legacyFileName: "codex-github-light.json",
+		name: "pi-desktop-github-light",
+		variant: "light",
+		codeThemeId: "github",
+		accent: "#0969da",
+		surface: "#ffffff",
+		ink: "#1f2328",
+		diffAdded: "#1a7f37",
+		diffRemoved: "#cf222e",
+		skill: "#8250df",
+		contrast: 45,
+	},
+] as const;
+
+const BUNDLED_THEME_ID_SET = new Set<string>(
+	BUNDLED_THEME_SPECS.flatMap((spec) => {
+		const ids = [spec.fileName.replace(/\.json$/i, "").toLowerCase()];
+		if (spec.legacyFileName) ids.push(spec.legacyFileName.replace(/\.json$/i, "").toLowerCase());
+		return ids;
+	}),
+);
+
+export function isBundledThemeId(id: string): boolean {
+	return BUNDLED_THEME_ID_SET.has(id.trim().toLowerCase());
+}
+
+function joinFsPath(base: string, child: string): string {
+	const b = base.replace(/\\/g, "/").replace(/\/+$/, "");
+	const c = child.replace(/\\/g, "/").replace(/^\/+/, "");
+	return b ? `${b}/${c}` : c;
+}
+
+function toPiThemeDocument(spec: BundledThemeSpec): Record<string, unknown> {
+	return {
+		name: spec.name,
+		vars: {
+			accent: spec.accent,
+			surface: spec.surface,
+			ink: spec.ink,
+			diffAdded: spec.diffAdded,
+			diffRemoved: spec.diffRemoved,
+			skill: spec.skill,
+		},
+		colors: {
+			accent: "accent",
+			text: "ink",
+			muted: "ink",
+			dim: "ink",
+			selectedBg: "surface",
+			userMessageBg: "surface",
+			userMessageText: "ink",
+			customMessageBg: "surface",
+			customMessageText: "ink",
+			toolPendingBg: "surface",
+			toolSuccessBg: "surface",
+			toolErrorBg: "surface",
+			toolTitle: "skill",
+			toolOutput: "ink",
+			diffAdded: "diffAdded",
+			diffRemoved: "diffRemoved",
+		},
+		piDesktop: {
+			source: "pi-desktop-theme-v1",
+			variant: spec.variant,
+			contrast: spec.contrast,
+			codeThemeId: spec.codeThemeId,
+		},
+	};
+}
+
+const BUNDLED_THEMES_MARKER = ".pi-desktop-default-themes-installed-v1";
+
+export interface BundledThemeInstallResult {
+	created: number;
+	renamed: number;
+	removedLegacy: number;
+	skippedByMarker: boolean;
+}
+
+export interface BundledThemesStatus {
+	themesRoot: string;
+	total: number;
+	installedCount: number;
+	installed: boolean;
+}
+
+export interface BundledThemeRemoveResult {
+	removed: number;
+	removedLegacy: number;
+}
+
+async function resolveThemesRoot(): Promise<string | null> {
+	const { homeDir } = await import("@tauri-apps/api/path");
+	const home = (await homeDir()).replace(/\\/g, "/").replace(/\/+$/, "");
+	if (!home) return null;
+	return joinFsPath(joinFsPath(joinFsPath(home, ".pi"), "agent"), "themes");
+}
+
+async function installBundledThemes(options: { respectMarker: boolean }): Promise<BundledThemeInstallResult> {
+	const { exists, mkdir, writeTextFile, rename, remove } = await import("@tauri-apps/plugin-fs");
+	const themesRoot = await resolveThemesRoot();
+	if (!themesRoot) return { created: 0, renamed: 0, removedLegacy: 0, skippedByMarker: true };
+	await mkdir(themesRoot, { recursive: true });
+
+	const markerPath = joinFsPath(themesRoot, BUNDLED_THEMES_MARKER);
+	if (options.respectMarker && (await exists(markerPath))) {
+		return { created: 0, renamed: 0, removedLegacy: 0, skippedByMarker: true };
+	}
+
+	let created = 0;
+	let renamed = 0;
+	let removedLegacy = 0;
+
+	for (const spec of BUNDLED_THEME_SPECS) {
+		const targetPath = joinFsPath(themesRoot, spec.fileName);
+		const legacyPath = spec.legacyFileName ? joinFsPath(themesRoot, spec.legacyFileName) : null;
+
+		if (!(await exists(targetPath)) && legacyPath && (await exists(legacyPath))) {
+			try {
+				await rename(legacyPath, targetPath);
+				renamed += 1;
+			} catch {
+				// ignore and fallback to write below
+			}
+		}
+
+		if (!(await exists(targetPath))) {
+			const doc = toPiThemeDocument(spec);
+			await writeTextFile(targetPath, `${JSON.stringify(doc, null, 2)}\n`);
+			created += 1;
+		}
+
+		if (legacyPath && legacyPath !== targetPath && (await exists(legacyPath))) {
+			try {
+				await remove(legacyPath);
+				removedLegacy += 1;
+			} catch {
+				// ignore cleanup failure
+			}
+		}
+	}
+
+	await writeTextFile(markerPath, `${new Date().toISOString()}\n`);
+	return { created, renamed, removedLegacy, skippedByMarker: false };
+}
+
+export async function ensureBundledThemesInstalled(): Promise<void> {
+	try {
+		await installBundledThemes({ respectMarker: true });
+	} catch {
+		// best effort only
+	}
+}
+
+export async function restoreBundledThemes(): Promise<BundledThemeInstallResult> {
+	return installBundledThemes({ respectMarker: false });
+}
+
+export async function getBundledThemesStatus(): Promise<BundledThemesStatus> {
+	const { exists } = await import("@tauri-apps/plugin-fs");
+	const themesRoot = await resolveThemesRoot();
+	if (!themesRoot) {
+		return { themesRoot: "", total: BUNDLED_THEME_SPECS.length, installedCount: 0, installed: false };
+	}
+	let installedCount = 0;
+	for (const spec of BUNDLED_THEME_SPECS) {
+		const targetPath = joinFsPath(themesRoot, spec.fileName);
+		if (await exists(targetPath)) installedCount += 1;
+	}
+	return {
+		themesRoot,
+		total: BUNDLED_THEME_SPECS.length,
+		installedCount,
+		installed: installedCount === BUNDLED_THEME_SPECS.length,
+	};
+}
+
+export async function removeBundledThemes(): Promise<BundledThemeRemoveResult> {
+	const { exists, remove } = await import("@tauri-apps/plugin-fs");
+	const themesRoot = await resolveThemesRoot();
+	if (!themesRoot) return { removed: 0, removedLegacy: 0 };
+
+	let removed = 0;
+	let removedLegacy = 0;
+	for (const spec of BUNDLED_THEME_SPECS) {
+		const targetPath = joinFsPath(themesRoot, spec.fileName);
+		if (await exists(targetPath)) {
+			try {
+				await remove(targetPath);
+				removed += 1;
+			} catch {
+				// ignore
+			}
+		}
+		if (spec.legacyFileName) {
+			const legacyPath = joinFsPath(themesRoot, spec.legacyFileName);
+			if (await exists(legacyPath)) {
+				try {
+					await remove(legacyPath);
+					removedLegacy += 1;
+				} catch {
+					// ignore
+				}
+			}
+		}
+	}
+
+	// Keep marker file so automatic first-run bootstrap does not reinstall after explicit uninstall.
+	return { removed, removedLegacy };
+}

--- a/src/theme/pi-theme-bridge.ts
+++ b/src/theme/pi-theme-bridge.ts
@@ -1,0 +1,382 @@
+import { getAppearanceProfileForResolvedTheme, loadDesktopAppearanceProfiles } from "./appearance-profiles.js";
+import type { DesktopThemeResolved } from "./theme-manager.js";
+
+interface PiThemeFile {
+	name?: string;
+	vars?: Record<string, unknown>;
+	colors?: Record<string, unknown>;
+}
+
+// Theme input for desktop should stay minimal (Codex-like):
+// Accent + Background + Foreground are the primary user-facing knobs.
+const PI_THEME_OVERLAY_VARS = [
+	"--color-accent-primary",
+	"--color-accent-soft",
+	"--color-bg-app",
+	"--color-bg-elevated",
+	"--color-bg-muted",
+	"--color-bg-soft",
+	"--color-bg-sidebar",
+	"--color-bg-workspace-chrome",
+	"--color-bg-workspace-chrome-soft",
+	"--color-text-primary",
+	"--color-text-secondary",
+	"--color-text-tertiary",
+	"--color-border-default",
+] as const;
+
+const PI_THEME_ACCENT_TOKENS = ["accent", "toolTitle", "mdHeading", "mdLink", "customMessageLabel"] as const;
+const PI_THEME_BACKGROUND_TOKENS = ["selectedBg", "userMessageBg", "customMessageBg", "toolPendingBg", "mdCodeBlock"] as const;
+const PI_THEME_FOREGROUND_TOKENS = ["text", "userMessageText", "customMessageText", "toolOutput", "syntaxVariable"] as const;
+
+const XTERM_LEVELS = [0, 95, 135, 175, 215, 255] as const;
+
+let lastSyncKey = "";
+let lastSyncAt = 0;
+
+function normalizeFsPath(path: string | null | undefined): string {
+	if (!path) return "";
+	return path.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
+function joinFsPath(base: string, child: string): string {
+	const b = base.replace(/\\/g, "/").replace(/\/+$/, "");
+	const c = child.replace(/\\/g, "/").replace(/^\/+/, "");
+	return b ? `${b}/${c}` : c;
+}
+
+function expandHomePath(path: string, home: string): string {
+	if (path === "~") return home;
+	if (path.startsWith("~/")) return joinFsPath(home, path.slice(2));
+	return path;
+}
+
+function isLikelyAbsolutePath(path: string): boolean {
+	if (path.startsWith("/")) return true;
+	return /^[A-Za-z]:[\\/]/.test(path);
+}
+
+function normalizeThemeModeFromDom(): DesktopThemeResolved {
+	return document.documentElement.classList.contains("light") ? "light" : "dark";
+}
+
+function normalizeThemeName(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function xtermIndexToHex(index: number): string | null {
+	if (!Number.isInteger(index) || index < 0 || index > 255) return null;
+	const hex = (value: number): string => value.toString(16).padStart(2, "0");
+
+	if (index < 16) {
+		const ansi = [
+			"#000000",
+			"#800000",
+			"#008000",
+			"#808000",
+			"#000080",
+			"#800080",
+			"#008080",
+			"#c0c0c0",
+			"#808080",
+			"#ff0000",
+			"#00ff00",
+			"#ffff00",
+			"#0000ff",
+			"#ff00ff",
+			"#00ffff",
+			"#ffffff",
+		] as const;
+		return ansi[index] ?? null;
+	}
+
+	if (index >= 16 && index <= 231) {
+		const value = index - 16;
+		const r = Math.floor(value / 36);
+		const g = Math.floor((value % 36) / 6);
+		const b = value % 6;
+		return `#${hex(XTERM_LEVELS[r] ?? 0)}${hex(XTERM_LEVELS[g] ?? 0)}${hex(XTERM_LEVELS[b] ?? 0)}`;
+	}
+
+	const gray = 8 + (index - 232) * 10;
+	return `#${hex(gray)}${hex(gray)}${hex(gray)}`;
+}
+
+function normalizeColorString(input: string): string | null {
+	const value = input.trim();
+	if (!value) return null;
+	if (/^#([0-9a-f]{3,8})$/i.test(value)) return value;
+	if (/^\d{1,3}$/.test(value)) return xtermIndexToHex(Number(value));
+	if (/^(rgb|hsl|oklch|oklab|color|var)\(/i.test(value)) return value;
+	return null;
+}
+
+function resolveThemeColorValue(
+	value: unknown,
+	theme: PiThemeFile,
+	seenVars: Set<string>,
+	seenColorRefs: Set<string>,
+): string | null {
+	if (typeof value === "number") return xtermIndexToHex(value);
+	if (typeof value !== "string") return null;
+
+	const direct = normalizeColorString(value);
+	if (direct) return direct;
+
+	const ref = value.trim();
+	if (!ref) return null;
+
+	const vars = theme.vars ?? {};
+	if (Object.prototype.hasOwnProperty.call(vars, ref)) {
+		if (seenVars.has(ref)) return null;
+		seenVars.add(ref);
+		const resolved = resolveThemeColorValue(vars[ref], theme, seenVars, seenColorRefs);
+		seenVars.delete(ref);
+		if (resolved) return resolved;
+	}
+
+	const colors = theme.colors ?? {};
+	if (Object.prototype.hasOwnProperty.call(colors, ref)) {
+		if (seenColorRefs.has(ref)) return null;
+		seenColorRefs.add(ref);
+		const resolved = resolveThemeColorValue(colors[ref], theme, seenVars, seenColorRefs);
+		seenColorRefs.delete(ref);
+		if (resolved) return resolved;
+	}
+
+	return null;
+}
+
+function resolveThemeColorToken(theme: PiThemeFile, token: string): string | null {
+	const colors = theme.colors ?? {};
+	if (!Object.prototype.hasOwnProperty.call(colors, token)) return null;
+	return resolveThemeColorValue(colors[token], theme, new Set<string>(), new Set<string>([token]));
+}
+
+function firstResolvedToken(theme: PiThemeFile, tokens: readonly string[]): string | null {
+	for (const token of tokens) {
+		const value = resolveThemeColorToken(theme, token);
+		if (value) return value;
+	}
+	return null;
+}
+
+function buildPiThemeOverlay(
+	theme: PiThemeFile,
+	mode: DesktopThemeResolved,
+): Partial<Record<(typeof PI_THEME_OVERLAY_VARS)[number], string>> {
+	const result: Partial<Record<(typeof PI_THEME_OVERLAY_VARS)[number], string>> = {};
+	const accent = firstResolvedToken(theme, PI_THEME_ACCENT_TOKENS);
+	const background = firstResolvedToken(theme, PI_THEME_BACKGROUND_TOKENS);
+	const foreground = firstResolvedToken(theme, PI_THEME_FOREGROUND_TOKENS);
+	const neutralLift = mode === "dark" ? "white" : "black";
+	const sidebarBase = mode === "dark" ? "86%" : "92%";
+	const sidebarShade = mode === "dark" ? "14%" : "8%";
+
+	if (accent) {
+		result["--color-accent-primary"] = accent;
+		result["--color-accent-soft"] = `color-mix(in srgb, ${accent} 20%, transparent)`;
+	}
+
+	// Important: foreground should mainly control text, not surface tint.
+	// Keep surface derivation tied to background to avoid colored "veil" overlays.
+	if (background) {
+		result["--color-bg-app"] = background;
+		result["--color-bg-elevated"] = `color-mix(in srgb, ${background} 94%, ${neutralLift} 6%)`;
+		result["--color-bg-muted"] = `color-mix(in srgb, ${background} 89%, ${neutralLift} 11%)`;
+		result["--color-bg-soft"] = `color-mix(in srgb, ${background} 84%, ${neutralLift} 16%)`;
+		result["--color-bg-sidebar"] = `color-mix(in srgb, ${background} ${sidebarBase}, black ${sidebarShade})`;
+		result["--color-bg-workspace-chrome"] = `color-mix(in srgb, ${background} 92%, ${neutralLift} 8%)`;
+		result["--color-bg-workspace-chrome-soft"] = `color-mix(in srgb, ${background} 86%, ${neutralLift} 14%)`;
+	}
+
+	if (foreground) {
+		result["--color-text-primary"] = foreground;
+		if (background) {
+			result["--color-text-secondary"] = `color-mix(in srgb, ${foreground} 68%, ${background} 32%)`;
+			result["--color-text-tertiary"] = `color-mix(in srgb, ${foreground} 52%, ${background} 48%)`;
+		} else {
+			result["--color-text-secondary"] = `color-mix(in srgb, ${foreground} 68%, transparent)`;
+			result["--color-text-tertiary"] = `color-mix(in srgb, ${foreground} 52%, transparent)`;
+		}
+		// Keep border subtle and neutral-ish relative to foreground.
+		result["--color-border-default"] = `color-mix(in srgb, ${foreground} 12%, transparent)`;
+	}
+
+	return result;
+}
+
+function clearPiThemeOverlay(root: HTMLElement): void {
+	for (const cssVar of PI_THEME_OVERLAY_VARS) {
+		root.style.removeProperty(cssVar);
+	}
+	delete root.dataset.piTheme;
+}
+
+function applyPiThemeOverlay(root: HTMLElement, overlay: Partial<Record<(typeof PI_THEME_OVERLAY_VARS)[number], string>>, themeName: string): void {
+	for (const cssVar of PI_THEME_OVERLAY_VARS) {
+		const value = overlay[cssVar];
+		if (value && value.trim().length > 0) {
+			root.style.setProperty(cssVar, value);
+		} else {
+			root.style.removeProperty(cssVar);
+		}
+	}
+	root.dataset.piTheme = themeName;
+}
+
+async function readJsonFile(path: string): Promise<Record<string, unknown> | null> {
+	try {
+		const { exists, readTextFile } = await import("@tauri-apps/plugin-fs");
+		if (!(await exists(path))) return null;
+		const content = await readTextFile(path);
+		const parsed = JSON.parse(content) as unknown;
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+		return parsed as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+async function resolveSelectedPiThemeName(projectPath: string | null | undefined, home: string): Promise<string | null> {
+	const globalSettingsPath = joinFsPath(joinFsPath(joinFsPath(home, ".pi"), "agent"), "settings.json");
+	const globalSettings = await readJsonFile(globalSettingsPath);
+	let selectedTheme = normalizeThemeName(globalSettings?.theme);
+
+	const normalizedProjectPath = normalizeFsPath(projectPath);
+	if (normalizedProjectPath) {
+		const projectSettingsPath = joinFsPath(joinFsPath(normalizedProjectPath, ".pi"), "settings.json");
+		const projectSettings = await readJsonFile(projectSettingsPath);
+		const projectTheme = normalizeThemeName(projectSettings?.theme);
+		if (projectTheme) selectedTheme = projectTheme;
+	}
+
+	return selectedTheme;
+}
+
+async function resolvePiThemeFilePath(themeName: string, projectPath: string | null | undefined, home: string): Promise<string | null> {
+	const { exists, readDir } = await import("@tauri-apps/plugin-fs");
+
+	const raw = themeName.trim();
+	if (!raw) return null;
+	if (raw === "dark" || raw === "light") return null;
+
+	const candidates: string[] = [];
+	const normalizedProjectPath = normalizeFsPath(projectPath);
+
+	if (isLikelyAbsolutePath(raw) || raw.startsWith("~/")) {
+		candidates.push(expandHomePath(raw, home));
+	} else {
+		if (normalizedProjectPath) {
+			candidates.push(joinFsPath(joinFsPath(joinFsPath(normalizedProjectPath, ".pi"), "themes"), `${raw}.json`));
+		}
+		candidates.push(joinFsPath(joinFsPath(joinFsPath(joinFsPath(home, ".pi"), "agent"), "themes"), `${raw}.json`));
+	}
+
+	for (const candidate of candidates) {
+		try {
+			if (await exists(candidate)) return candidate;
+		} catch {
+			// ignore and continue
+		}
+	}
+
+	// Backward compatibility: allow selecting by theme document "name" label (not only file stem).
+	if (!isLikelyAbsolutePath(raw) && !raw.startsWith("~/")) {
+		const normalizedWanted = raw.toLowerCase();
+		const roots: string[] = [];
+		if (normalizedProjectPath) roots.push(joinFsPath(joinFsPath(normalizedProjectPath, ".pi"), "themes"));
+		roots.push(joinFsPath(joinFsPath(joinFsPath(home, ".pi"), "agent"), "themes"));
+
+		for (const root of roots) {
+			try {
+				if (!(await exists(root))) continue;
+				const entries = await readDir(root);
+				for (const entry of entries) {
+					if (!entry.isFile || !entry.name.toLowerCase().endsWith(".json")) continue;
+					const candidate = joinFsPath(root, entry.name);
+					const json = await readJsonFile(candidate);
+					const fileStem = entry.name.replace(/\.json$/i, "").toLowerCase();
+					const declared = typeof json?.name === "string" ? json.name.trim().toLowerCase() : "";
+					if (fileStem === normalizedWanted || declared === normalizedWanted) {
+						return candidate;
+					}
+				}
+			} catch {
+				// ignore and continue
+			}
+		}
+	}
+
+	return null;
+}
+
+export async function syncDesktopThemeWithPiTheme(projectPath?: string | null, preferredThemeName?: string | null): Promise<void> {
+	const normalizedProjectPath = normalizeFsPath(projectPath);
+	const mode = normalizeThemeModeFromDom();
+	const explicitName = (preferredThemeName ?? "").trim();
+	const root = document.documentElement;
+
+	try {
+		const { homeDir } = await import("@tauri-apps/api/path");
+		const home = normalizeFsPath(await homeDir());
+		if (!home) {
+			clearPiThemeOverlay(root);
+			return;
+		}
+
+		let selectedThemeName = explicitName;
+		if (!selectedThemeName) {
+			try {
+				const profiles = loadDesktopAppearanceProfiles();
+				selectedThemeName = getAppearanceProfileForResolvedTheme(profiles, mode).themeName.trim();
+			} catch {
+				selectedThemeName = "";
+			}
+		}
+		if (!selectedThemeName) {
+			selectedThemeName = (await resolveSelectedPiThemeName(normalizedProjectPath, home)) ?? "";
+		}
+
+		const syncKey = `${mode}|${normalizedProjectPath}|${selectedThemeName}`;
+		const now = Date.now();
+		if (syncKey === lastSyncKey && now - lastSyncAt < 1200) return;
+		lastSyncKey = syncKey;
+		lastSyncAt = now;
+
+		if (!selectedThemeName || selectedThemeName === "dark" || selectedThemeName === "light" || selectedThemeName === "system") {
+			clearPiThemeOverlay(root);
+			return;
+		}
+
+		const themeFilePath = await resolvePiThemeFilePath(selectedThemeName, normalizedProjectPath, home);
+		if (!themeFilePath) {
+			clearPiThemeOverlay(root);
+			return;
+		}
+
+		const themeJson = await readJsonFile(themeFilePath);
+		if (!themeJson) {
+			clearPiThemeOverlay(root);
+			return;
+		}
+
+		const theme: PiThemeFile = {
+			name: typeof themeJson.name === "string" ? themeJson.name : selectedThemeName,
+			vars: (themeJson.vars as Record<string, unknown> | undefined) ?? {},
+			colors: (themeJson.colors as Record<string, unknown> | undefined) ?? {},
+		};
+
+		const overlay = buildPiThemeOverlay(theme, mode);
+		if (Object.keys(overlay).length === 0) {
+			clearPiThemeOverlay(root);
+			return;
+		}
+
+		applyPiThemeOverlay(root, overlay, theme.name ?? selectedThemeName);
+	} catch {
+		clearPiThemeOverlay(root);
+	}
+}

--- a/src/theme/theme-manager.ts
+++ b/src/theme/theme-manager.ts
@@ -1,0 +1,107 @@
+export type DesktopThemeMode = "dark" | "light" | "system";
+export type DesktopThemeResolved = "dark" | "light";
+
+export const DESKTOP_THEME_STORAGE_KEY = "pi-theme";
+export const DESKTOP_THEME_CHANGED_EVENT = "pi-desktop:theme-changed";
+
+let systemThemeListenerAttached = false;
+
+function resolveSystemTheme(): DesktopThemeResolved {
+	try {
+		return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+	} catch {
+		return "dark";
+	}
+}
+
+function normalizeThemeMode(input: string | null | undefined): DesktopThemeMode {
+	if (input === "light" || input === "dark" || input === "system") return input;
+	return "dark";
+}
+
+function resolveThemeMode(mode: DesktopThemeMode): DesktopThemeResolved {
+	return mode === "system" ? resolveSystemTheme() : mode;
+}
+
+export function getResolvedDesktopTheme(): DesktopThemeResolved {
+	return document.documentElement.classList.contains("light") ? "light" : "dark";
+}
+
+function emitThemeChange(mode: DesktopThemeMode, resolved: DesktopThemeResolved): void {
+	window.dispatchEvent(new CustomEvent(DESKTOP_THEME_CHANGED_EVENT, { detail: { mode, resolved } }));
+}
+
+function applyResolvedTheme(mode: DesktopThemeMode, resolved: DesktopThemeResolved, persist: boolean): DesktopThemeMode {
+	const root = document.documentElement;
+	const prevResolved = getResolvedDesktopTheme();
+	const prevMode = normalizeThemeMode(root.dataset.themeMode);
+
+	root.classList.remove("dark", "light");
+	root.classList.add(resolved);
+	root.dataset.theme = resolved;
+	root.dataset.themeMode = mode;
+
+	if (persist) {
+		try {
+			localStorage.setItem(DESKTOP_THEME_STORAGE_KEY, mode);
+		} catch {
+			// ignore
+		}
+	}
+
+	if (prevResolved !== resolved || prevMode !== mode) {
+		emitThemeChange(mode, resolved);
+	}
+
+	return mode;
+}
+
+function attachSystemThemeListener(): void {
+	if (systemThemeListenerAttached) return;
+	systemThemeListenerAttached = true;
+
+	try {
+		const media = window.matchMedia("(prefers-color-scheme: dark)");
+		const handleChange = () => {
+			const mode = readStoredDesktopTheme();
+			if (mode !== "system") return;
+			const resolved = resolveThemeMode(mode);
+			applyResolvedTheme(mode, resolved, false);
+		};
+
+		if (typeof media.addEventListener === "function") {
+			media.addEventListener("change", handleChange);
+		} else if (typeof media.addListener === "function") {
+			media.addListener(handleChange);
+		}
+	} catch {
+		// ignore
+	}
+}
+
+export function readStoredDesktopTheme(): DesktopThemeMode {
+	try {
+		return normalizeThemeMode(localStorage.getItem(DESKTOP_THEME_STORAGE_KEY));
+	} catch {
+		return "dark";
+	}
+}
+
+export function applyDesktopTheme(theme: DesktopThemeMode, options?: { persist?: boolean }): DesktopThemeMode {
+	attachSystemThemeListener();
+	const mode = normalizeThemeMode(theme);
+	const resolved = resolveThemeMode(mode);
+	return applyResolvedTheme(mode, resolved, options?.persist ?? true);
+}
+
+export function initializeDesktopTheme(): DesktopThemeMode {
+	attachSystemThemeListener();
+	const theme = readStoredDesktopTheme();
+	return applyDesktopTheme(theme, { persist: false });
+}
+
+export function toggleDesktopTheme(): DesktopThemeMode {
+	const current = readStoredDesktopTheme();
+	const next: DesktopThemeMode = current === "dark" ? "light" : "dark";
+	return applyDesktopTheme(next, { persist: true });
+}


### PR DESCRIPTION
## Summary
This PR completes a major Codex-parity frontend pass across chat, packages, settings, themes, and sidebar overlays.

### Key UX changes
- **Chat composer parity**
  - Refined composer spacing/controls and iconography.
  - Stable slash palette keyboard navigation (no hover/scroll jitter conflicts).
  - Skill pill inline behavior + keyboard remove support.
  - Improved model + reasoning controls and reduced visual noise.
  - Send/stop button state polish and sizing adjustments.
- **Model picker redesign**
  - Replaced flat model list with **provider → model** flyout picker.
  - Better label normalization and provider grouping.
- **Packages page cleanup**
  - Removed noisy counts/dividers in header and section counters.
  - Added cleaner section spacing and tighter hierarchy.
- **Settings moved from modal to full page pane**
  - Settings now behaves like Packages (main content pane), not a popup overlay.
  - Added sectioned layout and grouped settings blocks.
  - Added pane routing support for `settings` in workspace state.
- **Theme/appearance system upgrades**
  - Added token/theme foundation (`tokens.css`, `theme.css`) and theme manager modules.
  - Added appearance profiles, Pi theme bridge, bundled theme install flow.
- **Sidebar/context/overlay robustness**
  - Improved context close behavior.
  - Fixed project emoji picker clipping using a body portal + backdrop.
  - Corrected stacking order so overlay/modals render above app panes.
- **Topbar/content tabs polish**
  - Terminal action moved to trailing slot with divider and parity spacing.

### Native/macOS visual updates
- Updated Tauri config/runtime pieces used for transparency/rounded-corner behavior parity.

## Fixes included
- Startup regression where app could stick on "Starting pi agent…" after settings-pane refactor.
- Overlay stacking regressions where sidebar could clip/cover popup surfaces.

## Validation
- `npm run -s check`
- `npm run -s build:frontend`

## Related issues
- #63 (umbrella parity roadmap)
- #48 (provider → model picker flow)
- #52 (chat canvas noise/polish)
- #53 (chat UX scrolling/spacing)
- #46 (window/overlay visual layering context)
