### PR TITLE
fix(settings+themes+welcome): harden settings pane, CLI theme schema compat, and project-focused empty state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Fixed
+- Bundled default Pi Desktop themes now emit full Pi CLI-compatible theme schema (all required color tokens) instead of a partial Desktop-only color set.
+- Added bundled-theme auto-repair for legacy invalid `~/.pi/agent/themes/pi-desktop-*.json` files so existing installs stop producing CLI theme validation errors.
+- Theme files created from Settings (“Create theme”) now use the full Pi theme schema, so custom exports are valid in both Desktop and CLI.
+
 ## [0.1.8] - 2026-03-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,19 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ## [Unreleased]
 
+### Changed
+- Reworked the no-project / new-thread welcome view into a cleaner Codex-inspired centered layout with Pi Desktop branding, a project-focused dropdown, and reduced UI chrome.
+- Welcome project dropdown now lists all projects in the current workspace and supports direct project switching (plus quick actions for add project, packages, and settings).
+- Welcome heading copy now rotates between Pi-style idle phrases for a calmer ambient experience.
+
 ### Fixed
 - Bundled default Pi Desktop themes now emit full Pi CLI-compatible theme schema (all required color tokens) instead of a partial Desktop-only color set.
 - Added bundled-theme auto-repair for legacy invalid `~/.pi/agent/themes/pi-desktop-*.json` files so existing installs stop producing CLI theme validation errors.
 - Theme files created from Settings (“Create theme”) now use the full Pi theme schema, so custom exports are valid in both Desktop and CLI.
+- Hardened Settings pane mounting/open flow to recover from race conditions and stale container rebinding during workspace/project transitions.
+- Settings now degrade to a safe basic shell when runtime-dependent sections fail to render, instead of showing a blank pane.
+- No-project Settings flow is now runtime-decoupled, so Appearance settings remain available even before RPC runtime is connected.
+- Removed centered welcome dropdown jitter by stabilizing open/close layout behavior and avoiding no-project auto-scroll on re-render.
 
 ## [0.1.8] - 2026-03-23
 

--- a/TODO.md
+++ b/TODO.md
@@ -173,13 +173,15 @@ The app should feel native while still reflecting Pi’s actual resource model.
 - [x] Remove animated/dot unread styling; keep static unread emphasis (bold + italic)
 - [x] Add first-run onboarding card when Pi CLI is missing (install + copy command + retry)
 - [x] Add in-app Pi CLI update signaling (startup + daily reminder + sidebar hint + settings update path)
+- [x] Harden settings pane open/render lifecycle across no-project + project-switch states (#69)
+- [x] Refine no-project/new-thread welcome dashboard toward clean Codex-inspired centered flow (#63, partial)
 - [ ] Final new-file draft UX polish pass
 - [ ] Final session delete/select stability polish pass
 
 ### Manual smoke tests that still matter
 - [ ] Parallel runs in separate session tabs with different models
 - [ ] Legacy session restore / old session reopen after restart
-- [ ] Remove all projects => immediate clean no-project dashboard
+- [x] Remove all projects => immediate clean no-project dashboard
 - [ ] Packages pane navigation from no-project state
 - [ ] Package install/remove/update/list flow in real Tauri app
 - [ ] Command-backed resources actually reflect installed extensions/skills/prompts on machine

--- a/docs/ISSUE_IMPLEMENTATION_LOG_2026-03-31.md
+++ b/docs/ISSUE_IMPLEMENTATION_LOG_2026-03-31.md
@@ -1,0 +1,70 @@
+# Issue implementation log (2026-03-31)
+
+This log summarizes the current `feat/66-theme-schema-cli-compat` cycle covering theme schema compatibility, Settings stability, and no-project welcome/dashboard UX.
+
+## #66 — Theme schema / CLI compatibility
+
+Status: **Implemented on feature branch (pending PR merge to `dev`)**
+
+Implemented:
+- Bundled Pi Desktop themes now emit full Pi CLI schema-compatible theme documents.
+- Added default-theme install/repair path for legacy `~/.pi/agent/themes/pi-desktop-*.json` files.
+- Added schema compatibility validation + rewrite behavior for invalid bundled theme files.
+- Settings “Create theme” export now writes full schema-compatible theme JSON.
+
+Primary commits:
+- `b40572c`
+
+## #69 — Settings pane blank/failed render hardening
+
+Status: **Implemented on feature branch (pending PR merge to `dev`)**
+
+Implemented:
+- Rebind/reuse Settings panel container safely after shell re-renders.
+- Added pane-open recovery guards and anti-race handling for pane transitions.
+- Hardened open/mount flow for no-project, project-switch, and post-reset states.
+- Added fail-safe fallback shell so settings no longer collapse to a blank pane when advanced runtime sections fail.
+- Decoupled no-project settings from runtime-dependent sections (Appearance remains available without active RPC runtime).
+
+Primary commits:
+- `26295e0`
+- `87c3ab3`
+- `c50d551`
+- `b43a2d1`
+- `524218a`
+- `53005aa`
+- `45c985c`
+- `1b4d30e`
+
+## #63 — Codex-inspired frontend parity (welcome/dashboard scope in this cycle)
+
+Status: **Partially implemented (welcome/dashboard slice complete for this branch)**
+
+Implemented in this cycle:
+- Reworked no-project / new-thread welcome into a centered Codex-inspired layout.
+- Switched to official Pi Desktop icon in welcome lockup.
+- Added project-focused dropdown interaction with cleaner scale and reduced visual noise.
+- Added workspace-project listing and direct project switching from the centered welcome dropdown.
+- Stabilized dropdown open behavior (removed layout jitter/hop) and refined responsive sizing.
+- Added rotating Pi-style idle headline copy.
+
+Primary commits:
+- `20d06a3`
+- `ae46e36`
+- `5b7185b`
+- `ad02f84`
+- `1baf104`
+- `d3d02ad`
+- `4b475f3`
+- `663a841`
+- `97db931`
+- `e44166c`
+- `7b3da5f`
+- `25872e3`
+- `dba891d`
+
+## Remaining follow-up suggestions
+
+- Add search field inside welcome project dropdown to match Codex-style project picker more closely.
+- Continue #63 parity phases (chat canvas rhythm, markdown/code polish, packages/skills layout consistency).
+- Run final native smoke pass before release cut.

--- a/docs/THEMES_DESKTOP_MAPPING.md
+++ b/docs/THEMES_DESKTOP_MAPPING.md
@@ -19,6 +19,8 @@ These files are placed in:
 
 - `~/.pi/agent/themes`
 
+All bundled files are written in full Pi CLI theme schema format (all required `colors` tokens), so they are valid both in Desktop and in `pi` CLI.
+
 ## Theme package behavior
 
 In the Packages pane, **Pi Desktop Themes** behaves like a package:
@@ -29,6 +31,8 @@ In the Packages pane, **Pi Desktop Themes** behaves like a package:
 Only the bundled theme files are touched; user-created themes are not removed.
 
 Automatic bootstrap happens only once on first desktop startup. After explicit uninstall, themes stay uninstalled until you install the package again.
+
+Desktop also repairs legacy bundled theme files that were created with an older, incomplete schema (missing required tokens), so existing installations are cleaned up without manual edits.
 
 ## Theme variant detection (Light vs Dark)
 

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -110,6 +110,12 @@ interface WelcomeDashboardSummary {
 	updatedAt: number;
 }
 
+interface WelcomeProjectSummary {
+	id: string;
+	name: string;
+	path: string;
+}
+
 interface ComposerSkillDraft {
 	name: string;
 	commandText: string;
@@ -137,6 +143,10 @@ function joinFsPath(base: string, child: string): string {
 	const sep = base.includes("\\") ? "\\" : "/";
 	const cleanBase = base.replace(/[\\/]+$/, "");
 	return `${cleanBase}${sep}${child}`;
+}
+
+function normalizeComparablePath(value: string | null | undefined): string {
+	return (value ?? "").replace(/\\/g, "/").replace(/\/+$|\s+$/g, "").toLowerCase();
 }
 
 function formatUsd(value: number): string {
@@ -358,6 +368,7 @@ export class ChatView {
 	private onAddProject: (() => void) | null = null;
 	private onOpenSettings: (() => void) | null = null;
 	private onOpenPackages: (() => void) | null = null;
+	private onSelectWelcomeProject: ((projectId: string) => void) | null = null;
 	private onPromptSubmitted: (() => void) | null = null;
 	private onRunStateChange: ((running: boolean) => void) | null = null;
 	private availableModels: ModelOption[] = [];
@@ -468,6 +479,8 @@ export class ChatView {
 		updatedAt: 0,
 	};
 	private welcomeProjectMenuOpen = false;
+	private welcomeProjects: WelcomeProjectSummary[] = [];
+	private welcomeActiveProjectId: string | null = null;
 	private welcomeHeadlineTimer: ReturnType<typeof setInterval> | null = null;
 	private welcomeHeadlineIndex = 0;
 	private readonly welcomeHeadlines = ["Ready when you are", "Your move when you’re back", "Come back when you want, I’m here", "I’m waiting for you"];
@@ -494,6 +507,18 @@ export class ChatView {
 
 	setOnOpenPackages(cb: () => void): void {
 		this.onOpenPackages = cb;
+	}
+
+	setOnSelectWelcomeProject(cb: (projectId: string) => void): void {
+		this.onSelectWelcomeProject = cb;
+	}
+
+	setWelcomeProjects(projects: Array<{ id: string; name: string; path: string }>, activeProjectId: string | null): void {
+		this.welcomeProjects = projects
+			.filter((entry) => Boolean(entry?.id) && Boolean(entry?.name) && Boolean(entry?.path))
+			.map((entry) => ({ id: entry.id, name: entry.name, path: entry.path }));
+		this.welcomeActiveProjectId = activeProjectId;
+		if (!this.projectPath) this.render();
 	}
 
 	setOnPromptSubmitted(cb: () => void): void {
@@ -3724,8 +3749,13 @@ export class ChatView {
 	private renderCenteredWelcome(): TemplateResult {
 		const snapshot = this.welcomeDashboard;
 		const brandIconUrl = new URL("../../assets/branding/pi-desktop-icon.svg", import.meta.url).href;
-		const hasProject = Boolean(this.projectPath);
-		const projectLabel = this.projectPath ? this.fileNameFromPath(this.projectPath) : "Add project";
+		const comparableProjectPath = normalizeComparablePath(this.projectPath);
+		const activeProject =
+			this.welcomeProjects.find((project) => project.id === this.welcomeActiveProjectId) ??
+			this.welcomeProjects.find((project) => normalizeComparablePath(project.path) === comparableProjectPath) ??
+			null;
+		const hasProject = Boolean(activeProject || this.projectPath);
+		const projectLabel = activeProject?.name ?? (this.projectPath ? this.fileNameFromPath(this.projectPath) : "Add project");
 		const welcomeHeadline = this.welcomeHeadlines[this.welcomeHeadlineIndex] ?? this.welcomeHeadlines[0];
 
 		return html`
@@ -3748,7 +3778,19 @@ export class ChatView {
 					${this.welcomeProjectMenuOpen
 						? html`
 							<div class="welcome-project-menu">
-								${hasProject ? html`<div class="welcome-project-item current"><span>${projectLabel}</span><span>✓</span></div>` : nothing}
+								${this.welcomeProjects.map((project) => {
+									const isCurrent = project.id === activeProject?.id;
+									return html`
+										<button class="welcome-project-item ${isCurrent ? "current" : ""}" @click=${() => {
+											this.welcomeProjectMenuOpen = false;
+											if (!isCurrent) this.onSelectWelcomeProject?.(project.id);
+										}}>
+											<span>${project.name}</span>
+											<span>${isCurrent ? "✓" : ""}</span>
+										</button>
+									`;
+								})}
+								${this.welcomeProjects.length > 0 ? html`<div class="welcome-project-sep"></div>` : nothing}
 								<button class="welcome-project-item" @click=${() => {
 									this.welcomeProjectMenuOpen = false;
 									this.onAddProject?.();

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3723,67 +3723,33 @@ export class ChatView {
 
 	private renderWelcomeDashboard(): TemplateResult {
 		const snapshot = this.welcomeDashboard;
-		const modelProvider = normalizeText(this.state?.model?.provider);
-		const modelId = normalizeText(this.state?.model?.id);
-		const modelLabel = modelProvider && modelId ? `${modelProvider}/${modelId}` : "No active model";
-		const highlights = [
-			...snapshot.skills.slice(0, 3).map((item) => `Skill · ${item}`),
-			...snapshot.extensions.slice(0, 3).map((item) => `Extension · ${item}`),
-		].slice(0, 6);
-		const cliLabel = snapshot.currentCliVersion ? `v${snapshot.currentCliVersion}` : "Unavailable";
+		const cliLabel = snapshot.currentCliVersion ? `CLI ${snapshot.currentCliVersion}` : "CLI unavailable";
 		const updateLabel = snapshot.updateAvailable
-			? `Update available${snapshot.latestCliVersion ? ` · v${snapshot.latestCliVersion}` : ""}`
+			? `Update available${snapshot.latestCliVersion ? ` · ${snapshot.latestCliVersion}` : ""}`
 			: "CLI up to date";
+		const inventoryLabel = `${snapshot.skills.length} skills · ${snapshot.extensions.length} extensions · ${snapshot.themes.length} themes`;
 
 		return html`
-			<div class="welcome-dashboard">
-				<section class="welcome-hero welcome-hero-codex">
-					<div class="welcome-eyebrow">Workspace setup</div>
-					<h2>Start by adding a project</h2>
-					<p>Once a project is connected, chat, files, terminal, and full runtime settings unlock automatically.</p>
-					<div class="welcome-quick-grid">
-						<button class="welcome-quick-action primary" @click=${() => this.onAddProject?.()}>
-							<span class="welcome-quick-title">Add project</span>
-							<span class="welcome-quick-desc">Select a local folder and start working immediately.</span>
-						</button>
-						<button class="welcome-quick-action" @click=${() => this.onOpenPackages?.()}>
-							<span class="welcome-quick-title">Open packages</span>
-							<span class="welcome-quick-desc">Install skills, extensions, and templates first.</span>
-						</button>
-						<button class="welcome-quick-action" @click=${() => this.onOpenSettings?.()}>
-							<span class="welcome-quick-title">Appearance & settings</span>
-							<span class="welcome-quick-desc">Adjust theme now. Runtime settings unlock with a project.</span>
-						</button>
-					</div>
-					<div class="welcome-inline-note">Tip: press <kbd>⌘K</kbd> to open command palette.</div>
-				</section>
-
-				<section class="welcome-card welcome-status-card">
-					<div class="welcome-status-head">
-						<div class="welcome-card-title">Local Pi environment</div>
-						<div class="welcome-actions compact">
-							<button class="welcome-action" @click=${() => void this.refreshWelcomeDashboard(true)}>Refresh</button>
-							<button class="welcome-action" @click=${() => void this.openExternalUrl("https://github.com/mariozechner/pi-coding-agent")}>Pi docs</button>
-						</div>
-					</div>
-					<div class="welcome-kpis compact">
-						<div><span>Skills</span><strong>${snapshot.skills.length}</strong></div>
-						<div><span>Extensions</span><strong>${snapshot.extensions.length}</strong></div>
-						<div><span>Themes</span><strong>${snapshot.themes.length}</strong></div>
-						<div><span>CLI</span><strong>${cliLabel}</strong></div>
-					</div>
-					<div class="welcome-runtime-grid">
-						<div class="welcome-runtime-row"><span>Model</span><strong>${modelLabel}</strong></div>
-						<div class="welcome-runtime-row"><span>Status</span><strong>${updateLabel}</strong></div>
-					</div>
-					${snapshot.loading
-						? html`<div class="welcome-empty">Refreshing local Pi inventory…</div>`
-						: highlights.length > 0
-							? html`<div class="welcome-chip-list">${highlights.map((item) => html`<span class="welcome-chip">${item}</span>`)}</div>`
-							: html`<div class="welcome-empty">No extra skills or extensions detected yet.</div>`}
-					${snapshot.error ? html`<div class="welcome-error">${snapshot.error}</div>` : nothing}
-					<div class="welcome-updated">Updated ${formatAge(snapshot.updatedAt)}</div>
-				</section>
+			<div class="welcome-dashboard welcome-dashboard-minimal">
+				<div class="welcome-brand-lockup" aria-hidden="true">
+					<div class="welcome-brand-mark">🌊</div>
+					<div class="welcome-brand-name">Pi Desktop</div>
+				</div>
+				<h2>Let’s build</h2>
+				<p>Add a project to start your workspace.</p>
+				<div class="welcome-actions welcome-actions-centered">
+					<button class="welcome-action primary" @click=${() => this.onAddProject?.()}>Add project</button>
+					<button class="welcome-action" @click=${() => this.onOpenPackages?.()}>Packages</button>
+					<button class="welcome-action" @click=${() => this.onOpenSettings?.()}>Settings</button>
+				</div>
+				<div class="welcome-meta-line">${inventoryLabel}</div>
+				<div class="welcome-meta-line muted">${snapshot.loading ? "Refreshing local Pi inventory…" : `${cliLabel} · ${updateLabel}`}</div>
+				<div class="welcome-link-row">
+					<button class="welcome-link-btn" @click=${() => void this.refreshWelcomeDashboard(true)}>Refresh</button>
+					<button class="welcome-link-btn" @click=${() => void this.openExternalUrl("https://github.com/mariozechner/pi-coding-agent")}>Pi docs</button>
+				</div>
+				${snapshot.error ? html`<div class="welcome-error">${snapshot.error}</div>` : nothing}
+				<div class="welcome-updated">Updated ${formatAge(snapshot.updatedAt)}</div>
 			</div>
 		`;
 	}

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3744,7 +3744,7 @@ export class ChatView {
 					<div class="welcome-actions">
 						<button class="welcome-action primary" @click=${() => this.onAddProject?.()}>Add project</button>
 						<button class="welcome-action" @click=${() => this.onOpenPackages?.()}>Open packages</button>
-						<button class="welcome-action" @click=${() => this.onOpenSettings?.()}>Settings</button>
+						<button class="welcome-action" @click=${() => this.onOpenSettings?.()}>Appearance & settings</button>
 					</div>
 				</div>
 

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3724,7 +3724,7 @@ export class ChatView {
 				<div class="welcome-brand-lockup" aria-hidden="true">
 					<div class="welcome-brand-mark"><img src=${brandIconUrl} alt="Pi Desktop" /></div>
 				</div>
-				<h2>Let’s build</h2>
+				<h2>Ready when you are — Pi</h2>
 				<div class="welcome-project-wrap">
 					<button
 						class="welcome-project-trigger ${hasProject ? "active" : ""}"

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -4666,7 +4666,9 @@ export class ChatView {
 
 	render(): void {
 		this.doRender();
-		this.scrollToBottom();
+		if (this.projectPath) {
+			this.scrollToBottom();
+		}
 		this.syncWorkingStatusAnimation();
 		this.ensureActiveSlashItemVisible();
 	}

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -468,6 +468,9 @@ export class ChatView {
 		updatedAt: 0,
 	};
 	private welcomeProjectMenuOpen = false;
+	private welcomeHeadlineTimer: ReturnType<typeof setInterval> | null = null;
+	private welcomeHeadlineIndex = 0;
+	private readonly welcomeHeadlines = ["Ready when you are", "Your move when you’re back", "Come back when you want, I’m here", "I’m waiting for you"];
 
 	constructor(container: HTMLElement) {
 		this.container = container;
@@ -519,6 +522,7 @@ export class ChatView {
 		this.slashSkillsUpdatedAt = 0;
 		if (!path) {
 			this.bindingStatusText = null;
+			this.welcomeHeadlineIndex = (this.welcomeHeadlineIndex + 1) % this.welcomeHeadlines.length;
 			this.modelLoadRequestSeq += 1;
 			this.loadingModels = false;
 			this.runHasAssistantText = false;
@@ -906,6 +910,10 @@ export class ChatView {
 		this.cancelStreamingUiReconcile();
 		this.runHasAssistantText = false;
 		this.clearWorkingStatusTimer(true);
+		if (this.welcomeHeadlineTimer) {
+			clearInterval(this.welcomeHeadlineTimer);
+			this.welcomeHeadlineTimer = null;
+		}
 		for (const unlisten of this.nativeFileDropUnlisteners) {
 			unlisten();
 		}
@@ -3718,13 +3726,14 @@ export class ChatView {
 		const brandIconUrl = new URL("../../assets/branding/pi-desktop-icon.svg", import.meta.url).href;
 		const hasProject = Boolean(this.projectPath);
 		const projectLabel = this.projectPath ? this.fileNameFromPath(this.projectPath) : "Add project";
+		const welcomeHeadline = this.welcomeHeadlines[this.welcomeHeadlineIndex] ?? this.welcomeHeadlines[0];
 
 		return html`
 			<div class="welcome-dashboard welcome-dashboard-minimal">
 				<div class="welcome-brand-lockup" aria-hidden="true">
 					<div class="welcome-brand-mark"><img src=${brandIconUrl} alt="Pi Desktop" /></div>
 				</div>
-				<h2>Ready when you are — Pi</h2>
+				<h2>${welcomeHeadline}</h2>
 				<div class="welcome-project-wrap">
 					<button
 						class="welcome-project-trigger ${hasProject ? "active" : ""}"
@@ -3757,7 +3766,7 @@ export class ChatView {
 						`
 						: nothing}
 				</div>
-				<div class="welcome-meta-line muted">
+				<div class="welcome-meta-line muted ${this.welcomeProjectMenuOpen ? "hidden" : ""}">
 					${snapshot.loading ? "Refreshing local Pi inventory…" : `${snapshot.skills.length} skills · ${snapshot.extensions.length} extensions · ${snapshot.themes.length} themes`}
 				</div>
 				${snapshot.error ? html`<div class="welcome-error">${snapshot.error}</div>` : nothing}
@@ -4578,6 +4587,16 @@ export class ChatView {
 
 	private doRender(): void {
 		const hasProject = Boolean(this.projectPath);
+		if (!hasProject && !this.welcomeHeadlineTimer) {
+			this.welcomeHeadlineTimer = setInterval(() => {
+				if (this.projectPath) return;
+				this.welcomeHeadlineIndex = (this.welcomeHeadlineIndex + 1) % this.welcomeHeadlines.length;
+				this.render();
+			}, 10000);
+		} else if (hasProject && this.welcomeHeadlineTimer) {
+			clearInterval(this.welcomeHeadlineTimer);
+			this.welcomeHeadlineTimer = null;
+		}
 		const hasMessages = this.messages.length > 0;
 		const showWorkingIndicator = hasProject && this.shouldShowWorkingIndicator();
 		if (!hasProject && !this.welcomeDashboard.loading && this.welcomeDashboard.updatedAt === 0) {

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3739,11 +3739,11 @@ export class ChatView {
 					${this.welcomeProjectMenuOpen
 						? html`
 							<div class="welcome-project-menu">
-								${hasProject ? html`<div class="welcome-project-item current"><span>📁 ${projectLabel}</span><span>✓</span></div>` : nothing}
+								${hasProject ? html`<div class="welcome-project-item current"><span>${projectLabel}</span><span>✓</span></div>` : nothing}
 								<button class="welcome-project-item" @click=${() => {
 									this.welcomeProjectMenuOpen = false;
 									this.onAddProject?.();
-								}}>📂 Add new project</button>
+								}}>Add new project</button>
 								<div class="welcome-project-sep"></div>
 								<button class="welcome-project-item" @click=${() => {
 									this.welcomeProjectMenuOpen = false;

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3727,9 +3727,9 @@ export class ChatView {
 		const modelId = normalizeText(this.state?.model?.id);
 		const modelLabel = modelProvider && modelId ? `${modelProvider}/${modelId}` : "No active model";
 		const highlights = [
-			...snapshot.skills.slice(0, 4).map((item) => `Skill · ${item}`),
-			...snapshot.extensions.slice(0, 4).map((item) => `Extension · ${item}`),
-		].slice(0, 8);
+			...snapshot.skills.slice(0, 3).map((item) => `Skill · ${item}`),
+			...snapshot.extensions.slice(0, 3).map((item) => `Extension · ${item}`),
+		].slice(0, 6);
 		const cliLabel = snapshot.currentCliVersion ? `v${snapshot.currentCliVersion}` : "Unavailable";
 		const updateLabel = snapshot.updateAvailable
 			? `Update available${snapshot.latestCliVersion ? ` · v${snapshot.latestCliVersion}` : ""}`
@@ -3737,41 +3737,53 @@ export class ChatView {
 
 		return html`
 			<div class="welcome-dashboard">
-				<div class="welcome-hero">
-					<div class="welcome-eyebrow">No project open</div>
-					<h2>Open a project to start a Pi workspace</h2>
-					<p>Chat, files, terminal, and packages become available as soon as you add a project.</p>
-					<div class="welcome-actions">
-						<button class="welcome-action primary" @click=${() => this.onAddProject?.()}>Add project</button>
-						<button class="welcome-action" @click=${() => this.onOpenPackages?.()}>Open packages</button>
-						<button class="welcome-action" @click=${() => this.onOpenSettings?.()}>Appearance & settings</button>
+				<section class="welcome-hero welcome-hero-codex">
+					<div class="welcome-eyebrow">Workspace setup</div>
+					<h2>Start by adding a project</h2>
+					<p>Once a project is connected, chat, files, terminal, and full runtime settings unlock automatically.</p>
+					<div class="welcome-quick-grid">
+						<button class="welcome-quick-action primary" @click=${() => this.onAddProject?.()}>
+							<span class="welcome-quick-title">Add project</span>
+							<span class="welcome-quick-desc">Select a local folder and start working immediately.</span>
+						</button>
+						<button class="welcome-quick-action" @click=${() => this.onOpenPackages?.()}>
+							<span class="welcome-quick-title">Open packages</span>
+							<span class="welcome-quick-desc">Install skills, extensions, and templates first.</span>
+						</button>
+						<button class="welcome-quick-action" @click=${() => this.onOpenSettings?.()}>
+							<span class="welcome-quick-title">Appearance & settings</span>
+							<span class="welcome-quick-desc">Adjust theme now. Runtime settings unlock with a project.</span>
+						</button>
 					</div>
-				</div>
+					<div class="welcome-inline-note">Tip: press <kbd>⌘K</kbd> to open command palette.</div>
+				</section>
 
-				<div class="welcome-grid minimal">
-					<section class="welcome-card compact">
+				<section class="welcome-card welcome-status-card">
+					<div class="welcome-status-head">
 						<div class="welcome-card-title">Local Pi environment</div>
-						<div class="welcome-kpis compact">
-							<div><span>Skills</span><strong>${snapshot.skills.length}</strong></div>
-							<div><span>Extensions</span><strong>${snapshot.extensions.length}</strong></div>
-							<div><span>Themes</span><strong>${snapshot.themes.length}</strong></div>
-							<div><span>CLI</span><strong>${cliLabel}</strong></div>
-						</div>
-						${snapshot.loading
-							? html`<div class="welcome-empty">Refreshing local Pi inventory…</div>`
-							: highlights.length > 0
-								? html`<div class="welcome-chip-list">${highlights.map((item) => html`<span class="welcome-chip">${item}</span>`)}</div>`
-								: html`<div class="welcome-empty">No extra skills or extensions detected yet.</div>`}
-						<div class="welcome-runtime-row"><span>Model</span><strong>${modelLabel}</strong></div>
-						<div class="welcome-runtime-row"><span>Status</span><strong>${updateLabel}</strong></div>
 						<div class="welcome-actions compact">
 							<button class="welcome-action" @click=${() => void this.refreshWelcomeDashboard(true)}>Refresh</button>
 							<button class="welcome-action" @click=${() => void this.openExternalUrl("https://github.com/mariozechner/pi-coding-agent")}>Pi docs</button>
 						</div>
-						${snapshot.error ? html`<div class="welcome-error">${snapshot.error}</div>` : nothing}
-						<div class="welcome-updated">Updated ${formatAge(snapshot.updatedAt)}</div>
-					</section>
-				</div>
+					</div>
+					<div class="welcome-kpis compact">
+						<div><span>Skills</span><strong>${snapshot.skills.length}</strong></div>
+						<div><span>Extensions</span><strong>${snapshot.extensions.length}</strong></div>
+						<div><span>Themes</span><strong>${snapshot.themes.length}</strong></div>
+						<div><span>CLI</span><strong>${cliLabel}</strong></div>
+					</div>
+					<div class="welcome-runtime-grid">
+						<div class="welcome-runtime-row"><span>Model</span><strong>${modelLabel}</strong></div>
+						<div class="welcome-runtime-row"><span>Status</span><strong>${updateLabel}</strong></div>
+					</div>
+					${snapshot.loading
+						? html`<div class="welcome-empty">Refreshing local Pi inventory…</div>`
+						: highlights.length > 0
+							? html`<div class="welcome-chip-list">${highlights.map((item) => html`<span class="welcome-chip">${item}</span>`)}</div>`
+							: html`<div class="welcome-empty">No extra skills or extensions detected yet.</div>`}
+					${snapshot.error ? html`<div class="welcome-error">${snapshot.error}</div>` : nothing}
+					<div class="welcome-updated">Updated ${formatAge(snapshot.updatedAt)}</div>
+				</section>
 			</div>
 		`;
 	}

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -4589,7 +4589,7 @@ export class ChatView {
 		const hasProject = Boolean(this.projectPath);
 		if (!hasProject && !this.welcomeHeadlineTimer) {
 			this.welcomeHeadlineTimer = setInterval(() => {
-				if (this.projectPath) return;
+				if (this.projectPath || this.welcomeProjectMenuOpen) return;
 				this.welcomeHeadlineIndex = (this.welcomeHeadlineIndex + 1) % this.welcomeHeadlines.length;
 				this.render();
 			}, 10000);

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -467,6 +467,7 @@ export class ChatView {
 		error: null,
 		updatedAt: 0,
 	};
+	private welcomeProjectMenuOpen = false;
 
 	constructor(container: HTMLElement) {
 		this.container = container;
@@ -509,6 +510,7 @@ export class ChatView {
 		}).__PI_DESKTOP_PUSH_TRACE__;
 		push?.(`chat:setProjectPath ${previous ?? "-"} -> ${path ?? "-"}`);
 		this.gitMenuOpen = false;
+		this.welcomeProjectMenuOpen = false;
 		this.modelPickerOpen = false;
 		this.selectedSkillDraft = null;
 		this.slashPaletteOpen = false;
@@ -3566,21 +3568,7 @@ export class ChatView {
 	}
 
 	private renderEmptyState(): TemplateResult {
-		return html`
-			<div class="chat-row assistant-row intro-row">
-				<div class="message-shell assistant-message-shell">
-					<div class="assistant-block intro-block">
-						<div class="assistant-content intro-text">Hey! How can I help you today?</div>
-					</div>
-				</div>
-			</div>
-			<div class="chat-row intro-actions-row">
-				<div class="intro-actions">
-					<button class="ghost-btn intro-chip" @click=${() => this.setInputText("Summarize this repository and suggest the top 5 improvements")}>Summarize repository</button>
-					<button class="ghost-btn intro-chip" @click=${() => this.setInputText("Find bugs and propose a prioritized fix plan")}>Find bugs</button>
-				</div>
-			</div>
-		`;
+		return this.renderCenteredWelcome();
 	}
 
 	private async openExternalUrl(url: string): Promise<void> {
@@ -3722,35 +3710,57 @@ export class ChatView {
 	}
 
 	private renderWelcomeDashboard(): TemplateResult {
+		return this.renderCenteredWelcome();
+	}
+
+	private renderCenteredWelcome(): TemplateResult {
 		const snapshot = this.welcomeDashboard;
 		const brandIconUrl = new URL("../../assets/branding/pi-desktop-icon.svg", import.meta.url).href;
-		const cliLabel = snapshot.currentCliVersion ? `CLI ${snapshot.currentCliVersion}` : "CLI unavailable";
-		const updateLabel = snapshot.updateAvailable
-			? `Update available${snapshot.latestCliVersion ? ` · ${snapshot.latestCliVersion}` : ""}`
-			: "CLI up to date";
-		const inventoryLabel = `${snapshot.skills.length} skills · ${snapshot.extensions.length} extensions · ${snapshot.themes.length} themes`;
+		const hasProject = Boolean(this.projectPath);
+		const projectLabel = this.projectPath ? this.fileNameFromPath(this.projectPath) : "Add project";
 
 		return html`
 			<div class="welcome-dashboard welcome-dashboard-minimal">
 				<div class="welcome-brand-lockup" aria-hidden="true">
 					<div class="welcome-brand-mark"><img src=${brandIconUrl} alt="Pi Desktop" /></div>
-					<div class="welcome-brand-name">Pi Desktop</div>
 				</div>
 				<h2>Let’s build</h2>
-				<p>Add a project to start your workspace.</p>
-				<div class="welcome-actions welcome-actions-centered">
-					<button class="welcome-action primary" @click=${() => this.onAddProject?.()}>Add project</button>
-					<button class="welcome-action" @click=${() => this.onOpenPackages?.()}>Packages</button>
-					<button class="welcome-action" @click=${() => this.onOpenSettings?.()}>Settings</button>
+				<div class="welcome-project-wrap">
+					<button
+						class="welcome-project-trigger ${hasProject ? "active" : ""}"
+						@click=${() => {
+							this.welcomeProjectMenuOpen = !this.welcomeProjectMenuOpen;
+							this.render();
+						}}
+					>
+						<span>${projectLabel}</span>
+						<span class="welcome-project-caret">${this.welcomeProjectMenuOpen ? "⌃" : "⌄"}</span>
+					</button>
+					${this.welcomeProjectMenuOpen
+						? html`
+							<div class="welcome-project-menu">
+								${hasProject ? html`<div class="welcome-project-item current"><span>📁 ${projectLabel}</span><span>✓</span></div>` : nothing}
+								<button class="welcome-project-item" @click=${() => {
+									this.welcomeProjectMenuOpen = false;
+									this.onAddProject?.();
+								}}>📂 Add new project</button>
+								<div class="welcome-project-sep"></div>
+								<button class="welcome-project-item" @click=${() => {
+									this.welcomeProjectMenuOpen = false;
+									this.onOpenPackages?.();
+								}}>Packages</button>
+								<button class="welcome-project-item" @click=${() => {
+									this.welcomeProjectMenuOpen = false;
+									this.onOpenSettings?.();
+								}}>Settings</button>
+							</div>
+						`
+						: nothing}
 				</div>
-				<div class="welcome-meta-line">${inventoryLabel}</div>
-				<div class="welcome-meta-line muted">${snapshot.loading ? "Refreshing local Pi inventory…" : `${cliLabel} · ${updateLabel}`}</div>
-				<div class="welcome-link-row">
-					<button class="welcome-link-btn" @click=${() => void this.refreshWelcomeDashboard(true)}>Refresh</button>
-					<button class="welcome-link-btn" @click=${() => void this.openExternalUrl("https://github.com/mariozechner/pi-coding-agent")}>Pi docs</button>
+				<div class="welcome-meta-line muted">
+					${snapshot.loading ? "Refreshing local Pi inventory…" : `${snapshot.skills.length} skills · ${snapshot.extensions.length} extensions · ${snapshot.themes.length} themes`}
 				</div>
 				${snapshot.error ? html`<div class="welcome-error">${snapshot.error}</div>` : nothing}
-				<div class="welcome-updated">Updated ${formatAge(snapshot.updatedAt)}</div>
 			</div>
 		`;
 	}
@@ -4589,6 +4599,11 @@ export class ChatView {
 					if (this.gitMenuOpen && !target.closest(".git-branch-wrap")) {
 						this.gitMenuOpen = false;
 						this.gitBranchQuery = "";
+						changed = true;
+					}
+
+					if (this.welcomeProjectMenuOpen && !target.closest(".welcome-project-wrap")) {
+						this.welcomeProjectMenuOpen = false;
 						changed = true;
 					}
 

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3723,6 +3723,7 @@ export class ChatView {
 
 	private renderWelcomeDashboard(): TemplateResult {
 		const snapshot = this.welcomeDashboard;
+		const brandIconUrl = new URL("../../assets/branding/pi-desktop-icon.svg", import.meta.url).href;
 		const cliLabel = snapshot.currentCliVersion ? `CLI ${snapshot.currentCliVersion}` : "CLI unavailable";
 		const updateLabel = snapshot.updateAvailable
 			? `Update available${snapshot.latestCliVersion ? ` · ${snapshot.latestCliVersion}` : ""}`
@@ -3732,7 +3733,7 @@ export class ChatView {
 		return html`
 			<div class="welcome-dashboard welcome-dashboard-minimal">
 				<div class="welcome-brand-lockup" aria-hidden="true">
-					<div class="welcome-brand-mark">🌊</div>
+					<div class="welcome-brand-mark"><img src=${brandIconUrl} alt="Pi Desktop" /></div>
 					<div class="welcome-brand-name">Pi Desktop</div>
 				</div>
 				<h2>Let’s build</h2>

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3743,7 +3743,7 @@ export class ChatView {
 						}}
 					>
 						<span>${projectLabel}</span>
-						<span class="welcome-project-caret">${this.welcomeProjectMenuOpen ? "⌃" : "⌄"}</span>
+						<span class="welcome-project-caret ${this.welcomeProjectMenuOpen ? "open" : ""}">⌄</span>
 					</button>
 					${this.welcomeProjectMenuOpen
 						? html`

--- a/src/components/packages-view.ts
+++ b/src/components/packages-view.ts
@@ -2969,7 +2969,7 @@ Execute the required file creation/edits directly, then summarize exactly which 
 			try {
 				const result = await restoreBundledThemes();
 				await this.refreshBundledThemesStatus();
-				this.commandStatus = `Installed Pi Desktop Themes (${result.created} created, ${result.renamed} renamed).`;
+				this.commandStatus = `Installed Pi Desktop Themes (${result.created} created, ${result.updated} updated, ${result.renamed} renamed).`;
 			} catch (err) {
 				this.commandStatus = `Failed to install Pi Desktop Themes: ${err instanceof Error ? err.message : String(err)}`;
 			} finally {

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -776,7 +776,27 @@ export class SettingsPanel {
 		this.authLoading = true;
 		this.render();
 		try {
-			this.authStatus = await rpcBridge.getPiAuthStatus();
+			const raw = await rpcBridge.getPiAuthStatus();
+			const providers = Array.isArray(raw?.configured_providers)
+				? raw.configured_providers
+					.filter((entry) => entry && typeof entry === "object")
+					.map((entry) => {
+						const provider = typeof entry.provider === "string" && entry.provider.trim().length > 0 ? entry.provider.trim() : "unknown";
+						const source = entry.source === "environment" || entry.source === "auth_file_api_key" || entry.source === "auth_file_oauth"
+							? entry.source
+							: "environment";
+						const kind = entry.kind === "api_key" || entry.kind === "oauth" || entry.kind === "unknown"
+							? entry.kind
+							: "unknown";
+						return { provider, source, kind };
+					})
+				: [];
+			this.authStatus = {
+				agent_dir: typeof raw?.agent_dir === "string" ? raw.agent_dir : null,
+				auth_file: typeof raw?.auth_file === "string" ? raw.auth_file : null,
+				auth_file_exists: Boolean(raw?.auth_file_exists),
+				configured_providers: providers,
+			};
 		} catch {
 			this.authStatus = null;
 		} finally {
@@ -836,7 +856,13 @@ export class SettingsPanel {
 		this.compatibilityLoading = true;
 		this.render();
 		try {
-			this.compatibilityReport = await rpcBridge.checkRpcCompatibility();
+			const raw = await rpcBridge.checkRpcCompatibility();
+			this.compatibilityReport = {
+				ok: Boolean(raw?.ok),
+				checks: Array.isArray(raw?.checks) ? raw.checks.filter((entry) => typeof entry === "string") : [],
+				error: typeof raw?.error === "string" && raw.error.trim().length > 0 ? raw.error : undefined,
+				checkedAt: typeof raw?.checkedAt === "number" && Number.isFinite(raw.checkedAt) ? raw.checkedAt : Date.now(),
+			};
 		} catch (err) {
 			this.compatibilityReport = {
 				ok: false,
@@ -1109,7 +1135,11 @@ export class SettingsPanel {
 			return;
 		}
 
-		const template = html`
+		const authProviders = Array.isArray(this.authStatus?.configured_providers) ? this.authStatus.configured_providers : [];
+		const compatibilityChecks = Array.isArray(this.compatibilityReport?.checks) ? this.compatibilityReport.checks : [];
+
+		try {
+			const template = html`
 			<div class="settings-view-root">
 				<div class="settings-view-header">
 					<div class="settings-view-title-wrap">
@@ -1195,19 +1225,17 @@ export class SettingsPanel {
 									? html`<div class="settings-desc">Checking account status…</div>`
 									: html`
 										<div class="settings-desc">
-											${this.authStatus && this.authStatus.configured_providers.length > 0
-												? `Connected providers: ${this.authStatus.configured_providers.length}`
+											${authProviders.length > 0
+												? `Connected providers: ${authProviders.length}`
 												: "No provider connected yet."}
 										</div>
 										<div class="settings-actions">
 											<button class="ghost-btn" @click=${() => this.refreshAuthStatus()}>Refresh account status</button>
 										</div>
-										${this.authStatus && this.authStatus.configured_providers.length > 0
+										${authProviders.length > 0
 											? html`
 												<div class="account-chips">
-													${this.authStatus.configured_providers.map(
-														(p) => html`<span class="account-chip">${p.provider} · ${p.source === "environment" ? "env" : p.kind}</span>`,
-													)}
+													${authProviders.map((p) => html`<span class="account-chip">${p.provider} · ${p.source === "environment" ? "env" : p.kind}</span>`)}
 												</div>
 											`
 											: null}
@@ -1295,7 +1323,7 @@ export class SettingsPanel {
 										? html`
 											<div class="settings-desc">
 												RPC compatibility: ${this.compatibilityReport.ok ? "OK" : "Failed"}
-												${this.compatibilityReport.checks.length > 0 ? html` (${this.compatibilityReport.checks.join(", ")})` : null}
+												${compatibilityChecks.length > 0 ? html` (${compatibilityChecks.join(", ")})` : null}
 											</div>
 											${this.compatibilityReport.error ? html`<div class="settings-desc">${this.compatibilityReport.error}</div>` : null}
 										`
@@ -1309,7 +1337,27 @@ export class SettingsPanel {
 			</div>
 		`;
 
-		render(template, this.container);
+			render(template, this.container);
+		} catch (err) {
+			console.error("Settings panel render failed:", err);
+			this.container.innerHTML = `
+				<div class="settings-view-root">
+					<div class="settings-view-header">
+						<div class="settings-view-title-wrap">
+							<div class="settings-view-title">Settings</div>
+							<div class="settings-view-meta">Failed to render settings content.</div>
+						</div>
+					</div>
+					<div class="settings-view-body">
+						<div class="settings-group">
+							<div class="settings-section">
+								<div class="settings-desc">Something went wrong while rendering settings. Close and reopen Settings to retry.</div>
+							</div>
+						</div>
+					</div>
+				</div>
+			`;
+		}
 	}
 
 	destroy(): void {

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -99,8 +99,9 @@ export class SettingsPanel {
 
 	setContainer(container: HTMLElement): void {
 		if (this.container === container) return;
+		const wasOpen = this.isOpen;
 		this.container = container;
-		this.render();
+		if (wasOpen) this.render();
 	}
 
 	hasRenderedContent(): boolean {

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -62,6 +62,7 @@ export class SettingsPanel {
 		followUpMode: "one-at-a-time",
 	};
 	private onClose: (() => void) | null = null;
+	private onRequestAddProject: (() => void) | null = null;
 	private saving = false;
 	private authStatus: PiAuthStatus | null = null;
 	private authLoading = false;
@@ -111,6 +112,10 @@ export class SettingsPanel {
 
 	setOnClose(callback: () => void): void {
 		this.onClose = callback;
+	}
+
+	setOnRequestAddProject(callback: () => void): void {
+		this.onRequestAddProject = callback;
 	}
 
 	setOnDesktopStatusChange(callback: (status: DesktopUpdateStatus | null) => void): void {
@@ -754,8 +759,8 @@ export class SettingsPanel {
 	}
 
 	private async loadState(): Promise<void> {
-		const hasRuntimeProject = Boolean(this.runtimeProjectPath);
-		if (hasRuntimeProject) {
+		const runtimeReady = Boolean(this.runtimeProjectPath) && rpcBridge.isConnected;
+		if (runtimeReady) {
 			try {
 				const sessionState = await rpcBridge.getState();
 				this.state.autoCompactionEnabled = Boolean(sessionState.autoCompactionEnabled);
@@ -796,7 +801,7 @@ export class SettingsPanel {
 			// ignore missing persisted settings
 		}
 
-		if (!hasRuntimeProject) {
+		if (!runtimeReady) {
 			this.applyAppearanceProfileForCurrentResolvedTheme(false);
 			return;
 		}
@@ -1176,9 +1181,13 @@ export class SettingsPanel {
 
 		const authProviders = Array.isArray(this.authStatus?.configured_providers) ? this.authStatus.configured_providers : [];
 		const compatibilityChecks = Array.isArray(this.compatibilityReport?.checks) ? this.compatibilityReport.checks : [];
-		const runtimeControlsEnabled = Boolean(this.runtimeProjectPath);
+		const hasProjectContext = Boolean(this.runtimeProjectPath);
+		const runtimeControlsEnabled = hasProjectContext && rpcBridge.isConnected;
 
 		if (!runtimeControlsEnabled) {
+			const runtimeMessage = hasProjectContext
+				? "Runtime is still starting for this project. You can change appearance now; assistant/account settings unlock when runtime is ready."
+				: "Open a project to enable assistant, account, update diagnostics, and compatibility settings.";
 			try {
 				render(
 					html`
@@ -1186,7 +1195,7 @@ export class SettingsPanel {
 							<div class="settings-view-header">
 								<div class="settings-view-title-wrap">
 									<div class="settings-view-title">Settings</div>
-									<div class="settings-view-meta">Desktop preferences that work without an active project.</div>
+									<div class="settings-view-meta">Desktop preferences that work immediately.</div>
 								</div>
 								<div class="settings-view-header-actions">
 									<button class="settings-back-btn" @click=${() => this.close()}>← Back</button>
@@ -1209,7 +1218,14 @@ export class SettingsPanel {
 									<section class="settings-group settings-group-full">
 										<div class="settings-section">
 											<div class="settings-section-title">Runtime</div>
-											<div class="settings-desc">Open a project to enable assistant, account, update diagnostics, and compatibility settings.</div>
+											<div class="settings-desc">${runtimeMessage}</div>
+											${!hasProjectContext
+												? html`
+													<div class="settings-actions" style="margin-top:10px;">
+														<button class="ghost-btn" @click=${() => this.onRequestAddProject?.()}>Add project</button>
+													</div>
+												`
+												: nothing}
 										</div>
 									</section>
 								</div>

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -22,6 +22,7 @@ import {
 	rpcBridge,
 } from "../rpc/bridge.js";
 import { applyDesktopTheme, getResolvedDesktopTheme, readStoredDesktopTheme, type DesktopThemeMode } from "../theme/theme-manager.js";
+import { buildPiThemeDocument } from "../theme/pi-theme-document.js";
 
 interface ThemeOption {
 	id: string;
@@ -664,40 +665,20 @@ export class SettingsPanel {
 		const accent = preview.accent;
 		const background = preview.background;
 		const foreground = preview.foreground;
-		const doc = {
+		const doc = buildPiThemeDocument({
 			name: normalizedName,
-			vars: {
-				accent,
-				background,
-				foreground,
+			variant: theme,
+			accent,
+			surface: background,
+			ink: foreground,
+			contrast: profile.contrast,
+			fonts: {
+				ui: profile.uiFont || null,
+				code: profile.codeFont || null,
 			},
-			colors: {
-				accent: "accent",
-				text: "foreground",
-				muted: "foreground",
-				dim: "foreground",
-				selectedBg: "background",
-				userMessageBg: "background",
-				userMessageText: "foreground",
-				customMessageBg: "background",
-				customMessageText: "foreground",
-				toolPendingBg: "background",
-				toolSuccessBg: "background",
-				toolErrorBg: "background",
-				toolTitle: "accent",
-				toolOutput: "foreground",
-			},
-			piDesktop: {
-				source: "pi-desktop-theme-v1",
-				variant: theme,
-				contrast: profile.contrast,
-				fonts: {
-					ui: profile.uiFont || null,
-					code: profile.codeFont || null,
-				},
-				opaqueWindows: !profile.translucentSidebar,
-			},
-		};
+			opaqueWindows: !profile.translucentSidebar,
+			source: "pi-desktop-theme-v1",
+		});
 
 		const safeBase = normalizedName
 			.toLowerCase()

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -103,6 +103,10 @@ export class SettingsPanel {
 		this.render();
 	}
 
+	hasRenderedContent(): boolean {
+		return this.container.childElementCount > 0;
+	}
+
 	setOnClose(callback: () => void): void {
 		this.onClose = callback;
 	}

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -150,6 +150,15 @@ export class SettingsPanel {
 		if (notify) this.onClose?.();
 	}
 
+	hideWithoutClearing(): void {
+		this.resetColorDrafts();
+		this.createThemeDialogOpen = false;
+		this.createThemeDialogSaving = false;
+		this.createThemeDialogError = "";
+		this.applyAppearanceProfileForCurrentResolvedTheme();
+		this.isOpen = false;
+	}
+
 	private loadTheme(): void {
 		const saved = readStoredDesktopTheme();
 		this.state.theme = saved;

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -1173,6 +1173,56 @@ export class SettingsPanel {
 		`;
 	}
 
+	private renderBasicSettingsShell(runtimeMessage: string, options: { showAddProject: boolean; warning?: string } = { showAddProject: false }): void {
+		const { showAddProject, warning } = options;
+		render(
+			html`
+				<div class="settings-view-root">
+					<div class="settings-view-header">
+						<div class="settings-view-title-wrap">
+							<div class="settings-view-title">Settings</div>
+							<div class="settings-view-meta">Desktop preferences that work immediately.</div>
+						</div>
+						<div class="settings-view-header-actions">
+							<button class="settings-back-btn" @click=${() => this.close()}>← Back</button>
+						</div>
+					</div>
+					<div class="settings-view-body">
+						<div class="settings-view-grid">
+							<section class="settings-group settings-group-full">
+								<div class="settings-section">
+									<div class="settings-section-title">Appearance</div>
+									<div class="settings-label">Theme</div>
+									<div class="settings-desc">Choose light, dark, or system mode.</div>
+									<div class="theme-grid" style="margin-top:10px;">
+										<button class="theme-btn ${this.state.theme === "light" ? "active" : ""}" @click=${() => this.setTheme("light")}>Light</button>
+										<button class="theme-btn ${this.state.theme === "dark" ? "active" : ""}" @click=${() => this.setTheme("dark")}>Dark</button>
+										<button class="theme-btn ${this.state.theme === "system" ? "active" : ""}" @click=${() => this.setTheme("system")}>System</button>
+									</div>
+								</div>
+							</section>
+							<section class="settings-group settings-group-full">
+								<div class="settings-section">
+									<div class="settings-section-title">Runtime</div>
+									<div class="settings-desc">${runtimeMessage}</div>
+									${warning ? html`<div class="settings-desc" style="margin-top:8px;">${warning}</div>` : nothing}
+									${showAddProject
+										? html`
+											<div class="settings-actions" style="margin-top:10px;">
+												<button class="ghost-btn" @click=${() => this.onRequestAddProject?.()}>Add project</button>
+											</div>
+										`
+										: nothing}
+								</div>
+							</section>
+						</div>
+					</div>
+				</div>
+			`,
+			this.container,
+		);
+	}
+
 	render(): void {
 		if (!this.isOpen) {
 			this.container.innerHTML = "";
@@ -1189,51 +1239,7 @@ export class SettingsPanel {
 				? "Runtime is still starting for this project. You can change appearance now; assistant/account settings unlock when runtime is ready."
 				: "Open a project to enable assistant, account, update diagnostics, and compatibility settings.";
 			try {
-				render(
-					html`
-						<div class="settings-view-root">
-							<div class="settings-view-header">
-								<div class="settings-view-title-wrap">
-									<div class="settings-view-title">Settings</div>
-									<div class="settings-view-meta">Desktop preferences that work immediately.</div>
-								</div>
-								<div class="settings-view-header-actions">
-									<button class="settings-back-btn" @click=${() => this.close()}>← Back</button>
-								</div>
-							</div>
-							<div class="settings-view-body">
-								<div class="settings-view-grid">
-									<section class="settings-group settings-group-full">
-										<div class="settings-section">
-											<div class="settings-section-title">Appearance</div>
-											<div class="settings-label">Theme</div>
-											<div class="settings-desc">Choose light, dark, or system mode.</div>
-											<div class="theme-grid" style="margin-top:10px;">
-												<button class="theme-btn ${this.state.theme === "light" ? "active" : ""}" @click=${() => this.setTheme("light")}>Light</button>
-												<button class="theme-btn ${this.state.theme === "dark" ? "active" : ""}" @click=${() => this.setTheme("dark")}>Dark</button>
-												<button class="theme-btn ${this.state.theme === "system" ? "active" : ""}" @click=${() => this.setTheme("system")}>System</button>
-											</div>
-										</div>
-									</section>
-									<section class="settings-group settings-group-full">
-										<div class="settings-section">
-											<div class="settings-section-title">Runtime</div>
-											<div class="settings-desc">${runtimeMessage}</div>
-											${!hasProjectContext
-												? html`
-													<div class="settings-actions" style="margin-top:10px;">
-														<button class="ghost-btn" @click=${() => this.onRequestAddProject?.()}>Add project</button>
-													</div>
-												`
-												: nothing}
-										</div>
-									</section>
-								</div>
-							</div>
-						</div>
-					`,
-					this.container,
-				);
+				this.renderBasicSettingsShell(runtimeMessage, { showAddProject: !hasProjectContext });
 			} catch (err) {
 				console.error("Settings no-project render failed:", err);
 				this.container.innerHTML = "<div class=\"settings-view-root\"><div class=\"settings-view-body\"><div class=\"settings-desc\">Unable to render settings right now.</div></div></div>";
@@ -1458,23 +1464,14 @@ export class SettingsPanel {
 			render(template, this.container);
 		} catch (err) {
 			console.error("Settings panel render failed:", err);
-			this.container.innerHTML = `
-				<div class="settings-view-root">
-					<div class="settings-view-header">
-						<div class="settings-view-title-wrap">
-							<div class="settings-view-title">Settings</div>
-							<div class="settings-view-meta">Failed to render settings content.</div>
-						</div>
-					</div>
-					<div class="settings-view-body">
-						<div class="settings-group">
-							<div class="settings-section">
-								<div class="settings-desc">Something went wrong while rendering settings. Close and reopen Settings to retry.</div>
-							</div>
-						</div>
-					</div>
-				</div>
-			`;
+			try {
+				this.renderBasicSettingsShell(
+					"Advanced runtime settings are temporarily unavailable. You can still use appearance settings.",
+					{ showAddProject: false, warning: "Open another session or reopen settings once runtime stabilizes." },
+				);
+			} catch {
+				this.container.innerHTML = "<div class=\"settings-view-root\"><div class=\"settings-view-body\"><div class=\"settings-desc\">Unable to render settings right now.</div></div></div>";
+			}
 		}
 	}
 

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -97,6 +97,12 @@ export class SettingsPanel {
 		this.loadTheme();
 	}
 
+	setContainer(container: HTMLElement): void {
+		if (this.container === container) return;
+		this.container = container;
+		this.render();
+	}
+
 	setOnClose(callback: () => void): void {
 		this.onClose = callback;
 	}

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -87,6 +87,7 @@ export class SettingsPanel {
 	private createThemeDialogName = "";
 	private createThemeDialogSaving = false;
 	private createThemeDialogError = "";
+	private runtimeProjectPath: string | null = null;
 	private colorDrafts: Record<ThemeVariant, ThemeColorDraft> = {
 		light: { accent: "", background: "", foreground: "" },
 		dark: { accent: "", background: "", foreground: "" },
@@ -118,6 +119,10 @@ export class SettingsPanel {
 
 	setOnCliStatusChange(callback: (status: CliUpdateStatus | null) => void): void {
 		this.onCliStatusChange = callback;
+	}
+
+	setRuntimeProjectPath(projectPath: string | null): void {
+		this.runtimeProjectPath = typeof projectPath === "string" && projectPath.trim().length > 0 ? projectPath : null;
 	}
 
 	isVisible(): boolean {
@@ -182,6 +187,11 @@ export class SettingsPanel {
 	}
 
 	private getProfile(theme: ThemeVariant): DesktopAppearanceProfile {
+		const candidate = theme === "light" ? this.appearanceProfiles?.light : this.appearanceProfiles?.dark;
+		if (candidate && typeof candidate === "object") {
+			return candidate;
+		}
+		this.appearanceProfiles = loadDesktopAppearanceProfiles();
 		return theme === "light" ? this.appearanceProfiles.light : this.appearanceProfiles.dark;
 	}
 
@@ -488,10 +498,16 @@ export class SettingsPanel {
 		return this.availableThemes.filter((entry) => entry.variant === theme);
 	}
 
-	private lookupThemeOption(themeName: string): ThemeOption | null {
+	private lookupThemeOption(themeName: unknown): ThemeOption | null {
+		if (typeof themeName !== "string") return null;
 		const normalized = themeName.trim().toLowerCase();
 		if (!normalized) return null;
-		return this.availableThemes.find((entry) => entry.id.toLowerCase() === normalized || entry.label.toLowerCase() === normalized) ?? null;
+		if (!Array.isArray(this.availableThemes)) return null;
+		return this.availableThemes.find((entry) => {
+			const id = typeof entry?.id === "string" ? entry.id.toLowerCase() : "";
+			const label = typeof entry?.label === "string" ? entry.label.toLowerCase() : "";
+			return id === normalized || label === normalized;
+		}) ?? null;
 	}
 
 	private resolveDefaultThemeId(theme: ThemeVariant): string {
@@ -594,7 +610,8 @@ export class SettingsPanel {
 		this.render();
 	}
 
-	private normalizeHex6(value: string): string | null {
+	private normalizeHex6(value: unknown): string | null {
+		if (typeof value !== "string") return null;
 		const trimmed = value.trim();
 		const short = trimmed.match(/^#([0-9a-f]{3})$/i);
 		if (short) {
@@ -606,11 +623,11 @@ export class SettingsPanel {
 		return null;
 	}
 
-	private coercePickerColor(value: string): string {
+	private coercePickerColor(value: unknown): string {
 		return this.normalizeHex6(value) ?? "#7A818F";
 	}
 
-	private setProfileColor(theme: ThemeVariant, key: "accent" | "background" | "foreground", value: string): void {
+	private setProfileColor(theme: ThemeVariant, key: "accent" | "background" | "foreground", value: unknown): void {
 		const normalized = this.normalizeHex6(value);
 		if (!normalized) return;
 		this.colorDrafts[theme][key] = normalized;
@@ -620,7 +637,8 @@ export class SettingsPanel {
 		this.render();
 	}
 
-	private setProfileFont(theme: ThemeVariant, key: "uiFont" | "codeFont", value: string): void {
+	private setProfileFont(theme: ThemeVariant, key: "uiFont" | "codeFont", value: unknown): void {
+		if (typeof value !== "string") return;
 		const next = value.trim();
 		if (!next) return;
 		const profile = this.getProfile(theme);
@@ -736,13 +754,19 @@ export class SettingsPanel {
 	}
 
 	private async loadState(): Promise<void> {
-		try {
-			const sessionState = await rpcBridge.getState();
-			this.state.autoCompactionEnabled = sessionState.autoCompactionEnabled;
-			this.state.steeringMode = sessionState.steeringMode;
-			this.state.followUpMode = sessionState.followUpMode;
-		} catch {
-			// ignore
+		const hasRuntimeProject = Boolean(this.runtimeProjectPath);
+		if (hasRuntimeProject) {
+			try {
+				const sessionState = await rpcBridge.getState();
+				this.state.autoCompactionEnabled = Boolean(sessionState.autoCompactionEnabled);
+				this.state.steeringMode = sessionState.steeringMode === "all" ? "all" : "one-at-a-time";
+				this.state.followUpMode = sessionState.followUpMode === "all" ? "all" : "one-at-a-time";
+			} catch {
+				// ignore
+			}
+		} else {
+			this.authStatus = null;
+			this.compatibilityReport = null;
 		}
 
 		try {
@@ -762,13 +786,11 @@ export class SettingsPanel {
 			// ignore missing persisted settings
 		}
 
-		await Promise.all([
-			this.refreshAuthStatus(),
-			this.refreshDesktopStatus(),
-			this.refreshCliStatus(),
-			this.refreshCompatibilityStatus(),
-			this.refreshThemeCatalog(),
-		]);
+		const tasks: Promise<void>[] = [this.refreshDesktopStatus(), this.refreshCliStatus(), this.refreshThemeCatalog()];
+		if (hasRuntimeProject) {
+			tasks.push(this.refreshAuthStatus(), this.refreshCompatibilityStatus());
+		}
+		await Promise.all(tasks);
 		this.applyAppearanceProfileForCurrentResolvedTheme(false);
 	}
 
@@ -1137,6 +1159,7 @@ export class SettingsPanel {
 
 		const authProviders = Array.isArray(this.authStatus?.configured_providers) ? this.authStatus.configured_providers : [];
 		const compatibilityChecks = Array.isArray(this.compatibilityReport?.checks) ? this.compatibilityReport.checks : [];
+		const runtimeControlsEnabled = Boolean(this.runtimeProjectPath);
 
 		try {
 			const template = html`
@@ -1177,85 +1200,96 @@ export class SettingsPanel {
 							</div>
 						</section>
 
-						<section class="settings-group">
-							<div class="settings-section">
-								<div class="settings-section-title">Assistant</div>
-								${this.renderToggle(
-									"Auto-compaction",
-									"Summarize older context automatically when conversations get long.",
-									this.state.autoCompactionEnabled,
-									(v) => this.setAutoCompaction(v),
-								)}
-								${this.renderToggle(
-									"Auto-retry",
-									"Retry temporary provider errors automatically.",
-									this.state.autoRetryEnabled,
-									(v) => this.setAutoRetry(v),
-								)}
-							</div>
-							<div class="settings-section">
-								<div class="settings-section-title">Message queue</div>
-								<div class="settings-row">
-									<div>
-										<div class="settings-label">Steering messages</div>
-										<div class="settings-desc">How queued steering messages are sent while a response is streaming.</div>
+						${runtimeControlsEnabled
+							? html`
+								<section class="settings-group">
+									<div class="settings-section">
+										<div class="settings-section-title">Assistant</div>
+										${this.renderToggle(
+											"Auto-compaction",
+											"Summarize older context automatically when conversations get long.",
+											this.state.autoCompactionEnabled,
+											(v) => this.setAutoCompaction(v),
+										)}
+										${this.renderToggle(
+											"Auto-retry",
+											"Retry temporary provider errors automatically.",
+											this.state.autoRetryEnabled,
+											(v) => this.setAutoRetry(v),
+										)}
 									</div>
-									<select class="settings-select" .value=${this.state.steeringMode} @change=${(e: Event) => this.setSteeringMode((e.target as HTMLSelectElement).value as QueueMode)}>
-										<option value="one-at-a-time">One at a time</option>
-										<option value="all">All queued</option>
-									</select>
-								</div>
-								<div class="settings-row">
-									<div>
-										<div class="settings-label">Follow-up messages</div>
-										<div class="settings-desc">How queued follow-up prompts are sent after each run.</div>
+									<div class="settings-section">
+										<div class="settings-section-title">Message queue</div>
+										<div class="settings-row">
+											<div>
+												<div class="settings-label">Steering messages</div>
+												<div class="settings-desc">How queued steering messages are sent while a response is streaming.</div>
+											</div>
+											<select class="settings-select" .value=${this.state.steeringMode} @change=${(e: Event) => this.setSteeringMode((e.target as HTMLSelectElement).value as QueueMode)}>
+												<option value="one-at-a-time">One at a time</option>
+												<option value="all">All queued</option>
+											</select>
+										</div>
+										<div class="settings-row">
+											<div>
+												<div class="settings-label">Follow-up messages</div>
+												<div class="settings-desc">How queued follow-up prompts are sent after each run.</div>
+											</div>
+											<select class="settings-select" .value=${this.state.followUpMode} @change=${(e: Event) => this.setFollowUpMode((e.target as HTMLSelectElement).value as QueueMode)}>
+												<option value="one-at-a-time">One at a time</option>
+												<option value="all">All queued</option>
+											</select>
+										</div>
 									</div>
-									<select class="settings-select" .value=${this.state.followUpMode} @change=${(e: Event) => this.setFollowUpMode((e.target as HTMLSelectElement).value as QueueMode)}>
-										<option value="one-at-a-time">One at a time</option>
-										<option value="all">All queued</option>
-									</select>
-								</div>
-							</div>
-						</section>
+								</section>
 
-						<section class="settings-group">
-							<div class="settings-section">
-								<div class="settings-section-title">Account</div>
-								${this.authLoading
-									? html`<div class="settings-desc">Checking account status…</div>`
-									: html`
-										<div class="settings-desc">
-											${authProviders.length > 0
-												? `Connected providers: ${authProviders.length}`
-												: "No provider connected yet."}
-										</div>
-										<div class="settings-actions">
-											<button class="ghost-btn" @click=${() => this.refreshAuthStatus()}>Refresh account status</button>
-										</div>
-										${authProviders.length > 0
-											? html`
-												<div class="account-chips">
-													${authProviders.map((p) => html`<span class="account-chip">${p.provider} · ${p.source === "environment" ? "env" : p.kind}</span>`)}
+								<section class="settings-group">
+									<div class="settings-section">
+										<div class="settings-section-title">Account</div>
+										${this.authLoading
+											? html`<div class="settings-desc">Checking account status…</div>`
+											: html`
+												<div class="settings-desc">
+													${authProviders.length > 0
+														? `Connected providers: ${authProviders.length}`
+														: "No provider connected yet."}
 												</div>
-											`
-											: null}
-										<div class="settings-desc">Tip: run <code>/login</code> in terminal once, then restart desktop.</div>
-										${this.authStatus?.auth_file
-											? html`
-												<details class="settings-advanced">
-													<summary>Advanced account details</summary>
-													<div class="settings-desc">Auth file: <code>${this.authStatus.auth_file}</code></div>
-												</details>
-											`
-											: null}
-									`}
-							</div>
-							<div class="settings-section">
-								<div class="settings-section-title">Package configuration</div>
-								<div class="settings-desc">Package-specific settings are managed in <strong>Packages</strong> (gear icon on installed packages).</div>
-								<div class="settings-desc">Desktop stays capability-driven: packages can expose config commands, and those run via the normal chat/runtime flow.</div>
-							</div>
-						</section>
+												<div class="settings-actions">
+													<button class="ghost-btn" @click=${() => this.refreshAuthStatus()}>Refresh account status</button>
+												</div>
+												${authProviders.length > 0
+													? html`
+														<div class="account-chips">
+															${authProviders.map((p) => html`<span class="account-chip">${p.provider} · ${p.source === "environment" ? "env" : p.kind}</span>`)}
+														</div>
+													`
+													: null}
+												<div class="settings-desc">Tip: run <code>/login</code> in terminal once, then restart desktop.</div>
+												${this.authStatus?.auth_file
+													? html`
+														<details class="settings-advanced">
+															<summary>Advanced account details</summary>
+															<div class="settings-desc">Auth file: <code>${this.authStatus.auth_file}</code></div>
+														</details>
+													`
+													: null}
+											`}
+									</div>
+									<div class="settings-section">
+										<div class="settings-section-title">Package configuration</div>
+										<div class="settings-desc">Package-specific settings are managed in <strong>Packages</strong> (gear icon on installed packages).</div>
+										<div class="settings-desc">Desktop stays capability-driven: packages can expose config commands, and those run via the normal chat/runtime flow.</div>
+									</div>
+								</section>
+							`
+							: html`
+								<section class="settings-group">
+									<div class="settings-section">
+										<div class="settings-section-title">Runtime</div>
+										<div class="settings-desc">Open a project to enable assistant runtime, account, and compatibility settings.</div>
+									</div>
+								</section>
+							`}
 
 						<section class="settings-group settings-group-full">
 							<div class="settings-section">
@@ -1310,25 +1344,29 @@ export class SettingsPanel {
 									</button>
 								</div>
 								${this.cliActionMessage ? html`<div class="settings-desc">${this.cliActionMessage}</div>` : null}
-								<details class="settings-advanced">
-									<summary>Advanced CLI diagnostics</summary>
-									<div class="settings-desc">Discovery: <code>${this.cliStatus?.discovery || rpcBridge.discoveryInfo || "unknown"}</code></div>
-									${this.cliStatus?.update_command ? html`<div class="settings-desc">Manual update: <code>${this.cliStatus.update_command}</code></div>` : null}
-									<div class="settings-actions">
-										<button class="ghost-btn" ?disabled=${this.compatibilityLoading} @click=${() => this.refreshCompatibilityStatus()}>
-											${this.compatibilityLoading ? "Checking RPC…" : "Run RPC compatibility check"}
-										</button>
-									</div>
-									${this.compatibilityReport
-										? html`
-											<div class="settings-desc">
-												RPC compatibility: ${this.compatibilityReport.ok ? "OK" : "Failed"}
-												${compatibilityChecks.length > 0 ? html` (${compatibilityChecks.join(", ")})` : null}
+								${runtimeControlsEnabled
+									? html`
+										<details class="settings-advanced">
+											<summary>Advanced CLI diagnostics</summary>
+											<div class="settings-desc">Discovery: <code>${this.cliStatus?.discovery || rpcBridge.discoveryInfo || "unknown"}</code></div>
+											${this.cliStatus?.update_command ? html`<div class="settings-desc">Manual update: <code>${this.cliStatus.update_command}</code></div>` : null}
+											<div class="settings-actions">
+												<button class="ghost-btn" ?disabled=${this.compatibilityLoading} @click=${() => this.refreshCompatibilityStatus()}>
+													${this.compatibilityLoading ? "Checking RPC…" : "Run RPC compatibility check"}
+												</button>
 											</div>
-											${this.compatibilityReport.error ? html`<div class="settings-desc">${this.compatibilityReport.error}</div>` : null}
-										`
-										: null}
-								</details>
+											${this.compatibilityReport
+												? html`
+													<div class="settings-desc">
+														RPC compatibility: ${this.compatibilityReport.ok ? "OK" : "Failed"}
+														${compatibilityChecks.length > 0 ? html` (${compatibilityChecks.join(", ")})` : null}
+													</div>
+													${this.compatibilityReport.error ? html`<div class="settings-desc">${this.compatibilityReport.error}</div>` : null}
+												`
+												: null}
+										</details>
+									`
+									: html`<div class="settings-desc">Runtime diagnostics become available after opening a project.</div>`}
 							</div>
 						</section>
 					</div>

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -767,6 +767,16 @@ export class SettingsPanel {
 		} else {
 			this.authStatus = null;
 			this.compatibilityReport = null;
+			this.authLoading = false;
+			this.compatibilityLoading = false;
+			this.desktopStatus = null;
+			this.cliStatus = null;
+			this.desktopLoading = false;
+			this.cliLoading = false;
+			this.themeCatalogLoading = false;
+			this.themeCatalogError = "";
+			this.themeCatalogMessage = "";
+			this.availableThemes = [];
 		}
 
 		try {
@@ -786,11 +796,18 @@ export class SettingsPanel {
 			// ignore missing persisted settings
 		}
 
-		const tasks: Promise<void>[] = [this.refreshDesktopStatus(), this.refreshCliStatus(), this.refreshThemeCatalog()];
-		if (hasRuntimeProject) {
-			tasks.push(this.refreshAuthStatus(), this.refreshCompatibilityStatus());
+		if (!hasRuntimeProject) {
+			this.applyAppearanceProfileForCurrentResolvedTheme(false);
+			return;
 		}
-		await Promise.all(tasks);
+
+		await Promise.all([
+			this.refreshDesktopStatus(),
+			this.refreshCliStatus(),
+			this.refreshThemeCatalog(),
+			this.refreshAuthStatus(),
+			this.refreshCompatibilityStatus(),
+		]);
 		this.applyAppearanceProfileForCurrentResolvedTheme(false);
 	}
 
@@ -1160,6 +1177,53 @@ export class SettingsPanel {
 		const authProviders = Array.isArray(this.authStatus?.configured_providers) ? this.authStatus.configured_providers : [];
 		const compatibilityChecks = Array.isArray(this.compatibilityReport?.checks) ? this.compatibilityReport.checks : [];
 		const runtimeControlsEnabled = Boolean(this.runtimeProjectPath);
+
+		if (!runtimeControlsEnabled) {
+			try {
+				render(
+					html`
+						<div class="settings-view-root">
+							<div class="settings-view-header">
+								<div class="settings-view-title-wrap">
+									<div class="settings-view-title">Settings</div>
+									<div class="settings-view-meta">Desktop preferences that work without an active project.</div>
+								</div>
+								<div class="settings-view-header-actions">
+									<button class="settings-back-btn" @click=${() => this.close()}>← Back</button>
+								</div>
+							</div>
+							<div class="settings-view-body">
+								<div class="settings-view-grid">
+									<section class="settings-group settings-group-full">
+										<div class="settings-section">
+											<div class="settings-section-title">Appearance</div>
+											<div class="settings-label">Theme</div>
+											<div class="settings-desc">Choose light, dark, or system mode.</div>
+											<div class="theme-grid" style="margin-top:10px;">
+												<button class="theme-btn ${this.state.theme === "light" ? "active" : ""}" @click=${() => this.setTheme("light")}>Light</button>
+												<button class="theme-btn ${this.state.theme === "dark" ? "active" : ""}" @click=${() => this.setTheme("dark")}>Dark</button>
+												<button class="theme-btn ${this.state.theme === "system" ? "active" : ""}" @click=${() => this.setTheme("system")}>System</button>
+											</div>
+										</div>
+									</section>
+									<section class="settings-group settings-group-full">
+										<div class="settings-section">
+											<div class="settings-section-title">Runtime</div>
+											<div class="settings-desc">Open a project to enable assistant, account, update diagnostics, and compatibility settings.</div>
+										</div>
+									</section>
+								</div>
+							</div>
+						</div>
+					`,
+					this.container,
+				);
+			} catch (err) {
+				console.error("Settings no-project render failed:", err);
+				this.container.innerHTML = "<div class=\"settings-view-root\"><div class=\"settings-view-body\"><div class=\"settings-desc\">Unable to render settings right now.</div></div></div>";
+			}
+			return;
+		}
 
 		try {
 			const template = html`

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -634,6 +634,10 @@ export class Sidebar {
 		return p ? { id: p.id, name: p.name, path: p.path } : null;
 	}
 
+	listProjects(): Array<{ id: string; name: string; path: string }> {
+		return this.projects.map((project) => ({ id: project.id, name: project.name, path: project.path }));
+	}
+
 	getProjectById(projectId: string | null | undefined): { id: string; name: string; path: string } | null {
 		if (!projectId) return null;
 		const project = this.projects.find((entry) => entry.id === projectId) ?? null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2403,10 +2403,13 @@ async function initialize(): Promise<void> {
 }
 
 function mountSettingsPanel(): SettingsPanel {
-	if (settingsPanel) return settingsPanel;
 	const settingsContainer = document.getElementById("settings-pane");
 	if (!settingsContainer) {
 		throw new Error("Settings pane container not found");
+	}
+	if (settingsPanel) {
+		settingsPanel.setContainer(settingsContainer);
+		return settingsPanel;
 	}
 	const panel = new SettingsPanel(settingsContainer);
 	panel.setOnDesktopStatusChange((status) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -131,6 +131,7 @@ let desktopUpdateChecking = false;
 let projectSwitchTask: Promise<void> = Promise.resolve();
 let projectSwitchVersion = 0;
 let workspacePaneApplyVersion = 0;
+let settingsPaneRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
 
 class StaleProjectTaskError extends Error {
 	constructor() {
@@ -1853,6 +1854,7 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 			await panel.open();
 			if (isStale()) return;
 		}
+		scheduleSettingsPaneRecovery("apply-settings");
 		syncDebugOverlay();
 		return;
 	}
@@ -2639,6 +2641,32 @@ function wireCommandPaletteBuiltins(): void {
 	]);
 }
 
+function scheduleSettingsPaneRecovery(reason: string, delayMs = 80): void {
+	if (settingsPaneRecoveryTimer) {
+		clearTimeout(settingsPaneRecoveryTimer);
+	}
+	settingsPaneRecoveryTimer = setTimeout(() => {
+		settingsPaneRecoveryTimer = null;
+		void recoverSettingsPaneIfBlank(reason);
+	}, delayMs);
+}
+
+async function recoverSettingsPaneIfBlank(reason: string): Promise<void> {
+	const workspace = getActiveWorkspace();
+	if (!workspace || workspace.pane !== "settings") return;
+	const settingsContainer = document.getElementById("settings-pane");
+	if (!settingsContainer) return;
+	if (settingsContainer.childElementCount > 0 && settingsPanel?.isVisible()) return;
+	recordDebugTrace(`settings-recover reason=${reason}`);
+	try {
+		settingsPanel = null;
+		const panel = mountSettingsPanel();
+		await panel.open();
+	} catch (err) {
+		console.error("Settings pane blank recovery failed:", err);
+	}
+}
+
 function requestOpenSettingsPanel(): void {
 	const workspace = getActiveWorkspace();
 	if (!workspace) return;
@@ -2646,23 +2674,21 @@ function requestOpenSettingsPanel(): void {
 	persistWorkspaces();
 	syncWorkspaceTabsBar();
 	setPaneVisibility("settings");
-	try {
-		const panel = mountSettingsPanel();
-		void panel.open();
-	} catch (err) {
-		console.error("Failed to pre-open settings pane:", err);
-	}
-	void applyWorkspacePane(workspace).catch((err) => {
-		console.error("Failed to open settings pane:", err);
-		try {
-			settingsPanel = null;
-			setPaneVisibility("settings");
-			const panel = mountSettingsPanel();
-			void panel.open();
-		} catch (innerErr) {
-			console.error("Settings pane recovery failed:", innerErr);
-		}
-	});
+	void applyWorkspacePane(workspace)
+		.catch((err) => {
+			console.error("Failed to open settings pane:", err);
+			try {
+				settingsPanel = null;
+				setPaneVisibility("settings");
+				const panel = mountSettingsPanel();
+				void panel.open();
+			} catch (innerErr) {
+				console.error("Settings pane recovery failed:", innerErr);
+			}
+		})
+		.finally(() => {
+			scheduleSettingsPaneRecovery("request-open");
+		});
 }
 
 function openSettings(): void {
@@ -2915,6 +2941,10 @@ function renderApp(): void {
 		if (settingsPanel.isVisible() && !settingsPanel.hasRenderedContent()) {
 			settingsPanel.render();
 		}
+	}
+	const activeWorkspace = getActiveWorkspace();
+	if (activeWorkspace?.pane === "settings" && settingsPaneContainer && settingsPaneContainer.childElementCount === 0) {
+		scheduleSettingsPaneRecovery("render-app");
 	}
 
 	applySidebarWidth();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1603,7 +1603,10 @@ function ensureDebugOverlayPolling(): void {
 }
 
 function syncSidebarSelectionFromWorkspace(workspace: WorkspaceState | null = getActiveWorkspace()): void {
-	if (!sidebar) return;
+	if (!sidebar) {
+		chatView?.setWelcomeProjects([], workspace?.activeProjectId ?? null);
+		return;
+	}
 	if (!workspace) {
 		sidebar.clearActiveProject();
 		sidebar.setActiveSessionPath(null);
@@ -1611,6 +1614,7 @@ function syncSidebarSelectionFromWorkspace(workspace: WorkspaceState | null = ge
 		sidebar.setSuppressedSessionPaths([]);
 		sidebar.setAttentionSessions([]);
 		sidebar.setTransientSessionDraft(null);
+		chatView?.setWelcomeProjects(sidebar.listProjects(), null);
 		return;
 	}
 
@@ -1626,6 +1630,7 @@ function syncSidebarSelectionFromWorkspace(workspace: WorkspaceState | null = ge
 	} else {
 		sidebar.clearActiveProject();
 	}
+	chatView?.setWelcomeProjects(sidebar.listProjects(), getWorkspaceActiveProjectId(workspace));
 
 	const suppressedDraftSessionPaths = workspace.sessionTabs
 		.filter((tab) => isEphemeralSessionTab(tab) && Boolean(tab.sessionPath))
@@ -2373,6 +2378,9 @@ async function initialize(): Promise<void> {
 			persistWorkspaces();
 			syncWorkspaceTabsBar();
 			void applyWorkspacePane(workspace);
+		});
+		chatView.setOnSelectWelcomeProject((projectId) => {
+			sidebar?.setActiveProject(projectId, true);
 		});
 		chatView.setOnPromptSubmitted(() => {
 			startSidebarSessionsWarmRefresh();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1762,6 +1762,15 @@ function setPaneVisibility(pane: WorkspaceState["pane"]): void {
 	settingsPane.classList.toggle("hidden-pane", pane !== "settings");
 }
 
+function resolveSettingsRuntimeProjectPath(workspace: WorkspaceState | null): string | null {
+	if (!workspace) return null;
+	const workspacePath = getWorkspaceActiveProjectPath(workspace);
+	if (!workspacePath) return null;
+	const sidebarMatch = sidebar?.getProjectByPath(workspacePath) ?? null;
+	if (!sidebarMatch) return null;
+	return sidebarMatch.path;
+}
+
 async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWorkspace()): Promise<void> {
 	const applyVersion = ++workspacePaneApplyVersion;
 	const isStale = (): boolean => applyVersion !== workspacePaneApplyVersion;
@@ -1845,14 +1854,14 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 		setPaneVisibility("settings");
 		try {
 			const panel = mountSettingsPanel();
-			panel.setRuntimeProjectPath(getWorkspaceActiveProjectPath(workspace));
+			panel.setRuntimeProjectPath(resolveSettingsRuntimeProjectPath(workspace));
 			await panel.open();
 			if (isStale()) return;
 		} catch (err) {
 			console.error("Failed to render settings pane:", err);
 			settingsPanel = null;
 			const panel = mountSettingsPanel();
-			panel.setRuntimeProjectPath(getWorkspaceActiveProjectPath(workspace));
+			panel.setRuntimeProjectPath(resolveSettingsRuntimeProjectPath(workspace));
 			await panel.open();
 			if (isStale()) return;
 		}
@@ -2663,7 +2672,7 @@ async function recoverSettingsPaneIfBlank(reason: string): Promise<void> {
 	try {
 		settingsPanel = null;
 		const panel = mountSettingsPanel();
-		panel.setRuntimeProjectPath(getWorkspaceActiveProjectPath(workspace));
+		panel.setRuntimeProjectPath(resolveSettingsRuntimeProjectPath(workspace));
 		await panel.open();
 	} catch (err) {
 		console.error("Settings pane blank recovery failed:", err);
@@ -2684,7 +2693,7 @@ function requestOpenSettingsPanel(): void {
 				settingsPanel = null;
 				setPaneVisibility("settings");
 				const panel = mountSettingsPanel();
-				panel.setRuntimeProjectPath(getWorkspaceActiveProjectPath(workspace));
+				panel.setRuntimeProjectPath(resolveSettingsRuntimeProjectPath(workspace));
 				void panel.open();
 			} catch (innerErr) {
 				console.error("Settings pane recovery failed:", innerErr);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1827,11 +1827,18 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 
 	if (workspace.pane === "settings") {
 		setPaneVisibility("settings");
-		const panel = mountSettingsPanel();
-		if (!panel.isVisible()) {
+		try {
+			const panel = mountSettingsPanel();
+			if (!panel.isVisible() || !panel.hasRenderedContent()) {
+				await panel.open();
+			} else {
+				panel.render();
+			}
+		} catch (err) {
+			console.error("Failed to render settings pane:", err);
+			settingsPanel = null;
+			const panel = mountSettingsPanel();
 			await panel.open();
-		} else {
-			panel.render();
 		}
 		syncDebugOverlay();
 		return;
@@ -2625,7 +2632,17 @@ function requestOpenSettingsPanel(): void {
 	workspace.pane = "settings";
 	persistWorkspaces();
 	syncWorkspaceTabsBar();
-	void applyWorkspacePane(workspace);
+	void applyWorkspacePane(workspace).catch((err) => {
+		console.error("Failed to open settings pane:", err);
+		try {
+			settingsPanel = null;
+			setPaneVisibility("settings");
+			const panel = mountSettingsPanel();
+			void panel.open();
+		} catch (innerErr) {
+			console.error("Settings pane recovery failed:", innerErr);
+		}
+	});
 }
 
 function openSettings(): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1764,11 +1764,7 @@ function setPaneVisibility(pane: WorkspaceState["pane"]): void {
 
 function resolveSettingsRuntimeProjectPath(workspace: WorkspaceState | null): string | null {
 	if (!workspace) return null;
-	const workspacePath = getWorkspaceActiveProjectPath(workspace);
-	if (!workspacePath) return null;
-	const sidebarMatch = sidebar?.getProjectByPath(workspacePath) ?? null;
-	if (!sidebarMatch) return null;
-	return sidebarMatch.path;
+	return getWorkspaceActiveProjectPath(workspace);
 }
 
 async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWorkspace()): Promise<void> {
@@ -2461,6 +2457,9 @@ function mountSettingsPanel(): SettingsPanel {
 		persistWorkspaces();
 		syncWorkspaceTabsBar();
 		void applyWorkspacePane(workspace);
+	});
+	panel.setOnRequestAddProject(() => {
+		void sidebar?.openFolder();
 	});
 	settingsPanel = panel;
 	return panel;

--- a/src/main.ts
+++ b/src/main.ts
@@ -919,6 +919,7 @@ function resetWorkspaceContentTabs(
 	workspace: WorkspaceState,
 	project: { id?: string | null; path?: string | null } | null = { id: workspace.activeProjectId, path: workspace.activeProjectPath },
 ): void {
+	const previousPane = workspace.pane;
 	setWorkspaceActiveProject(workspace, project);
 	workspace.sessionTabs = [createSessionTab(NEW_SESSION_TAB_TITLE, null, workspace.activeProjectId, workspace.activeProjectPath)];
 	workspace.activeSessionTabId = workspace.sessionTabs[0].id;
@@ -926,7 +927,7 @@ function resetWorkspaceContentTabs(
 	workspace.activeFileTabId = null;
 	workspace.filePath = null;
 	workspace.sessionTitle = NEW_SESSION_TAB_TITLE;
-	workspace.pane = "chat";
+	workspace.pane = previousPane === "settings" || previousPane === "packages" ? previousPane : "chat";
 }
 
 function createAndActivateEmptySessionTab(
@@ -1843,12 +1844,8 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 		setPaneVisibility("settings");
 		try {
 			const panel = mountSettingsPanel();
-			if (!panel.isVisible() || !panel.hasRenderedContent()) {
-				await panel.open();
-				if (isStale()) return;
-			} else {
-				panel.render();
-			}
+			await panel.open();
+			if (isStale()) return;
 		} catch (err) {
 			console.error("Failed to render settings pane:", err);
 			settingsPanel = null;
@@ -2645,10 +2642,16 @@ function wireCommandPaletteBuiltins(): void {
 function requestOpenSettingsPanel(): void {
 	const workspace = getActiveWorkspace();
 	if (!workspace) return;
-	mountSettingsPanel();
 	workspace.pane = "settings";
 	persistWorkspaces();
 	syncWorkspaceTabsBar();
+	setPaneVisibility("settings");
+	try {
+		const panel = mountSettingsPanel();
+		void panel.open();
+	} catch (err) {
+		console.error("Failed to pre-open settings pane:", err);
+	}
 	void applyWorkspacePane(workspace).catch((err) => {
 		console.error("Failed to open settings pane:", err);
 		try {

--- a/src/main.ts
+++ b/src/main.ts
@@ -130,6 +130,7 @@ let desktopUpdateChecking = false;
 
 let projectSwitchTask: Promise<void> = Promise.resolve();
 let projectSwitchVersion = 0;
+let workspacePaneApplyVersion = 0;
 
 class StaleProjectTaskError extends Error {
 	constructor() {
@@ -1760,9 +1761,13 @@ function setPaneVisibility(pane: WorkspaceState["pane"]): void {
 }
 
 async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWorkspace()): Promise<void> {
+	const applyVersion = ++workspacePaneApplyVersion;
+	const isStale = (): boolean => applyVersion !== workspacePaneApplyVersion;
+
 	syncWorkspaceContextChrome(workspace);
 	syncSidebarSelectionFromWorkspace(workspace);
 	syncContentTabsBar(workspace);
+	if (isStale()) return;
 
 	if (!workspace) {
 		const resolved = getResolvedDesktopTheme();
@@ -1770,7 +1775,8 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 		void syncDesktopThemeWithPiTheme(null).finally(() => {
 			applyDesktopAppearanceProfileToRoot(resolved, profiles);
 		});
-		settingsPanel?.close(false);
+		if (isStale()) return;
+		settingsPanel?.hideWithoutClearing();
 		syncRunningSessionIndicators();
 		setPaneVisibility("chat");
 		return;
@@ -1783,15 +1789,18 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 	void syncDesktopThemeWithPiTheme(workspaceProjectPath).finally(() => {
 		applyDesktopAppearanceProfileToRoot(resolved, profiles);
 	});
+	if (isStale()) return;
+
 	chatView?.setProjectPath(workspaceProjectPath);
 	packagesView?.setProjectPath(workspaceProjectPath);
 	terminalPanel?.setProjectPath(workspaceProjectPath);
 	if (workspace.pane !== "settings") {
-		settingsPanel?.close(false);
+		settingsPanel?.hideWithoutClearing();
 	}
 	if (workspace.pane !== "file") {
 		fileViewer?.setProjectPath(workspaceProjectPath);
 	}
+	if (isStale()) return;
 
 	if (workspace.pane === "file") {
 		const activeFileTab = getActiveFileTab(workspace);
@@ -1800,6 +1809,7 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 		setPaneVisibility("file");
 		if (activeFileTab?.path) {
 			await fileViewer?.openFile(activeFileTab.path);
+			if (isStale()) return;
 		} else {
 			const draftId = activeFileTab?.id ?? "draft";
 			const draftTitle = activeFileTab?.title || NEW_FILE_TAB_TITLE;
@@ -1810,27 +1820,32 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 
 	if (workspace.pane === "terminal" && workspace.terminalOpen) {
 		terminalPanel?.setProjectPath(getWorkspaceActiveProjectPath(workspace));
+		if (isStale()) return;
 		setPaneVisibility("terminal");
 		terminalPanel?.focusInput();
 		return;
 	}
 
 	if (workspace.pane === "packages") {
-		settingsPanel?.close(false);
+		settingsPanel?.hideWithoutClearing();
 		packagesView?.setProjectPath(getWorkspaceActiveProjectPath(workspace));
+		if (isStale()) return;
 		setPaneVisibility("packages");
 		await packagesView?.open();
+		if (isStale()) return;
 		workspaceTabsBar?.setPackagesSearchQuery(packagesView?.getQuery() ?? "");
 		syncDebugOverlay();
 		return;
 	}
 
 	if (workspace.pane === "settings") {
+		if (isStale()) return;
 		setPaneVisibility("settings");
 		try {
 			const panel = mountSettingsPanel();
 			if (!panel.isVisible() || !panel.hasRenderedContent()) {
 				await panel.open();
+				if (isStale()) return;
 			} else {
 				panel.render();
 			}
@@ -1839,12 +1854,14 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 			settingsPanel = null;
 			const panel = mountSettingsPanel();
 			await panel.open();
+			if (isStale()) return;
 		}
 		syncDebugOverlay();
 		return;
 	}
 
-	settingsPanel?.close(false);
+	if (isStale()) return;
+	settingsPanel?.hideWithoutClearing();
 	syncActiveChatRuntimeBinding(workspace);
 	setPaneVisibility("chat");
 	chatView?.focusInput();
@@ -2889,6 +2906,14 @@ function renderApp(): void {
 		`,
 		app,
 	);
+	const settingsPaneContainer = document.getElementById("settings-pane");
+	if (settingsPanel && settingsPaneContainer) {
+		settingsPanel.setContainer(settingsPaneContainer);
+		if (settingsPanel.isVisible() && !settingsPanel.hasRenderedContent()) {
+			settingsPanel.render();
+		}
+	}
+
 	applySidebarWidth();
 	setupSidebarResize();
 	syncSidebarCollapseToggleButton();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1845,12 +1845,14 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 		setPaneVisibility("settings");
 		try {
 			const panel = mountSettingsPanel();
+			panel.setRuntimeProjectPath(getWorkspaceActiveProjectPath(workspace));
 			await panel.open();
 			if (isStale()) return;
 		} catch (err) {
 			console.error("Failed to render settings pane:", err);
 			settingsPanel = null;
 			const panel = mountSettingsPanel();
+			panel.setRuntimeProjectPath(getWorkspaceActiveProjectPath(workspace));
 			await panel.open();
 			if (isStale()) return;
 		}
@@ -2661,6 +2663,7 @@ async function recoverSettingsPaneIfBlank(reason: string): Promise<void> {
 	try {
 		settingsPanel = null;
 		const panel = mountSettingsPanel();
+		panel.setRuntimeProjectPath(getWorkspaceActiveProjectPath(workspace));
 		await panel.open();
 	} catch (err) {
 		console.error("Settings pane blank recovery failed:", err);
@@ -2681,6 +2684,7 @@ function requestOpenSettingsPanel(): void {
 				settingsPanel = null;
 				setPaneVisibility("settings");
 				const panel = mountSettingsPanel();
+				panel.setRuntimeProjectPath(getWorkspaceActiveProjectPath(workspace));
 				void panel.open();
 			} catch (innerErr) {
 				console.error("Settings pane recovery failed:", innerErr);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4654,19 +4654,23 @@ body.sidebar-resizing {
 }
 
 .welcome-dashboard {
-	width: min(840px, calc(100% - 40px));
+	width: min(920px, calc(100% - 40px));
 	margin: 0 auto;
 	display: grid;
-	gap: 16px;
+	gap: 14px;
 }
 
 .welcome-hero {
 	border: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
-	background: color-mix(in srgb, var(--bg-elev) 62%, transparent);
+	background: color-mix(in srgb, var(--bg-elev) 64%, transparent);
 	border-radius: 18px;
-	padding: 24px;
+	padding: 22px;
 	display: grid;
 	gap: 10px;
+}
+
+.welcome-hero-codex {
+	gap: 12px;
 }
 
 .welcome-eyebrow {
@@ -4678,24 +4682,81 @@ body.sidebar-resizing {
 
 .welcome-hero h2 {
 	margin: 0;
-	font-size: 32px;
-	line-height: 1.02;
+	font-size: 34px;
+	line-height: 1.04;
 	letter-spacing: -0.03em;
-	max-width: 560px;
+	max-width: 620px;
 }
 
 .welcome-hero p {
 	margin: 0;
 	color: var(--muted);
 	font-size: 14px;
-	line-height: 1.5;
-	max-width: 580px;
+	line-height: 1.55;
+	max-width: 680px;
 }
 
 .welcome-actions {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 8px;
+}
+
+.welcome-quick-grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: 10px;
+}
+
+.welcome-quick-action {
+	border-radius: 14px;
+	border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+	background: color-mix(in srgb, var(--bg-soft) 62%, transparent);
+	padding: 11px 12px;
+	text-align: left;
+	display: grid;
+	gap: 5px;
+	cursor: pointer;
+	color: var(--text);
+}
+
+.welcome-quick-action:hover {
+	background: color-mix(in srgb, var(--bg-soft) 78%, transparent);
+}
+
+.welcome-quick-action.primary {
+	border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
+	background: color-mix(in srgb, var(--accent) 16%, var(--bg-soft));
+}
+
+.welcome-quick-title {
+	font-size: 13px;
+	font-weight: 620;
+}
+
+.welcome-quick-desc {
+	font-size: 11px;
+	color: var(--muted);
+	line-height: 1.35;
+}
+
+.welcome-inline-note {
+	font-size: 11px;
+	color: var(--muted-2);
+}
+
+.welcome-inline-note kbd {
+	display: inline-flex;
+	align-items: center;
+	height: 20px;
+	padding: 0 6px;
+	margin: 0 3px;
+	border-radius: 6px;
+	border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+	background: color-mix(in srgb, var(--bg-soft) 66%, transparent);
+	font-size: 10px;
+	font-family: var(--font-family-mono);
+	color: var(--text);
 }
 
 .welcome-action {
@@ -4736,9 +4797,21 @@ body.sidebar-resizing {
 	border: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
 	background: color-mix(in srgb, var(--bg-elev) 60%, transparent);
 	border-radius: 16px;
-	padding: 16px;
+	padding: 15px;
 	display: grid;
 	gap: 10px;
+}
+
+.welcome-status-card {
+	gap: 11px;
+}
+
+.welcome-status-head {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	flex-wrap: wrap;
 }
 
 .welcome-card.compact {
@@ -4799,13 +4872,19 @@ body.sidebar-resizing {
 	color: var(--text);
 }
 
+.welcome-runtime-grid {
+	display: grid;
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+	gap: 8px;
+}
+
 .welcome-runtime-row {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	gap: 10px;
 	font-size: 11px;
-	padding-top: 2px;
+	padding: 0;
 }
 
 .welcome-runtime-row span {
@@ -6046,6 +6125,14 @@ body.sidebar-resizing {
 		grid-template-columns: 1fr;
 	}
 
+	.welcome-quick-grid {
+		grid-template-columns: 1fr;
+	}
+
+	.welcome-runtime-grid {
+		grid-template-columns: 1fr;
+	}
+
 	.welcome-kpis.compact {
 		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
@@ -6086,8 +6173,16 @@ body.sidebar-resizing {
 		grid-template-columns: 1fr;
 	}
 
+	.welcome-dashboard {
+		width: calc(100% - 20px);
+	}
+
 	.welcome-hero h2 {
-		font-size: 22px;
+		font-size: 24px;
+	}
+
+	.welcome-kpis.compact {
+		grid-template-columns: 1fr 1fr;
 	}
 
 	.composer-shell {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4719,7 +4719,7 @@ body.sidebar-resizing {
 .welcome-project-wrap {
 	position: relative;
 	justify-self: center;
-	width: min(520px, 100%);
+	width: min(430px, 100%);
 }
 
 .welcome-project-trigger {
@@ -4727,13 +4727,13 @@ body.sidebar-resizing {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	gap: 8px;
+	gap: 7px;
 	border: none;
 	background: transparent;
 	padding: 0;
-	font-size: 44px;
+	font-size: 30px;
 	line-height: 1;
-	letter-spacing: -0.03em;
+	letter-spacing: -0.025em;
 	color: color-mix(in srgb, var(--text) 56%, var(--bg));
 	cursor: pointer;
 }
@@ -4743,25 +4743,25 @@ body.sidebar-resizing {
 }
 
 .welcome-project-caret {
-	font-size: 24px;
+	font-size: 18px;
 	line-height: 1;
 	color: color-mix(in srgb, var(--text) 52%, var(--bg));
-	margin-top: 6px;
+	margin-top: 3px;
 }
 
 .welcome-project-menu {
 	position: absolute;
 	left: 50%;
 	transform: translateX(-50%);
-	top: calc(100% + 12px);
-	width: min(560px, calc(100vw - 70px));
-	border-radius: 20px;
+	top: calc(100% + 10px);
+	width: min(430px, calc(100vw - 70px));
+	border-radius: 16px;
 	border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
 	background: color-mix(in srgb, var(--bg-elev) 96%, transparent);
-	box-shadow: 0 14px 36px rgba(0, 0, 0, 0.16);
-	padding: 10px;
+	box-shadow: 0 10px 24px rgba(0, 0, 0, 0.14);
+	padding: 8px;
 	display: grid;
-	gap: 4px;
+	gap: 3px;
 	z-index: 5;
 }
 
@@ -4770,20 +4770,20 @@ body.sidebar-resizing {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	gap: 10px;
+	gap: 8px;
 	border: none;
 	background: transparent;
 	color: var(--text);
-	font-size: 24px;
-	line-height: 1.2;
-	padding: 9px 12px;
-	border-radius: 12px;
+	font-size: 15px;
+	line-height: 1.3;
+	padding: 8px 10px;
+	border-radius: 10px;
 	text-align: left;
 	cursor: pointer;
 }
 
 .welcome-project-item.current {
-	font-size: 24px;
+	font-size: 15px;
 	cursor: default;
 }
 
@@ -6082,14 +6082,17 @@ body.sidebar-resizing {
 		font-size: 38px;
 	}
 
-	.welcome-project-trigger,
+	.welcome-project-trigger {
+		font-size: 28px;
+	}
+
 	.welcome-project-item,
 	.welcome-project-item.current {
-		font-size: 34px;
+		font-size: 15px;
 	}
 
 	.welcome-project-caret {
-		font-size: 22px;
+		font-size: 18px;
 	}
 
 	.composer-controls {
@@ -6145,15 +6148,18 @@ body.sidebar-resizing {
 		width: 100%;
 	}
 
-	.welcome-project-trigger,
-	.welcome-project-item,
-	.welcome-project-item.current {
+	.welcome-project-trigger {
 		font-size: 24px;
 	}
 
+	.welcome-project-item,
+	.welcome-project-item.current {
+		font-size: 14px;
+	}
+
 	.welcome-project-caret {
-		font-size: 22px;
-		margin-top: 4px;
+		font-size: 16px;
+		margin-top: 2px;
 	}
 
 	.welcome-project-menu {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4716,6 +4716,87 @@ body.sidebar-resizing {
 	line-height: 1.35;
 }
 
+.welcome-project-wrap {
+	position: relative;
+	justify-self: center;
+	width: min(520px, 100%);
+}
+
+.welcome-project-trigger {
+	width: 100%;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	border: none;
+	background: transparent;
+	padding: 0;
+	font-size: 64px;
+	line-height: 1;
+	letter-spacing: -0.03em;
+	color: color-mix(in srgb, var(--text) 48%, var(--bg));
+	cursor: pointer;
+}
+
+.welcome-project-trigger.active {
+	color: color-mix(in srgb, var(--text) 92%, var(--bg));
+}
+
+.welcome-project-caret {
+	font-size: 36px;
+	line-height: 1;
+	color: color-mix(in srgb, var(--text) 52%, var(--bg));
+	margin-top: 8px;
+}
+
+.welcome-project-menu {
+	position: absolute;
+	left: 50%;
+	transform: translateX(-50%);
+	top: calc(100% + 12px);
+	width: min(560px, calc(100vw - 70px));
+	border-radius: 20px;
+	border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+	background: color-mix(in srgb, var(--bg-elev) 96%, transparent);
+	box-shadow: 0 14px 36px rgba(0, 0, 0, 0.16);
+	padding: 10px;
+	display: grid;
+	gap: 4px;
+	z-index: 5;
+}
+
+.welcome-project-item {
+	width: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	border: none;
+	background: transparent;
+	color: var(--text);
+	font-size: 33px;
+	line-height: 1.15;
+	padding: 10px 12px;
+	border-radius: 12px;
+	text-align: left;
+	cursor: pointer;
+}
+
+.welcome-project-item.current {
+	font-size: 33px;
+	cursor: default;
+}
+
+.welcome-project-item:hover {
+	background: color-mix(in srgb, var(--bg-soft) 74%, transparent);
+}
+
+.welcome-project-sep {
+	height: 1px;
+	background: color-mix(in srgb, var(--border) 84%, transparent);
+	margin: 3px 6px;
+}
+
 .welcome-actions {
 	display: flex;
 	flex-wrap: wrap;
@@ -6001,6 +6082,16 @@ body.sidebar-resizing {
 		font-size: 46px;
 	}
 
+	.welcome-project-trigger,
+	.welcome-project-item,
+	.welcome-project-item.current {
+		font-size: 42px;
+	}
+
+	.welcome-project-caret {
+		font-size: 28px;
+	}
+
 	.composer-controls {
 		flex-wrap: wrap;
 	}
@@ -6048,6 +6139,25 @@ body.sidebar-resizing {
 
 	.welcome-dashboard p {
 		font-size: 15px;
+	}
+
+	.welcome-project-wrap {
+		width: 100%;
+	}
+
+	.welcome-project-trigger,
+	.welcome-project-item,
+	.welcome-project-item.current {
+		font-size: 30px;
+	}
+
+	.welcome-project-caret {
+		font-size: 22px;
+		margin-top: 4px;
+	}
+
+	.welcome-project-menu {
+		width: calc(100vw - 38px);
 	}
 
 	.welcome-actions-centered {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4650,24 +4650,21 @@ body.sidebar-resizing {
 }
 
 .welcome-scroll {
-	padding: 24px 20px 40px;
-	display: flex;
-	align-items: center;
-	justify-content: center;
+	padding: 0 20px 40px;
+	display: block;
 	overflow-y: visible;
 }
 
 .welcome-dashboard {
 	width: min(520px, 100%);
-	margin: 0 auto;
+	margin: clamp(88px, 16vh, 170px) auto 0;
 	display: grid;
 	gap: 8px;
-	place-content: center;
 	text-align: center;
 }
 
 .welcome-dashboard-minimal {
-	min-height: min(520px, 100%);
+	min-height: 0;
 }
 
 .welcome-brand-lockup {
@@ -6142,12 +6139,13 @@ body.sidebar-resizing {
 	}
 
 	.welcome-scroll {
-		padding: 18px 14px 28px;
+		padding: 0 14px 28px;
 	}
 
 	.welcome-dashboard {
 		width: 100%;
 		min-height: 0;
+		margin-top: clamp(56px, 14vh, 120px);
 	}
 
 	.welcome-dashboard h2 {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4682,9 +4682,15 @@ body.sidebar-resizing {
 	border-radius: 16px;
 	display: grid;
 	place-items: center;
-	font-size: 28px;
 	border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
 	background: color-mix(in srgb, var(--bg-elev) 72%, transparent);
+	overflow: hidden;
+}
+
+.welcome-brand-mark img {
+	width: 34px;
+	height: 34px;
+	display: block;
 }
 
 .welcome-brand-name {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4704,9 +4704,9 @@ body.sidebar-resizing {
 
 .welcome-dashboard h2 {
 	margin: 6px 0 0;
-	font-size: 54px;
+	font-size: 42px;
 	line-height: 1;
-	letter-spacing: -0.04em;
+	letter-spacing: -0.03em;
 }
 
 .welcome-dashboard p {
@@ -4727,14 +4727,14 @@ body.sidebar-resizing {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	gap: 10px;
+	gap: 8px;
 	border: none;
 	background: transparent;
 	padding: 0;
-	font-size: 64px;
+	font-size: 44px;
 	line-height: 1;
 	letter-spacing: -0.03em;
-	color: color-mix(in srgb, var(--text) 48%, var(--bg));
+	color: color-mix(in srgb, var(--text) 56%, var(--bg));
 	cursor: pointer;
 }
 
@@ -4743,10 +4743,10 @@ body.sidebar-resizing {
 }
 
 .welcome-project-caret {
-	font-size: 36px;
+	font-size: 24px;
 	line-height: 1;
 	color: color-mix(in srgb, var(--text) 52%, var(--bg));
-	margin-top: 8px;
+	margin-top: 6px;
 }
 
 .welcome-project-menu {
@@ -4774,16 +4774,16 @@ body.sidebar-resizing {
 	border: none;
 	background: transparent;
 	color: var(--text);
-	font-size: 33px;
-	line-height: 1.15;
-	padding: 10px 12px;
+	font-size: 24px;
+	line-height: 1.2;
+	padding: 9px 12px;
 	border-radius: 12px;
 	text-align: left;
 	cursor: pointer;
 }
 
 .welcome-project-item.current {
-	font-size: 33px;
+	font-size: 24px;
 	cursor: default;
 }
 
@@ -6079,17 +6079,17 @@ body.sidebar-resizing {
 	}
 
 	.welcome-dashboard h2 {
-		font-size: 46px;
+		font-size: 38px;
 	}
 
 	.welcome-project-trigger,
 	.welcome-project-item,
 	.welcome-project-item.current {
-		font-size: 42px;
+		font-size: 34px;
 	}
 
 	.welcome-project-caret {
-		font-size: 28px;
+		font-size: 22px;
 	}
 
 	.composer-controls {
@@ -6134,7 +6134,7 @@ body.sidebar-resizing {
 	}
 
 	.welcome-dashboard h2 {
-		font-size: 38px;
+		font-size: 32px;
 	}
 
 	.welcome-dashboard p {
@@ -6148,7 +6148,7 @@ body.sidebar-resizing {
 	.welcome-project-trigger,
 	.welcome-project-item,
 	.welcome-project-item.current {
-		font-size: 30px;
+		font-size: 24px;
 	}
 
 	.welcome-project-caret {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4654,6 +4654,7 @@ body.sidebar-resizing {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	overflow-y: visible;
 }
 
 .welcome-dashboard {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4688,9 +4688,11 @@ body.sidebar-resizing {
 }
 
 .welcome-brand-mark img {
-	width: 34px;
-	height: 34px;
+	width: 100%;
+	height: 100%;
 	display: block;
+	object-fit: cover;
+	border-radius: inherit;
 }
 
 .welcome-brand-name {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4650,50 +4650,62 @@ body.sidebar-resizing {
 }
 
 .welcome-scroll {
-	padding: 44px 0 54px;
+	padding: 24px 20px 40px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .welcome-dashboard {
-	width: min(920px, calc(100% - 40px));
+	width: min(720px, 100%);
 	margin: 0 auto;
 	display: grid;
-	gap: 14px;
-}
-
-.welcome-hero {
-	border: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
-	background: color-mix(in srgb, var(--bg-elev) 64%, transparent);
-	border-radius: 18px;
-	padding: 22px;
-	display: grid;
 	gap: 10px;
+	place-content: center;
+	text-align: center;
 }
 
-.welcome-hero-codex {
-	gap: 12px;
+.welcome-dashboard-minimal {
+	min-height: min(620px, 100%);
 }
 
-.welcome-eyebrow {
-	font-size: 10px;
+.welcome-brand-lockup {
+	display: grid;
+	justify-items: center;
+	gap: 6px;
+	margin-bottom: 2px;
+}
+
+.welcome-brand-mark {
+	width: 56px;
+	height: 56px;
+	border-radius: 16px;
+	display: grid;
+	place-items: center;
+	font-size: 28px;
+	border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+	background: color-mix(in srgb, var(--bg-elev) 72%, transparent);
+}
+
+.welcome-brand-name {
+	font-size: 11px;
 	letter-spacing: 0.08em;
 	text-transform: uppercase;
 	color: var(--muted-2);
 }
 
-.welcome-hero h2 {
-	margin: 0;
-	font-size: 34px;
-	line-height: 1.04;
-	letter-spacing: -0.03em;
-	max-width: 620px;
+.welcome-dashboard h2 {
+	margin: 6px 0 0;
+	font-size: 54px;
+	line-height: 1;
+	letter-spacing: -0.04em;
 }
 
-.welcome-hero p {
+.welcome-dashboard p {
 	margin: 0;
 	color: var(--muted);
-	font-size: 14px;
-	line-height: 1.55;
-	max-width: 680px;
+	font-size: 18px;
+	line-height: 1.35;
 }
 
 .welcome-actions {
@@ -4702,71 +4714,19 @@ body.sidebar-resizing {
 	gap: 8px;
 }
 
-.welcome-quick-grid {
-	display: grid;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
-	gap: 10px;
-}
-
-.welcome-quick-action {
-	border-radius: 14px;
-	border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
-	background: color-mix(in srgb, var(--bg-soft) 62%, transparent);
-	padding: 11px 12px;
-	text-align: left;
-	display: grid;
-	gap: 5px;
-	cursor: pointer;
-	color: var(--text);
-}
-
-.welcome-quick-action:hover {
-	background: color-mix(in srgb, var(--bg-soft) 78%, transparent);
-}
-
-.welcome-quick-action.primary {
-	border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
-	background: color-mix(in srgb, var(--accent) 16%, var(--bg-soft));
-}
-
-.welcome-quick-title {
-	font-size: 13px;
-	font-weight: 620;
-}
-
-.welcome-quick-desc {
-	font-size: 11px;
-	color: var(--muted);
-	line-height: 1.35;
-}
-
-.welcome-inline-note {
-	font-size: 11px;
-	color: var(--muted-2);
-}
-
-.welcome-inline-note kbd {
-	display: inline-flex;
-	align-items: center;
-	height: 20px;
-	padding: 0 6px;
-	margin: 0 3px;
-	border-radius: 6px;
-	border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
-	background: color-mix(in srgb, var(--bg-soft) 66%, transparent);
-	font-size: 10px;
-	font-family: var(--font-family-mono);
-	color: var(--text);
+.welcome-actions-centered {
+	justify-content: center;
+	margin-top: 8px;
 }
 
 .welcome-action {
-	height: 32px;
-	padding: 0 12px;
+	height: 34px;
+	padding: 0 14px;
 	border-radius: 999px;
 	border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
-	background: color-mix(in srgb, var(--bg-soft) 72%, transparent);
+	background: color-mix(in srgb, var(--bg-soft) 70%, transparent);
 	color: var(--text);
-	font-size: 11px;
+	font-size: 12px;
 	cursor: pointer;
 }
 
@@ -4779,126 +4739,34 @@ body.sidebar-resizing {
 	border-color: color-mix(in srgb, var(--accent) 34%, var(--border));
 }
 
-.welcome-actions.compact {
-	margin-top: 2px;
-}
-
-.welcome-grid {
-	display: grid;
-	grid-template-columns: 1fr;
-	gap: 12px;
-}
-
-.welcome-grid.minimal {
-	grid-template-columns: 1fr;
-}
-
-.welcome-card {
-	border: 1px solid color-mix(in srgb, var(--border) 74%, transparent);
-	background: color-mix(in srgb, var(--bg-elev) 60%, transparent);
-	border-radius: 16px;
-	padding: 15px;
-	display: grid;
-	gap: 10px;
-}
-
-.welcome-status-card {
-	gap: 11px;
-}
-
-.welcome-status-head {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 8px;
-	flex-wrap: wrap;
-}
-
-.welcome-card.compact {
-	min-height: 0;
-}
-
-.welcome-card-title {
-	font-size: 11px;
-	letter-spacing: 0.05em;
-	text-transform: uppercase;
-	color: var(--muted-2);
-}
-
-.welcome-kpis {
-	display: grid;
-	grid-template-columns: repeat(3, minmax(0, 1fr));
-	gap: 8px;
-}
-
-.welcome-kpis.compact {
-	grid-template-columns: repeat(4, minmax(0, 1fr));
-}
-
-.welcome-kpis div {
-	border-radius: 10px;
-	border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-	background: color-mix(in srgb, var(--bg-soft) 60%, transparent);
-	padding: 8px;
-	display: grid;
-	gap: 2px;
-}
-
-.welcome-kpis span {
-	font-size: 10px;
-	color: var(--muted-2);
-}
-
-.welcome-kpis strong {
-	font-size: 15px;
-	font-weight: 620;
-}
-
-.welcome-chip-list {
-	display: flex;
-	flex-wrap: wrap;
-	gap: 6px;
-}
-
-.welcome-chip {
-	height: 24px;
-	padding: 0 9px;
-	border-radius: 999px;
-	border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-	background: color-mix(in srgb, var(--bg-soft) 60%, transparent);
-	display: inline-flex;
-	align-items: center;
-	font-size: 10px;
+.welcome-meta-line {
+	font-size: 12px;
 	color: var(--text);
 }
 
-.welcome-runtime-grid {
-	display: grid;
-	grid-template-columns: repeat(2, minmax(0, 1fr));
-	gap: 8px;
-}
-
-.welcome-runtime-row {
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	gap: 10px;
-	font-size: 11px;
-	padding: 0;
-}
-
-.welcome-runtime-row span {
+.welcome-meta-line.muted {
 	color: var(--muted-2);
 }
 
-.welcome-runtime-row strong {
-	font-size: 11px;
-	font-weight: 560;
-	text-align: right;
+.welcome-link-row {
+	display: flex;
+	justify-content: center;
+	gap: 10px;
 }
 
-.welcome-card-note,
-.welcome-empty,
+.welcome-link-btn {
+	border: none;
+	background: transparent;
+	padding: 0;
+	font-size: 11px;
+	color: var(--muted);
+	cursor: pointer;
+}
+
+.welcome-link-btn:hover {
+	color: var(--text);
+}
+
 .welcome-updated,
 .welcome-error {
 	font-size: 11px;
@@ -6121,20 +5989,8 @@ body.sidebar-resizing {
 		font-size: 28px;
 	}
 
-	.welcome-grid {
-		grid-template-columns: 1fr;
-	}
-
-	.welcome-quick-grid {
-		grid-template-columns: 1fr;
-	}
-
-	.welcome-runtime-grid {
-		grid-template-columns: 1fr;
-	}
-
-	.welcome-kpis.compact {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
+	.welcome-dashboard h2 {
+		font-size: 46px;
 	}
 
 	.composer-controls {
@@ -6169,20 +6025,25 @@ body.sidebar-resizing {
 		font-size: 24px;
 	}
 
-	.welcome-grid {
-		grid-template-columns: 1fr;
+	.welcome-scroll {
+		padding: 18px 14px 28px;
 	}
 
 	.welcome-dashboard {
-		width: calc(100% - 20px);
+		width: 100%;
+		min-height: 0;
 	}
 
-	.welcome-hero h2 {
-		font-size: 24px;
+	.welcome-dashboard h2 {
+		font-size: 38px;
 	}
 
-	.welcome-kpis.compact {
-		grid-template-columns: 1fr 1fr;
+	.welcome-dashboard p {
+		font-size: 15px;
+	}
+
+	.welcome-actions-centered {
+		justify-content: center;
 	}
 
 	.composer-shell {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4747,6 +4747,13 @@ body.sidebar-resizing {
 	line-height: 1;
 	color: color-mix(in srgb, var(--text) 52%, var(--bg));
 	margin-top: 1px;
+	display: inline-block;
+	transform-origin: center;
+	transition: transform 120ms ease;
+}
+
+.welcome-project-caret.open {
+	transform: rotate(180deg);
 }
 
 .welcome-project-menu {
@@ -4838,7 +4845,9 @@ body.sidebar-resizing {
 }
 
 .welcome-meta-line.hidden {
-	display: none;
+	opacity: 0;
+	visibility: hidden;
+	pointer-events: none;
 }
 
 .welcome-link-row {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4657,7 +4657,7 @@ body.sidebar-resizing {
 }
 
 .welcome-dashboard {
-	width: min(560px, 100%);
+	width: min(520px, 100%);
 	margin: 0 auto;
 	display: grid;
 	gap: 8px;
@@ -4666,7 +4666,7 @@ body.sidebar-resizing {
 }
 
 .welcome-dashboard-minimal {
-	min-height: min(560px, 100%);
+	min-height: min(520px, 100%);
 }
 
 .welcome-brand-lockup {
@@ -4677,9 +4677,9 @@ body.sidebar-resizing {
 }
 
 .welcome-brand-mark {
-	width: 46px;
-	height: 46px;
-	border-radius: 14px;
+	width: 42px;
+	height: 42px;
+	border-radius: 12px;
 	display: grid;
 	place-items: center;
 	border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
@@ -4719,7 +4719,7 @@ body.sidebar-resizing {
 .welcome-project-wrap {
 	position: relative;
 	justify-self: center;
-	width: min(360px, 100%);
+	width: min(320px, 100%);
 }
 
 .welcome-project-trigger {
@@ -4731,7 +4731,7 @@ body.sidebar-resizing {
 	border: none;
 	background: transparent;
 	padding: 0;
-	font-size: 22px;
+	font-size: 20px;
 	line-height: 1;
 	letter-spacing: -0.02em;
 	color: color-mix(in srgb, var(--text) 56%, var(--bg));
@@ -4754,7 +4754,7 @@ body.sidebar-resizing {
 	left: 50%;
 	transform: translateX(-50%);
 	top: calc(100% + 8px);
-	width: min(360px, calc(100vw - 56px));
+	width: min(320px, calc(100vw - 56px));
 	border-radius: 14px;
 	border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
 	background: color-mix(in srgb, var(--bg-elev) 96%, transparent);
@@ -4774,7 +4774,7 @@ body.sidebar-resizing {
 	border: none;
 	background: transparent;
 	color: var(--text);
-	font-size: 13px;
+	font-size: 12px;
 	line-height: 1.3;
 	padding: 7px 8px;
 	border-radius: 9px;
@@ -4783,7 +4783,7 @@ body.sidebar-resizing {
 }
 
 .welcome-project-item.current {
-	font-size: 13px;
+	font-size: 12px;
 	cursor: default;
 }
 
@@ -4835,6 +4835,10 @@ body.sidebar-resizing {
 
 .welcome-meta-line.muted {
 	color: var(--muted-2);
+}
+
+.welcome-meta-line.hidden {
+	display: none;
 }
 
 .welcome-link-row {
@@ -6088,7 +6092,7 @@ body.sidebar-resizing {
 
 	.welcome-project-item,
 	.welcome-project-item.current {
-		font-size: 13px;
+		font-size: 12px;
 	}
 
 	.welcome-project-caret {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4657,16 +4657,16 @@ body.sidebar-resizing {
 }
 
 .welcome-dashboard {
-	width: min(720px, 100%);
+	width: min(560px, 100%);
 	margin: 0 auto;
 	display: grid;
-	gap: 10px;
+	gap: 8px;
 	place-content: center;
 	text-align: center;
 }
 
 .welcome-dashboard-minimal {
-	min-height: min(620px, 100%);
+	min-height: min(560px, 100%);
 }
 
 .welcome-brand-lockup {
@@ -4677,9 +4677,9 @@ body.sidebar-resizing {
 }
 
 .welcome-brand-mark {
-	width: 56px;
-	height: 56px;
-	border-radius: 16px;
+	width: 46px;
+	height: 46px;
+	border-radius: 14px;
 	display: grid;
 	place-items: center;
 	border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
@@ -4703,10 +4703,10 @@ body.sidebar-resizing {
 }
 
 .welcome-dashboard h2 {
-	margin: 6px 0 0;
-	font-size: 42px;
+	margin: 4px 0 0;
+	font-size: 32px;
 	line-height: 1;
-	letter-spacing: -0.03em;
+	letter-spacing: -0.02em;
 }
 
 .welcome-dashboard p {
@@ -4719,7 +4719,7 @@ body.sidebar-resizing {
 .welcome-project-wrap {
 	position: relative;
 	justify-self: center;
-	width: min(430px, 100%);
+	width: min(360px, 100%);
 }
 
 .welcome-project-trigger {
@@ -4727,13 +4727,13 @@ body.sidebar-resizing {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	gap: 7px;
+	gap: 5px;
 	border: none;
 	background: transparent;
 	padding: 0;
-	font-size: 30px;
+	font-size: 22px;
 	line-height: 1;
-	letter-spacing: -0.025em;
+	letter-spacing: -0.02em;
 	color: color-mix(in srgb, var(--text) 56%, var(--bg));
 	cursor: pointer;
 }
@@ -4743,25 +4743,25 @@ body.sidebar-resizing {
 }
 
 .welcome-project-caret {
-	font-size: 18px;
+	font-size: 14px;
 	line-height: 1;
 	color: color-mix(in srgb, var(--text) 52%, var(--bg));
-	margin-top: 3px;
+	margin-top: 1px;
 }
 
 .welcome-project-menu {
 	position: absolute;
 	left: 50%;
 	transform: translateX(-50%);
-	top: calc(100% + 10px);
-	width: min(430px, calc(100vw - 70px));
-	border-radius: 16px;
+	top: calc(100% + 8px);
+	width: min(360px, calc(100vw - 56px));
+	border-radius: 14px;
 	border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
 	background: color-mix(in srgb, var(--bg-elev) 96%, transparent);
-	box-shadow: 0 10px 24px rgba(0, 0, 0, 0.14);
-	padding: 8px;
+	box-shadow: 0 8px 18px rgba(0, 0, 0, 0.12);
+	padding: 6px;
 	display: grid;
-	gap: 3px;
+	gap: 2px;
 	z-index: 5;
 }
 
@@ -4774,16 +4774,16 @@ body.sidebar-resizing {
 	border: none;
 	background: transparent;
 	color: var(--text);
-	font-size: 15px;
+	font-size: 13px;
 	line-height: 1.3;
-	padding: 8px 10px;
-	border-radius: 10px;
+	padding: 7px 8px;
+	border-radius: 9px;
 	text-align: left;
 	cursor: pointer;
 }
 
 .welcome-project-item.current {
-	font-size: 15px;
+	font-size: 13px;
 	cursor: default;
 }
 
@@ -6079,20 +6079,20 @@ body.sidebar-resizing {
 	}
 
 	.welcome-dashboard h2 {
-		font-size: 38px;
+		font-size: 30px;
 	}
 
 	.welcome-project-trigger {
-		font-size: 28px;
+		font-size: 20px;
 	}
 
 	.welcome-project-item,
 	.welcome-project-item.current {
-		font-size: 15px;
+		font-size: 13px;
 	}
 
 	.welcome-project-caret {
-		font-size: 18px;
+		font-size: 13px;
 	}
 
 	.composer-controls {
@@ -6137,11 +6137,11 @@ body.sidebar-resizing {
 	}
 
 	.welcome-dashboard h2 {
-		font-size: 32px;
+		font-size: 28px;
 	}
 
 	.welcome-dashboard p {
-		font-size: 15px;
+		font-size: 14px;
 	}
 
 	.welcome-project-wrap {
@@ -6149,21 +6149,21 @@ body.sidebar-resizing {
 	}
 
 	.welcome-project-trigger {
-		font-size: 24px;
+		font-size: 18px;
 	}
 
 	.welcome-project-item,
 	.welcome-project-item.current {
-		font-size: 14px;
+		font-size: 12px;
 	}
 
 	.welcome-project-caret {
-		font-size: 16px;
-		margin-top: 2px;
+		font-size: 12px;
+		margin-top: 1px;
 	}
 
 	.welcome-project-menu {
-		width: calc(100vw - 38px);
+		width: calc(100vw - 32px);
 	}
 
 	.welcome-actions-centered {

--- a/src/theme/bundled-themes.ts
+++ b/src/theme/bundled-themes.ts
@@ -1,3 +1,5 @@
+import { buildPiThemeDocument, isThemeDocumentSchemaCompatible } from "./pi-theme-document.js";
+
 interface BundledThemeSpec {
 	fileName: string;
 	legacyFileName?: string;
@@ -146,48 +148,29 @@ function joinFsPath(base: string, child: string): string {
 	return b ? `${b}/${c}` : c;
 }
 
-function toPiThemeDocument(spec: BundledThemeSpec): Record<string, unknown> {
-	return {
+function toPiThemeDocument(spec: BundledThemeSpec) {
+	return buildPiThemeDocument({
 		name: spec.name,
-		vars: {
-			accent: spec.accent,
-			surface: spec.surface,
-			ink: spec.ink,
-			diffAdded: spec.diffAdded,
-			diffRemoved: spec.diffRemoved,
-			skill: spec.skill,
-		},
-		colors: {
-			accent: "accent",
-			text: "ink",
-			muted: "ink",
-			dim: "ink",
-			selectedBg: "surface",
-			userMessageBg: "surface",
-			userMessageText: "ink",
-			customMessageBg: "surface",
-			customMessageText: "ink",
-			toolPendingBg: "surface",
-			toolSuccessBg: "surface",
-			toolErrorBg: "surface",
-			toolTitle: "skill",
-			toolOutput: "ink",
-			diffAdded: "diffAdded",
-			diffRemoved: "diffRemoved",
-		},
-		piDesktop: {
-			source: "pi-desktop-theme-v1",
-			variant: spec.variant,
-			contrast: spec.contrast,
-			codeThemeId: spec.codeThemeId,
-		},
-	};
+		variant: spec.variant,
+		accent: spec.accent,
+		surface: spec.surface,
+		ink: spec.ink,
+		skill: spec.skill,
+		diffAdded: spec.diffAdded,
+		diffRemoved: spec.diffRemoved,
+		success: spec.diffAdded,
+		error: spec.diffRemoved,
+		contrast: spec.contrast,
+		codeThemeId: spec.codeThemeId,
+		source: "pi-desktop-theme-v1",
+	});
 }
 
 const BUNDLED_THEMES_MARKER = ".pi-desktop-default-themes-installed-v1";
 
 export interface BundledThemeInstallResult {
 	created: number;
+	updated: number;
 	renamed: number;
 	removedLegacy: number;
 	skippedByMarker: boolean;
@@ -212,18 +195,55 @@ async function resolveThemesRoot(): Promise<string | null> {
 	return joinFsPath(joinFsPath(joinFsPath(home, ".pi"), "agent"), "themes");
 }
 
+async function readJsonFile(path: string, readTextFile: (path: string) => Promise<string>): Promise<unknown | null> {
+	try {
+		const content = await readTextFile(path);
+		return JSON.parse(content) as unknown;
+	} catch {
+		return null;
+	}
+}
+
+async function hasBundledThemeRepairCandidate(
+	themesRoot: string,
+	exists: (path: string) => Promise<boolean>,
+	readTextFile: (path: string) => Promise<string>,
+): Promise<boolean> {
+	for (const spec of BUNDLED_THEME_SPECS) {
+		const targetPath = joinFsPath(themesRoot, spec.fileName);
+		const legacyPath = spec.legacyFileName ? joinFsPath(themesRoot, spec.legacyFileName) : null;
+
+		if (legacyPath && !(await exists(targetPath)) && (await exists(legacyPath))) {
+			return true;
+		}
+
+		if (await exists(targetPath)) {
+			const doc = await readJsonFile(targetPath, readTextFile);
+			if (!isThemeDocumentSchemaCompatible(doc)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
 async function installBundledThemes(options: { respectMarker: boolean }): Promise<BundledThemeInstallResult> {
-	const { exists, mkdir, writeTextFile, rename, remove } = await import("@tauri-apps/plugin-fs");
+	const { exists, mkdir, writeTextFile, readTextFile, rename, remove } = await import("@tauri-apps/plugin-fs");
 	const themesRoot = await resolveThemesRoot();
-	if (!themesRoot) return { created: 0, renamed: 0, removedLegacy: 0, skippedByMarker: true };
+	if (!themesRoot) return { created: 0, updated: 0, renamed: 0, removedLegacy: 0, skippedByMarker: true };
 	await mkdir(themesRoot, { recursive: true });
 
 	const markerPath = joinFsPath(themesRoot, BUNDLED_THEMES_MARKER);
 	if (options.respectMarker && (await exists(markerPath))) {
-		return { created: 0, renamed: 0, removedLegacy: 0, skippedByMarker: true };
+		const hasRepairCandidate = await hasBundledThemeRepairCandidate(themesRoot, exists, readTextFile);
+		if (!hasRepairCandidate) {
+			return { created: 0, updated: 0, renamed: 0, removedLegacy: 0, skippedByMarker: true };
+		}
 	}
 
 	let created = 0;
+	let updated = 0;
 	let renamed = 0;
 	let removedLegacy = 0;
 
@@ -244,6 +264,13 @@ async function installBundledThemes(options: { respectMarker: boolean }): Promis
 			const doc = toPiThemeDocument(spec);
 			await writeTextFile(targetPath, `${JSON.stringify(doc, null, 2)}\n`);
 			created += 1;
+		} else {
+			const existingDoc = await readJsonFile(targetPath, readTextFile);
+			if (!isThemeDocumentSchemaCompatible(existingDoc)) {
+				const doc = toPiThemeDocument(spec);
+				await writeTextFile(targetPath, `${JSON.stringify(doc, null, 2)}\n`);
+				updated += 1;
+			}
 		}
 
 		if (legacyPath && legacyPath !== targetPath && (await exists(legacyPath))) {
@@ -257,7 +284,7 @@ async function installBundledThemes(options: { respectMarker: boolean }): Promis
 	}
 
 	await writeTextFile(markerPath, `${new Date().toISOString()}\n`);
-	return { created, renamed, removedLegacy, skippedByMarker: false };
+	return { created, updated, renamed, removedLegacy, skippedByMarker: false };
 }
 
 export async function ensureBundledThemesInstalled(): Promise<void> {

--- a/src/theme/pi-theme-document.ts
+++ b/src/theme/pi-theme-document.ts
@@ -1,0 +1,305 @@
+export const PI_THEME_SCHEMA_URL =
+	"https://raw.githubusercontent.com/badlogic/pi-mono/main/packages/coding-agent/src/modes/interactive/theme/theme-schema.json";
+
+export const PI_THEME_REQUIRED_COLOR_TOKENS = [
+	"accent",
+	"border",
+	"borderAccent",
+	"borderMuted",
+	"success",
+	"error",
+	"warning",
+	"muted",
+	"dim",
+	"text",
+	"thinkingText",
+	"selectedBg",
+	"userMessageBg",
+	"userMessageText",
+	"customMessageBg",
+	"customMessageText",
+	"customMessageLabel",
+	"toolPendingBg",
+	"toolSuccessBg",
+	"toolErrorBg",
+	"toolTitle",
+	"toolOutput",
+	"mdHeading",
+	"mdLink",
+	"mdLinkUrl",
+	"mdCode",
+	"mdCodeBlock",
+	"mdCodeBlockBorder",
+	"mdQuote",
+	"mdQuoteBorder",
+	"mdHr",
+	"mdListBullet",
+	"toolDiffAdded",
+	"toolDiffRemoved",
+	"toolDiffContext",
+	"syntaxComment",
+	"syntaxKeyword",
+	"syntaxFunction",
+	"syntaxVariable",
+	"syntaxString",
+	"syntaxNumber",
+	"syntaxType",
+	"syntaxOperator",
+	"syntaxPunctuation",
+	"thinkingOff",
+	"thinkingMinimal",
+	"thinkingLow",
+	"thinkingMedium",
+	"thinkingHigh",
+	"thinkingXhigh",
+	"bashMode",
+] as const;
+
+type PiThemeVariant = "dark" | "light";
+
+interface BuildPiThemeDocumentOptions {
+	name: string;
+	variant: PiThemeVariant;
+	accent: string;
+	surface: string;
+	ink: string;
+	skill?: string;
+	diffAdded?: string;
+	diffRemoved?: string;
+	success?: string;
+	error?: string;
+	warning?: string;
+	contrast?: number;
+	codeThemeId?: string;
+	fonts?: {
+		ui: string | null;
+		code: string | null;
+	};
+	opaqueWindows?: boolean;
+	source?: string;
+}
+
+interface PiThemeDocument {
+	$schema: string;
+	name: string;
+	vars: Record<string, string | number>;
+	colors: Record<(typeof PI_THEME_REQUIRED_COLOR_TOKENS)[number], string | number>;
+	piDesktop: Record<string, unknown>;
+}
+
+function variantDefaults(variant: PiThemeVariant): {
+	muted: string;
+	dim: string;
+	borderMuted: string;
+	success: string;
+	error: string;
+	warning: string;
+	syntaxComment: string;
+	syntaxKeyword: string;
+	syntaxFunction: string;
+	syntaxVariable: string;
+	syntaxString: string;
+	syntaxNumber: string;
+	syntaxType: string;
+	syntaxOperator: string;
+	syntaxPunctuation: string;
+	thinkingOff: string;
+	thinkingMinimal: string;
+	thinkingLow: string;
+	thinkingMedium: string;
+	thinkingHigh: string;
+	thinkingXhigh: string;
+} {
+	if (variant === "light") {
+		return {
+			muted: "#6c6c6c",
+			dim: "#767676",
+			borderMuted: "#b0b0b0",
+			success: "#008000",
+			error: "#a31515",
+			warning: "#9a7326",
+			syntaxComment: "#008000",
+			syntaxKeyword: "#0000FF",
+			syntaxFunction: "#795E26",
+			syntaxVariable: "#001080",
+			syntaxString: "#A31515",
+			syntaxNumber: "#098658",
+			syntaxType: "#267F99",
+			syntaxOperator: "#000000",
+			syntaxPunctuation: "#000000",
+			thinkingOff: "#b0b0b0",
+			thinkingMinimal: "#767676",
+			thinkingLow: "#547da7",
+			thinkingMedium: "#5a8080",
+			thinkingHigh: "#875f87",
+			thinkingXhigh: "#8b008b",
+		};
+	}
+
+	return {
+		muted: "#808080",
+		dim: "#666666",
+		borderMuted: "#505050",
+		success: "#4ec9b0",
+		error: "#fa423e",
+		warning: "#f0c674",
+		syntaxComment: "#6A9955",
+		syntaxKeyword: "#569CD6",
+		syntaxFunction: "#DCDCAA",
+		syntaxVariable: "#9CDCFE",
+		syntaxString: "#CE9178",
+		syntaxNumber: "#B5CEA8",
+		syntaxType: "#4EC9B0",
+		syntaxOperator: "#D4D4D4",
+		syntaxPunctuation: "#D4D4D4",
+		thinkingOff: "#505050",
+		thinkingMinimal: "#6e6e6e",
+		thinkingLow: "#5f87af",
+		thinkingMedium: "#81a2be",
+		thinkingHigh: "#b294bb",
+		thinkingXhigh: "#d183e8",
+	};
+}
+
+export function buildPiThemeDocument(options: BuildPiThemeDocumentOptions): PiThemeDocument {
+	const defaults = variantDefaults(options.variant);
+	const skill = options.skill ?? options.accent;
+	const success = options.success ?? options.diffAdded ?? defaults.success;
+	const error = options.error ?? options.diffRemoved ?? defaults.error;
+	const warning = options.warning ?? defaults.warning;
+	const diffAdded = options.diffAdded ?? success;
+	const diffRemoved = options.diffRemoved ?? error;
+	const muted = defaults.muted;
+	const dim = defaults.dim;
+	const borderMuted = defaults.borderMuted;
+
+	const vars: Record<string, string | number> = {
+		accent: options.accent,
+		surface: options.surface,
+		ink: options.ink,
+		skill,
+		success,
+		error,
+		warning,
+		muted,
+		dim,
+		border: options.accent,
+		borderAccent: options.accent,
+		borderMuted,
+		thinkingText: muted,
+		mdHeading: warning,
+		mdLink: options.accent,
+		mdLinkUrl: muted,
+		mdCode: options.accent,
+		mdCodeBlock: success,
+		mdCodeBlockBorder: muted,
+		mdQuote: muted,
+		mdQuoteBorder: muted,
+		mdHr: muted,
+		mdListBullet: options.accent,
+		toolDiffAdded: diffAdded,
+		toolDiffRemoved: diffRemoved,
+		toolDiffContext: muted,
+		syntaxComment: defaults.syntaxComment,
+		syntaxKeyword: defaults.syntaxKeyword,
+		syntaxFunction: defaults.syntaxFunction,
+		syntaxVariable: defaults.syntaxVariable,
+		syntaxString: defaults.syntaxString,
+		syntaxNumber: defaults.syntaxNumber,
+		syntaxType: defaults.syntaxType,
+		syntaxOperator: defaults.syntaxOperator,
+		syntaxPunctuation: defaults.syntaxPunctuation,
+		thinkingOff: defaults.thinkingOff,
+		thinkingMinimal: defaults.thinkingMinimal,
+		thinkingLow: defaults.thinkingLow,
+		thinkingMedium: defaults.thinkingMedium,
+		thinkingHigh: defaults.thinkingHigh,
+		thinkingXhigh: defaults.thinkingXhigh,
+		bashMode: success,
+	};
+
+	return {
+		$schema: PI_THEME_SCHEMA_URL,
+		name: options.name,
+		vars,
+		colors: {
+			accent: "accent",
+			border: "border",
+			borderAccent: "borderAccent",
+			borderMuted: "borderMuted",
+			success: "success",
+			error: "error",
+			warning: "warning",
+			muted: "muted",
+			dim: "dim",
+			text: "ink",
+			thinkingText: "thinkingText",
+			selectedBg: "surface",
+			userMessageBg: "surface",
+			userMessageText: "ink",
+			customMessageBg: "surface",
+			customMessageText: "ink",
+			customMessageLabel: "skill",
+			toolPendingBg: "surface",
+			toolSuccessBg: "surface",
+			toolErrorBg: "surface",
+			toolTitle: "skill",
+			toolOutput: "ink",
+			mdHeading: "mdHeading",
+			mdLink: "mdLink",
+			mdLinkUrl: "mdLinkUrl",
+			mdCode: "mdCode",
+			mdCodeBlock: "mdCodeBlock",
+			mdCodeBlockBorder: "mdCodeBlockBorder",
+			mdQuote: "mdQuote",
+			mdQuoteBorder: "mdQuoteBorder",
+			mdHr: "mdHr",
+			mdListBullet: "mdListBullet",
+			toolDiffAdded: "toolDiffAdded",
+			toolDiffRemoved: "toolDiffRemoved",
+			toolDiffContext: "toolDiffContext",
+			syntaxComment: "syntaxComment",
+			syntaxKeyword: "syntaxKeyword",
+			syntaxFunction: "syntaxFunction",
+			syntaxVariable: "syntaxVariable",
+			syntaxString: "syntaxString",
+			syntaxNumber: "syntaxNumber",
+			syntaxType: "syntaxType",
+			syntaxOperator: "syntaxOperator",
+			syntaxPunctuation: "syntaxPunctuation",
+			thinkingOff: "thinkingOff",
+			thinkingMinimal: "thinkingMinimal",
+			thinkingLow: "thinkingLow",
+			thinkingMedium: "thinkingMedium",
+			thinkingHigh: "thinkingHigh",
+			thinkingXhigh: "thinkingXhigh",
+			bashMode: "bashMode",
+		},
+		piDesktop: {
+			source: options.source ?? "pi-desktop-theme-v1",
+			variant: options.variant,
+			contrast: options.contrast,
+			codeThemeId: options.codeThemeId,
+			fonts: options.fonts,
+			opaqueWindows: options.opaqueWindows,
+		},
+	};
+}
+
+export function isThemeDocumentSchemaCompatible(input: unknown): boolean {
+	if (!input || typeof input !== "object" || Array.isArray(input)) return false;
+	const doc = input as Record<string, unknown>;
+	if (typeof doc.name !== "string" || doc.name.trim().length === 0) return false;
+	const colors = doc.colors;
+	if (!colors || typeof colors !== "object" || Array.isArray(colors)) return false;
+	const colorMap = colors as Record<string, unknown>;
+
+	for (const token of PI_THEME_REQUIRED_COLOR_TOKENS) {
+		const value = colorMap[token];
+		if (typeof value === "string") continue;
+		if (typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 255) continue;
+		return false;
+	}
+
+	return true;
+}


### PR DESCRIPTION
## Summary

This PR combines three related reliability/UX tracks completed on `feat/66-theme-schema-cli-compat`:

1) **Theme schema compatibility (Desktop + CLI)**
- Bundled Pi Desktop themes now emit full Pi CLI-compatible theme schema documents.
- Added bundled-theme repair flow for legacy invalid `~/.pi/agent/themes/pi-desktop-*.json` files.
- Settings "Create theme" now exports full schema-compatible JSON.

2) **Settings pane stability hardening (#69)**
- Hardened settings mount/open lifecycle against pane-switch races and stale renders.
- Added container rebinding + recovery guards for shell re-render transitions.
- Decoupled no-project settings from runtime-dependent sections.
- Added safe-shell fallback when advanced runtime sections fail to render.

3) **No-project/new-thread welcome redesign (refs #63)**
- Rebuilt welcome into a clean centered, project-focused flow with Pi branding.
- Added dropdown-based project focus with direct workspace project switching.
- Reduced visual noise (removed heavy card stack) and tuned responsive scale.
- Fixed dropdown open jitter/jump.

## Key files

- `src/theme/pi-theme-document.ts`
- `src/theme/bundled-themes.ts`
- `src/components/settings-panel.ts`
- `src/main.ts`
- `src/components/chat-view.ts`
- `src/components/sidebar.ts`
- `src/styles/app.css`
- `docs/THEMES_DESKTOP_MAPPING.md`
- `docs/ISSUE_IMPLEMENTATION_LOG_2026-03-31.md`
- `CHANGELOG.md`
- `TODO.md`

## Validation

- `npm run check` ✅
- Manual verification performed during iteration:
  - no-project settings open path
  - project/new-session settings open path
  - centered welcome dropdown interactions
  - multi-project switching from centered dropdown
  - dropdown jitter regression check

## Issue links

- Closes #69
- Refs #63
