### PR TITLE
feat(chat): codex-style workflow timeline + streaming/codeblock stability sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Reworked the no-project / new-thread welcome view into a cleaner Codex-inspired centered layout with Pi Desktop branding, a project-focused dropdown, and reduced UI chrome.
 - Welcome project dropdown now lists all projects in the current workspace and supports direct project switching (plus quick actions for add project, packages, and settings).
 - Welcome heading copy now rotates between Pi-style idle phrases for a calmer ambient experience.
+- Reworked assistant tool-heavy runs into a compact workflow timeline with centered duration summary, grouped repeated tool calls, and progressive disclosure for details.
+- Workflow detail timeline now preserves natural interleaving of thinking and tool entries (including mid-run thinking blocks), instead of forcing thinking to the top.
+- Running-state affordances now use synchronized Pi/text animation cadence, including inline Pi indicators on active workflow rows and toned-down bottom-status typography.
+- Polished markdown code blocks toward a cleaner Codex-like appearance (single surface, tightened header/content spacing, smaller copy affordance, less chrome).
 
 ### Fixed
 - Bundled default Pi Desktop themes now emit full Pi CLI-compatible theme schema (all required color tokens) instead of a partial Desktop-only color set.
@@ -19,6 +23,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Settings now degrade to a safe basic shell when runtime-dependent sections fail to render, instead of showing a blank pane.
 - No-project Settings flow is now runtime-decoupled, so Appearance settings remain available even before RPC runtime is connected.
 - Removed centered welcome dropdown jitter by stabilizing open/close layout behavior and avoiding no-project auto-scroll on re-render.
+- Prevented active workflow dropdowns from auto-reopening after user-initiated manual collapse during ongoing tool runs.
+- Removed transient blank spacing before workflow materialization by avoiding empty assistant placeholder rows during stream startup.
+- Fixed repeated streamed thinking duplication by tightening partial-update merge/dedupe behavior in workflow rendering.
+- Assistant message-level copy action is now suppressed for messages that are only a single fenced code block (copy remains on the code block itself).
 
 ## [0.1.8] - 2026-03-23
 

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,12 @@ Branch: `feat/chat-interface-issue-sweep` (based on `origin/dev`)
 
 Scope (deduped): **#49, #50, #52, #53, #54, #55, #63, #70, #72**
 
+Latest session recap (chat sweep):
+- [x] Workflow dropdown state stabilized (manual collapse override respected during active runs).
+- [x] Thinking/tool timeline ordering and streaming dedupe hardened.
+- [x] Code-block UX polished and assistant-level duplicate copy action removed for pure fenced-block replies.
+- [ ] Remaining: slash action audit/cleanup (#70) and final PR packaging/issue closure notes.
+
 ### A) Markdown/code rendering integrity + readability
 Issues: #49, #50, #54
 
@@ -33,7 +39,7 @@ Issues: #52, #55, #72
 - [x] #55 Use a single collapsible compaction status element per cycle.
   - [x] State transitions in-place (`running -> done -> error`) with no duplicate blocks.
 - [x] #72 Investigate/fix weird tool result rows after steer message.
-  - [ ] Reproduce from screenshot scenario.
+  - [x] Reproduce from screenshot scenario.
   - [x] Add guard/normalization for post-steer tool event/result mapping.
 
 Acceptance gate:

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,85 @@
 # TODO — V1/V1.1 release cleanup plan
 
+## Chat interface sweep plan (new branch)
+
+Branch: `feat/chat-interface-issue-sweep` (based on `origin/dev`)
+
+Scope (deduped): **#49, #50, #52, #53, #54, #55, #63, #70, #72**
+
+### A) Markdown/code rendering integrity + readability
+Issues: #49, #50, #54
+
+- [ ] #49 Ensure fenced code blocks always render in chat and file markdown contexts.
+  - [ ] Verify `CodeBlock` component registration/import in all markdown hosts.
+  - [ ] Add regression check for language-tagged and plain fenced blocks.
+- [ ] #50 Make code-block copy actions hover/focus-only (keyboard accessible).
+  - [ ] No layout jump when action appears.
+  - [ ] Keep inline code behavior unchanged.
+- [ ] #54 Remove chat-level horizontal overflow for normal text flow.
+  - [ ] Add robust wrapping (`overflow-wrap`) for long tokens/pasted formatted text.
+  - [ ] Preserve horizontal scroll only inside code blocks.
+
+Acceptance gate:
+- [ ] No missing code blocks
+- [ ] No chat-level horizontal scrollbar for normal messages
+- [ ] Copy action UX matches hover/focus behavior
+
+### B) Chat canvas tool/compaction noise reduction
+Issues: #52, #55, #72
+
+- [ ] #52 Compact tool rows by default with meaningful action preview text.
+  - [ ] Progressive disclosure for full details.
+  - [ ] Group repeated consecutive same-tool runs (`tool × N`).
+- [ ] #55 Use a single collapsible compaction status element per cycle.
+  - [ ] State transitions in-place (`running -> done -> error`) with no duplicate blocks.
+- [ ] #72 Investigate/fix weird tool result rows after steer message.
+  - [ ] Reproduce from screenshot scenario.
+  - [ ] Add guard/normalization for post-steer tool event/result mapping.
+
+Acceptance gate:
+- [ ] Assistant text remains dominant in tool-heavy runs
+- [ ] No duplicate compaction/tool status boxes
+- [ ] Steer flow no longer produces malformed tool entries
+
+### C) Composer/scroll/actions behavior
+Issues: #53, #70
+
+- [ ] #53 Dynamic composer offset so latest content is always visible.
+  - [ ] Measure composer with `ResizeObserver`.
+  - [ ] Drive chat bottom padding and jump-to-latest offset via CSS variable.
+- [ ] #70 Audit slash actions (`/`) and keep only meaningful chat-surface actions.
+  - [ ] Verify `/compact` and other supported actions are functional.
+  - [ ] Remove/disable slash actions already covered by better UX entrypoints.
+
+Acceptance gate:
+- [ ] Bottom-most assistant content never hidden by tall composer
+- [ ] Slash action list is reliable and intentionally curated
+
+### D) Roadmap alignment / parity integration
+Issue: #63 (umbrella)
+
+- [ ] Keep #63 open as umbrella and close sub-issues via implementation PRs.
+- [ ] Track completed slices in issue comments + changelog after each merge.
+- [ ] Ensure clean-room parity guardrails remain documented in PR descriptions.
+
+### Execution order (recommended PR slicing)
+
+- [ ] PR-1: Rendering integrity baseline (#49, #54)
+- [ ] PR-2: Code block UX polish (#50)
+- [ ] PR-3: Composer offset + scroll correctness (#53)
+- [ ] PR-4: Tool/compaction timeline cleanup (#52, #55, #72)
+- [ ] PR-5: Slash action audit/cleanup (#70)
+- [ ] PR-6: #63 rollout summary + visual QA pass
+
+### Test matrix (must pass before closing issues)
+
+- [ ] Long markdown/code responses (tagged + untagged fenced blocks)
+- [ ] Large pasted formatted text (no chat horizontal overflow)
+- [ ] Tall composer + attachments + long streaming response
+- [ ] Steer/follow-up runs with multiple tool calls
+- [ ] Slash command smoke (`/compact`, curated list)
+- [ ] Dark/light visual regression snapshots
+
 ## Active issue (current session)
 - [x] #33 RPC reliability: fix duplicate tool cards + loading/reconnect UX
   - [x] Make RPC bridge listener setup idempotent under concurrent `ensureListeners()` calls

--- a/TODO.md
+++ b/TODO.md
@@ -9,15 +9,15 @@ Scope (deduped): **#49, #50, #52, #53, #54, #55, #63, #70, #72**
 ### A) Markdown/code rendering integrity + readability
 Issues: #49, #50, #54
 
-- [ ] #49 Ensure fenced code blocks always render in chat and file markdown contexts.
-  - [ ] Verify `CodeBlock` component registration/import in all markdown hosts.
+- [x] #49 Ensure fenced code blocks always render in chat and file markdown contexts.
+  - [x] Verify `CodeBlock` component registration/import in all markdown hosts.
   - [ ] Add regression check for language-tagged and plain fenced blocks.
-- [ ] #50 Make code-block copy actions hover/focus-only (keyboard accessible).
-  - [ ] No layout jump when action appears.
-  - [ ] Keep inline code behavior unchanged.
-- [ ] #54 Remove chat-level horizontal overflow for normal text flow.
-  - [ ] Add robust wrapping (`overflow-wrap`) for long tokens/pasted formatted text.
-  - [ ] Preserve horizontal scroll only inside code blocks.
+- [x] #50 Make code-block copy actions hover/focus-only (keyboard accessible).
+  - [x] No layout jump when action appears.
+  - [x] Keep inline code behavior unchanged.
+- [x] #54 Remove chat-level horizontal overflow for normal text flow.
+  - [x] Add robust wrapping (`overflow-wrap`) for long tokens/pasted formatted text.
+  - [x] Preserve horizontal scroll only inside code blocks.
 
 Acceptance gate:
 - [ ] No missing code blocks
@@ -27,14 +27,14 @@ Acceptance gate:
 ### B) Chat canvas tool/compaction noise reduction
 Issues: #52, #55, #72
 
-- [ ] #52 Compact tool rows by default with meaningful action preview text.
-  - [ ] Progressive disclosure for full details.
-  - [ ] Group repeated consecutive same-tool runs (`tool × N`).
-- [ ] #55 Use a single collapsible compaction status element per cycle.
-  - [ ] State transitions in-place (`running -> done -> error`) with no duplicate blocks.
-- [ ] #72 Investigate/fix weird tool result rows after steer message.
+- [x] #52 Compact tool rows by default with meaningful action preview text.
+  - [x] Progressive disclosure for full details.
+  - [x] Group repeated consecutive same-tool runs (`tool × N`).
+- [x] #55 Use a single collapsible compaction status element per cycle.
+  - [x] State transitions in-place (`running -> done -> error`) with no duplicate blocks.
+- [x] #72 Investigate/fix weird tool result rows after steer message.
   - [ ] Reproduce from screenshot scenario.
-  - [ ] Add guard/normalization for post-steer tool event/result mapping.
+  - [x] Add guard/normalization for post-steer tool event/result mapping.
 
 Acceptance gate:
 - [ ] Assistant text remains dominant in tool-heavy runs
@@ -44,12 +44,12 @@ Acceptance gate:
 ### C) Composer/scroll/actions behavior
 Issues: #53, #70
 
-- [ ] #53 Dynamic composer offset so latest content is always visible.
-  - [ ] Measure composer with `ResizeObserver`.
-  - [ ] Drive chat bottom padding and jump-to-latest offset via CSS variable.
+- [x] #53 Dynamic composer offset so latest content is always visible.
+  - [x] Measure composer with `ResizeObserver`.
+  - [x] Drive chat bottom padding and jump-to-latest offset via CSS variable.
 - [ ] #70 Audit slash actions (`/`) and keep only meaningful chat-surface actions.
   - [ ] Verify `/compact` and other supported actions are functional.
-  - [ ] Remove/disable slash actions already covered by better UX entrypoints.
+  - [x] Remove/disable slash actions already covered by better UX entrypoints.
 
 Acceptance gate:
 - [ ] Bottom-most assistant content never hidden by tall composer
@@ -64,10 +64,10 @@ Issue: #63 (umbrella)
 
 ### Execution order (recommended PR slicing)
 
-- [ ] PR-1: Rendering integrity baseline (#49, #54)
-- [ ] PR-2: Code block UX polish (#50)
-- [ ] PR-3: Composer offset + scroll correctness (#53)
-- [ ] PR-4: Tool/compaction timeline cleanup (#52, #55, #72)
+- [x] PR-1: Rendering integrity baseline (#49, #54)
+- [x] PR-2: Code block UX polish (#50)
+- [x] PR-3: Composer offset + scroll correctness (#53)
+- [x] PR-4: Tool/compaction timeline cleanup (#52, #55, #72)
 - [ ] PR-5: Slash action audit/cleanup (#70)
 - [ ] PR-6: #63 rollout summary + visual QA pass
 

--- a/docs/ISSUE_IMPLEMENTATION_LOG_2026-03-31.md
+++ b/docs/ISSUE_IMPLEMENTATION_LOG_2026-03-31.md
@@ -1,70 +1,123 @@
 # Issue implementation log (2026-03-31)
 
-This log summarizes the current `feat/66-theme-schema-cli-compat` cycle covering theme schema compatibility, Settings stability, and no-project welcome/dashboard UX.
+This log now covers both implementation tracks completed/advanced on 2026-03-31:
+
+1. **Theme/settings/welcome track** on `feat/66-theme-schema-cli-compat` (merged to `dev` via PR #73)
+2. **Chat interface sweep track** on `feat/chat-interface-issue-sweep` (pushed branch, PR creation pending)
+
+---
+
+## Status by affected issue
+
+- **#49** Markdown code-block render integrity — **Implemented (chat sweep branch)**
+- **#50** Code-block copy UX polish — **Implemented (chat sweep branch)**
+- **#52** Tool-call compact workflow timeline — **Implemented (chat sweep branch)**
+- **#53** Composer offset + scroll correctness — **Implemented (chat sweep branch)**
+- **#54** Chat overflow/wrapping robustness — **Implemented (chat sweep branch)**
+- **#55** Single compaction-cycle UI — **Implemented (chat sweep branch)**
+- **#63** Codex parity umbrella — **Partially implemented** (welcome slice merged; chat slice implemented on sweep branch)
+- **#66** Theme schema / CLI compatibility — **Merged to dev (PR #73)**
+- **#69** Settings pane render hardening — **Merged to dev (PR #73)**
+- **#70** Slash action audit/cleanup — **In progress**
+- **#72** Tool-result/steer timeline anomalies — **Implemented (chat sweep branch)**
+
+---
 
 ## #66 — Theme schema / CLI compatibility
 
-Status: **Implemented on feature branch (pending PR merge to `dev`)**
+Status: **Merged to `dev` via PR #73**
 
 Implemented:
-- Bundled Pi Desktop themes now emit full Pi CLI schema-compatible theme documents.
-- Added default-theme install/repair path for legacy `~/.pi/agent/themes/pi-desktop-*.json` files.
-- Added schema compatibility validation + rewrite behavior for invalid bundled theme files.
-- Settings “Create theme” export now writes full schema-compatible theme JSON.
+- Bundled themes now emit full Pi CLI-compatible schema documents (required tokens + schema URL).
+- Legacy invalid bundled theme files in `~/.pi/agent/themes/pi-desktop-*.json` are auto-repaired on install/restore.
+- Settings “Create theme” now exports full schema-compatible documents.
 
-Primary commits:
-- `b40572c`
+---
 
 ## #69 — Settings pane blank/failed render hardening
 
-Status: **Implemented on feature branch (pending PR merge to `dev`)**
+Status: **Merged to `dev` via PR #73**
 
 Implemented:
-- Rebind/reuse Settings panel container safely after shell re-renders.
-- Added pane-open recovery guards and anti-race handling for pane transitions.
-- Hardened open/mount flow for no-project, project-switch, and post-reset states.
-- Added fail-safe fallback shell so settings no longer collapse to a blank pane when advanced runtime sections fail.
-- Decoupled no-project settings from runtime-dependent sections (Appearance remains available without active RPC runtime).
+- Deterministic pane open/mount handling with race/rebind guards.
+- Safe fallback settings shell when runtime-dependent sections fail.
+- No-project settings flow decoupled from runtime-dependent rendering.
 
-Primary commits:
-- `26295e0`
-- `87c3ab3`
-- `c50d551`
-- `b43a2d1`
-- `524218a`
-- `53005aa`
-- `45c985c`
-- `1b4d30e`
+---
 
-## #63 — Codex-inspired frontend parity (welcome/dashboard scope in this cycle)
+## #63 — Codex-inspired parity umbrella
 
-Status: **Partially implemented (welcome/dashboard slice complete for this branch)**
+Status: **Partial (split across tracks)**
 
-Implemented in this cycle:
-- Reworked no-project / new-thread welcome into a centered Codex-inspired layout.
-- Switched to official Pi Desktop icon in welcome lockup.
-- Added project-focused dropdown interaction with cleaner scale and reduced visual noise.
-- Added workspace-project listing and direct project switching from the centered welcome dropdown.
-- Stabilized dropdown open behavior (removed layout jitter/hop) and refined responsive sizing.
-- Added rotating Pi-style idle headline copy.
+Implemented in merged track (`feat/66...`):
+- Centered no-project/new-thread welcome/dashboard redesign.
+- Project-focused dropdown with workspace project listing + direct switching.
 
-Primary commits:
-- `20d06a3`
-- `ae46e36`
-- `5b7185b`
-- `ad02f84`
-- `1baf104`
-- `d3d02ad`
-- `4b475f3`
-- `663a841`
-- `97db931`
-- `e44166c`
-- `7b3da5f`
-- `25872e3`
-- `dba891d`
+Implemented in chat sweep branch (`feat/chat-interface-issue-sweep`):
+- Compact Codex-style tool workflow summaries.
+- Reduced tool chrome with grouped rows and progressive disclosure.
+- Improved markdown/code block visual polish and calmer minimalist hierarchy.
 
-## Remaining follow-up suggestions
+---
 
-- Add search field inside welcome project dropdown to match Codex-style project picker more closely.
-- Continue #63 parity phases (chat canvas rhythm, markdown/code polish, packages/skills layout consistency).
-- Run final native smoke pass before release cut.
+## Chat interface sweep details (`feat/chat-interface-issue-sweep`)
+
+### #49 / #50 / #54 — Markdown and code rendering + UX
+
+Implemented:
+- Ensured fenced code blocks render reliably in chat/file markdown hosts.
+- Refined code-block copy affordance (hover/focus behavior, reduced visual noise).
+- Suppressed assistant-level copy action when a message is only a fenced code block (copy stays on the code block itself).
+- Removed “card-in-card” feel in code blocks; tightened spacing and icon proportions.
+- Hardened wrapping and overflow rules to avoid chat-level horizontal overflow for normal prose.
+
+### #52 / #55 / #72 — Tool workflow and compaction timeline stabilization
+
+Implemented:
+- Single compact workflow summary per assistant run with duration-centered header.
+- Grouped repeated consecutive tool runs; single-open tool detail behavior preserved.
+- Compaction updates consolidated into one in-place cycle block.
+- Manual-collapse override respected during active runs (no unwanted auto-reopen).
+- Collapse behavior now defers to final assistant handoff instead of individual tool completion.
+- Removed transient blank placeholder row generation that caused pre-workflow spacing jumps.
+- Thinking/tool timeline now supports interleaving order from stream events (not forced top-only).
+- Added stronger dedupe for repeated streamed thinking content.
+- Improved handling for concurrent running tool groups and inline running indicators.
+
+### #53 — Composer/scroll behavior
+
+Implemented:
+- Dynamic composer-aware bottom spacing with `ResizeObserver` and CSS offset variable.
+- Maintained “latest” visibility behavior while streaming.
+
+### #70 — Slash actions
+
+Status: **Not complete**
+
+Progress:
+- Redundant slash actions already covered by clearer UI entry points were reduced.
+
+Remaining:
+- Final curated slash list audit and `/compact`-path validation before closing #70.
+
+---
+
+## Notable chat-sweep commits (latest)
+
+- `9824044` feat(chat): compact workflow timeline + markdown/composer hardening
+- `3412b61` fix(chat): running workflows expanded behavior stabilization
+- `3c7df3c` fix(chat): active dropdown stability + truncation improvements
+- `9ce8d56` refactor(chat): restore workflow thinking + minimal running treatment
+- `fe5f925` fix(chat): keep pre-tool thinking inside workflow + sync animation state
+- `bfabdfa` refine(chat): manual collapse persistence + inline Pi affordance
+- `4553916` refine(chat): code-block polish + interleaved timeline behavior
+- `f36e29f` fix(chat): avoid empty assistant placeholder row generation
+- `211db6f` fix(chat): dedupe repeated streamed thinking in workflow timeline
+
+---
+
+## Remaining follow-up before merge
+
+- Open PR for `feat/chat-interface-issue-sweep` with issue mapping and validation notes.
+- Complete #70 slash-action audit/cleanup and update status in issue + changelog.
+- Final native smoke pass (streaming, parallel tools, long markdown/code, dark/light visual checks).

--- a/issues/chat-ui-polish-checklist-temp.md
+++ b/issues/chat-ui-polish-checklist-temp.md
@@ -1,0 +1,32 @@
+# Chat UI polish – temporary checklist
+
+Context: consolidated from latest UX feedback for Codex-like chat/workflow parity.
+
+## Workflow / dropdown behavior
+- [x] Keep workflow expanded by default while run is active.
+- [x] Respect manual collapse override during active run (do not auto-reopen on subsequent tool events).
+- [x] Avoid closing on individual tool completion; close automatically only when final agent text handoff starts.
+- [x] Hide global bottom Pi working indicator when a workflow dropdown is expanded.
+- [x] Show global bottom Pi working indicator when dropdown is collapsed.
+- [x] Render inline Pi indicator inside expanded workflow for active thinking/tool rows.
+- [x] Keep inline Pi + running text animation in sync (same animation cadence).
+- [x] Support concurrent running tool groups (indicator on each running row).
+
+## Thinking / tool timeline
+- [x] Thinking should not be hard-locked to top: keep timeline order from message stream.
+- [x] Thinking blocks can appear before, between, or after tool rows based on actual event order.
+- [x] Thinking detail area uses scroll/max-height behavior like tool details.
+- [x] Thinking content tone/weight aligned to tool detail content style.
+
+## Code block UX polish
+- [x] Remove assistant message-level copy action when message is only a single fenced code block.
+- [x] Keep code-block-local copy action as primary copy affordance.
+- [x] Remove card-in-card look for fenced blocks (single surface treatment).
+- [x] Tighten code block spacing, header/footer proportions, and copy icon sizing.
+- [x] Soften copy button/copied state visual weight for minimal look.
+
+## Remaining QA pass
+- [ ] Validate long code blocks (horizontal + vertical scroll behavior).
+- [ ] Validate mixed markdown (paragraph + code block + paragraph) copy button behavior.
+- [ ] Validate timeline ordering on streamed runs with interleaved thinking/tool updates.
+- [ ] Validate manual collapse persistence across multi-tool runs with retries.

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3773,12 +3773,14 @@ export class ChatView {
 		let text = value.replace(/^\s*thinking\.\.\.\s*/i, "").trim();
 		if (!text) return "";
 		const paragraphs = text
-			.split(/\n{2,}/)
+		.split(/\n{2,}/)
 			.map((part) => part.trim())
 			.filter(Boolean);
 		const deduped: string[] = [];
+		const seen = new Set<string>();
 		for (const part of paragraphs) {
-			if (deduped[deduped.length - 1] === part) continue;
+			if (seen.has(part)) continue;
+			seen.add(part);
 			deduped.push(part);
 		}
 		text = deduped.join("\n\n").trim();
@@ -4130,22 +4132,49 @@ export class ChatView {
 				group: ToolCallGroup;
 			};
 		const detailEntries: WorkflowDetailEntry[] = [];
+		let lastThinkingFull = "";
 		for (const message of workflow.messages) {
 			const normalizedThinking = this.normalizeThinkingText((message.thinking ?? "").replace(/^\s+/, ""));
 			if (normalizedThinking) {
-				const entryId = `${workflow.id}:thinking:${message.id}`;
+				let displayThinking = normalizedThinking;
+				if (lastThinkingFull) {
+					if (normalizedThinking.startsWith(lastThinkingFull)) {
+						displayThinking = normalizedThinking.slice(lastThinkingFull.length).replace(/^\s+/, "").trim();
+					} else if (lastThinkingFull.startsWith(normalizedThinking)) {
+						displayThinking = "";
+					}
+				}
+				lastThinkingFull = normalizedThinking;
+
 				const previous = detailEntries[detailEntries.length - 1];
-				if (previous && previous.kind === "thinking" && previous.text === normalizedThinking) {
+				if (!displayThinking) {
+					if (previous && previous.kind === "thinking") {
+						previous.animating = previous.animating || Boolean(message.isThinkingStreaming);
+					}
+				} else if (previous && previous.kind === "thinking") {
 					previous.animating = previous.animating || Boolean(message.isThinkingStreaming);
+					if (displayThinking === previous.text || previous.text.startsWith(displayThinking)) {
+						// no-op: duplicate or shorter repeat
+					} else if (displayThinking.startsWith(previous.text)) {
+						previous.text = displayThinking;
+					} else {
+						detailEntries.push({
+							kind: "thinking",
+							id: `${workflow.id}:thinking:${message.id}`,
+							text: displayThinking,
+							animating: Boolean(message.isThinkingStreaming),
+						});
+					}
 				} else {
 					detailEntries.push({
 						kind: "thinking",
-						id: entryId,
-						text: normalizedThinking,
+						id: `${workflow.id}:thinking:${message.id}`,
+						text: displayThinking,
 						animating: Boolean(message.isThinkingStreaming),
 					});
 				}
 			}
+
 			for (const toolCall of message.toolCalls) {
 				const preview = this.summarizeToolCall(toolCall);
 				const previous = detailEntries[detailEntries.length - 1];

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3766,6 +3766,52 @@ export class ChatView {
 		const duration = startedAt > 0 ? formatDuration((running > 0 ? Date.now() : Math.max(endedAt, startedAt)) - startedAt) : null;
 		const primaryLabel = running > 0 ? `Working with ${total} tool call${total === 1 ? "" : "s"}` : duration ? `Worked for ${duration}` : `Worked with ${total} tool call${total === 1 ? "" : "s"}`;
 		const secondaryLabel = running > 0 ? "in progress" : failed > 0 ? `${failed} failed` : `${total} complete`;
+		const showSummary = total > 1 || groups.length > 1;
+		const showDetails = showSummary ? expanded : true;
+
+		const workflowList = html`
+			<div class="tool-workflow-list">
+				${groups.map((group) => {
+					const count = group.calls.length;
+					const groupExpanded = group.calls.some((tc) => tc.isExpanded);
+					const groupRunning = group.calls.some((tc) => tc.isRunning);
+					const groupFailed = group.calls.some((tc) => tc.isError);
+					return html`
+						<div class="tool-workflow-item ${groupExpanded ? "expanded" : ""}">
+							<button class="tool-workflow-line" @click=${() => this.toggleToolCallGroupExpanded(group)}>
+								<span class="tool-workflow-line-text">${group.preview}</span>
+								${count > 1 ? html`<span class="tool-workflow-count">×${count}</span>` : nothing}
+								<span class="tool-workflow-state ${groupRunning ? "running" : groupFailed ? "error" : "done"}">${groupRunning ? "running" : groupFailed ? "failed" : "done"}</span>
+								<span class="tool-workflow-caret">${groupExpanded ? "▾" : "▸"}</span>
+							</button>
+							${groupExpanded
+								? html`
+									<div class="tool-workflow-details">
+										${group.calls.map((call, index) => {
+											const output = (call.streamingOutput ?? call.result ?? "").trimEnd();
+											const hasOutput = output.length > 0;
+											const placeholder = call.isRunning ? "Waiting for tool output…" : "No output reported.";
+											return html`
+												<div class="tool-workflow-detail-run">
+													${group.calls.length > 1 ? html`<div class="tool-workflow-detail-label">Run ${index + 1}</div>` : nothing}
+													<pre class="tool-workflow-output ${hasOutput ? "" : "tool-output-empty"}">${hasOutput ? output : placeholder}${call.isRunning
+														? html`<span class="streaming-inline"></span>`
+														: nothing}</pre>
+												</div>
+											`;
+										})}
+									</div>
+								`
+								: nothing}
+						</div>
+					`;
+				})}
+			</div>
+		`;
+
+		if (!showSummary) {
+			return html`<div class="tool-workflow tool-workflow-flat">${workflowList}</div>`;
+		}
 
 		return html`
 			<div class="tool-workflow ${expanded ? "expanded" : ""}">
@@ -3776,73 +3822,43 @@ export class ChatView {
 					<span class="workflow-summary-caret">${expanded ? "▾" : "▸"}</span>
 					<span class="workflow-divider" aria-hidden="true"></span>
 				</button>
-				${expanded
-					? html`
-						<div class="tool-workflow-list">
-							${groups.map((group) => {
-								const count = group.calls.length;
-								const groupExpanded = group.calls.some((tc) => tc.isExpanded);
-								const groupRunning = group.calls.some((tc) => tc.isRunning);
-								const groupFailed = group.calls.some((tc) => tc.isError);
-								return html`
-									<div class="tool-workflow-item ${groupExpanded ? "expanded" : ""}">
-										<button class="tool-workflow-line" @click=${() => this.toggleToolCallGroupExpanded(group)}>
-											<span class="tool-workflow-line-text">${group.preview}</span>
-											${count > 1 ? html`<span class="tool-workflow-count">×${count}</span>` : nothing}
-											<span class="tool-workflow-state ${groupRunning ? "running" : groupFailed ? "error" : "done"}">${groupRunning ? "running" : groupFailed ? "failed" : "done"}</span>
-											<span class="tool-workflow-caret">${groupExpanded ? "▾" : "▸"}</span>
-										</button>
-										${groupExpanded
-											? html`
-												<div class="tool-workflow-details">
-													${group.calls.map((call, index) => {
-														const output = (call.streamingOutput ?? call.result ?? "").trimEnd();
-														const hasOutput = output.length > 0;
-														const placeholder = call.isRunning ? "Waiting for tool output…" : "No output reported.";
-														return html`
-															<div class="tool-workflow-detail-run">
-																${group.calls.length > 1 ? html`<div class="tool-workflow-detail-label">Run ${index + 1}</div>` : nothing}
-																<pre class="tool-workflow-output ${hasOutput ? "" : "tool-output-empty"}">${hasOutput ? output : placeholder}${call.isRunning
-																	? html`<span class="streaming-inline"></span>`
-																	: nothing}</pre>
-															</div>
-														`;
-													})}
-												</div>
-											`
-											: nothing}
-									</div>
-								`;
-							})}
-						</div>
-					`
-					: nothing}
+				${showDetails ? workflowList : nothing}
 			</div>
 		`;
 	}
 
-	private renderAssistantMessage(msg: UiMessage): TemplateResult {
-		const canCopy = Boolean(
-			msg.text.trim().length > 0 ||
-				msg.toolCalls.length > 0 ||
-				(msg.thinking ?? "").trim().length > 0 ||
-				(msg.errorText ?? "").trim().length > 0,
-		);
+	private hasAssistantTextAfter(messages: UiMessage[], index: number): boolean {
+		for (let i = index + 1; i < messages.length; i += 1) {
+			const candidate = messages[i];
+			if (candidate.role !== "assistant") continue;
+			if (candidate.text.trim().length > 0) return true;
+		}
+		return false;
+	}
+
+	private renderAssistantMessage(msg: UiMessage, context: { previous: UiMessage | null; index: number; all: UiMessage[] }): TemplateResult {
+		const canCopy = Boolean(msg.text.trim().length > 0 || (msg.errorText ?? "").trim().length > 0);
 		const errorLine = (msg.errorText ?? "").trim();
 		const formattedErrorLine = errorLine
 			? (/^error\b[:\s-]*/i.test(errorLine) ? errorLine : `Error: ${errorLine}`)
 			: "";
 		const hasToolWorkflow = msg.toolCalls.length > 0;
+		const hasText = msg.text.trim().length > 0;
+		const previousHasTools = Boolean(context.previous?.role === "assistant" && context.previous.toolCalls.length > 0);
+		const showFinalDivider = hasText && (hasToolWorkflow || previousHasTools);
+		const shouldRenderThinking = Boolean(msg.thinking) && !(hasToolWorkflow && !hasText);
+		const hasLaterAssistantText = this.hasAssistantTextAfter(context.all, context.index);
+		const showMissingWrapUp = hasToolWorkflow && !hasText && !msg.isStreaming && !this.currentIsStreaming() && !hasLaterAssistantText;
+
 		return html`
-			<div class="chat-row assistant-row" data-message-id=${msg.id}>
+			<div class="chat-row assistant-row ${hasToolWorkflow && !hasText ? "assistant-tool-only-row" : ""}" data-message-id=${msg.id}>
 				<div class="message-shell assistant-message-shell">
 					<div class="assistant-block">
 						${hasToolWorkflow ? this.renderToolWorkflow(msg) : nothing}
-						${this.renderThinking(msg)}
-						${msg.text && hasToolWorkflow
-							? html`<div class="assistant-final-divider"><span>Final message</span></div>`
-							: nothing}
-						${msg.text
+						${shouldRenderThinking ? this.renderThinking(msg) : nothing}
+						${showFinalDivider ? html`<div class="assistant-final-divider"><span>Final message</span></div>` : nothing}
+						${showMissingWrapUp ? html`<div class="assistant-wrapup-missing">No final message returned for this tool run.</div>` : nothing}
+						${hasText
 							? html`
 								<div class="assistant-content ${msg.isStreaming ? "streaming-cursor" : ""}">
 									<markdown-block .content=${msg.text}></markdown-block>
@@ -5010,9 +5026,15 @@ export class ChatView {
 					${!hasProject
 						? this.renderWelcomeDashboard()
 						: hasMessages
-							? html`${this.messages.map((m) => {
+							? html`${this.messages.map((m, index, all) => {
 									if (m.role === "user") return this.renderUserMessage(m);
-									if (m.role === "assistant") return this.renderAssistantMessage(m);
+									if (m.role === "assistant") {
+										return this.renderAssistantMessage(m, {
+											previous: index > 0 ? all[index - 1] ?? null : null,
+											index,
+											all,
+										});
+									}
 									return this.renderSystemMessage(m);
 								})}`
 							: this.bindingStatusText

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -447,6 +447,7 @@ export class ChatView {
 	private slashSkillsLoading = false;
 	private slashSkillsUpdatedAt = 0;
 	private runHasAssistantText = false;
+	private runSawToolActivity = false;
 	private keepWorkflowExpandedUntilAssistantText = false;
 	private readonly workingStatusPhrases = [
 		"starting",
@@ -592,6 +593,7 @@ export class ChatView {
 			this.modelLoadRequestSeq += 1;
 			this.loadingModels = false;
 			this.runHasAssistantText = false;
+			this.runSawToolActivity = false;
 			this.clearWorkingStatusTimer(true);
 			void this.refreshWelcomeDashboard(true);
 		}
@@ -618,6 +620,7 @@ export class ChatView {
 		this.expandedToolGroupByWorkflowId.clear();
 		this.compactionCycle = null;
 		this.runHasAssistantText = false;
+		this.runSawToolActivity = false;
 		this.keepWorkflowExpandedUntilAssistantText = false;
 		this.clearWorkingStatusTimer(true);
 		this.bindingStatusText = projectPath ? (statusText ?? "Loading session…") : null;
@@ -975,6 +978,8 @@ export class ChatView {
 		this.unsubscribeEvents = null;
 		this.cancelStreamingUiReconcile();
 		this.runHasAssistantText = false;
+		this.runSawToolActivity = false;
+		this.keepWorkflowExpandedUntilAssistantText = false;
 		this.clearWorkingStatusTimer(true);
 		if (this.welcomeHeadlineTimer) {
 			clearInterval(this.welcomeHeadlineTimer);
@@ -1039,9 +1044,28 @@ export class ChatView {
 					if ((entry.role as string) !== "assistant") return false;
 					return this.extractText((entry as Record<string, unknown>).content).trim().length > 0;
 				});
-				this.keepWorkflowExpandedUntilAssistantText = !this.runHasAssistantText;
+				const sawToolInStreamWindow = streamWindow.some((entry) => {
+					const role = (entry.role as string) ?? "";
+					if (role === "toolResult") return true;
+					if (role !== "assistant") return false;
+					const directToolCalls = (entry as { toolCalls?: unknown }).toolCalls;
+					if (Array.isArray(directToolCalls) && directToolCalls.length > 0) return true;
+					const content = (entry as Record<string, unknown>).content;
+					if (!Array.isArray(content)) return false;
+					return content.some((part) => {
+						if (!part || typeof part !== "object") return false;
+						const rec = part as Record<string, unknown>;
+						const type = typeof rec.type === "string" ? rec.type.toLowerCase() : "";
+						return type.includes("tool") || Boolean(rec.toolCall);
+					});
+				});
+				this.runSawToolActivity = this.runSawToolActivity || sawToolInStreamWindow;
+				if (this.runSawToolActivity) {
+					this.keepWorkflowExpandedUntilAssistantText = !this.runHasAssistantText;
+				}
 			} else {
 				this.runHasAssistantText = false;
+				this.runSawToolActivity = false;
 				this.keepWorkflowExpandedUntilAssistantText = false;
 			}
 			this.pendingDeliveryMode = state.isStreaming ? "steer" : "prompt";
@@ -2249,6 +2273,7 @@ export class ChatView {
 			case "agent_start":
 				this.pendingDeliveryMode = "steer";
 				this.runHasAssistantText = false;
+				this.runSawToolActivity = false;
 				this.keepWorkflowExpandedUntilAssistantText = true;
 				if (this.state) {
 					this.state = { ...this.state, isStreaming: true };
@@ -2277,6 +2302,7 @@ export class ChatView {
 					this.pushRuntimeNotice(`Run failed: ${truncate(runError, 180)}`, "error", 2600);
 				}
 				this.runHasAssistantText = false;
+				this.runSawToolActivity = false;
 				this.keepWorkflowExpandedUntilAssistantText = false;
 				this.onRunStateChange?.(false);
 				rpcBridge
@@ -2317,7 +2343,9 @@ export class ChatView {
 					});
 					if (initialText.trim().length > 0) {
 						this.runHasAssistantText = true;
-						this.keepWorkflowExpandedUntilAssistantText = false;
+						if (this.runSawToolActivity) {
+							this.keepWorkflowExpandedUntilAssistantText = false;
+						}
 					}
 					this.render();
 					this.scrollToBottom();
@@ -2325,6 +2353,8 @@ export class ChatView {
 				}
 
 				if (role === "toolResult") {
+					this.runSawToolActivity = true;
+					this.keepWorkflowExpandedUntilAssistantText = true;
 					const toolCallId = typeof msg.toolCallId === "string" ? msg.toolCallId : "";
 					const output = this.extractToolOutput(msg.content ?? msg.result ?? msg);
 					const isError = Boolean(msg.isError);
@@ -2375,7 +2405,9 @@ export class ChatView {
 					last.text = this.mergeStreamingText(last.text, partialText, assistantEvent.delta);
 					if (last.text.trim().length > 0) {
 						this.runHasAssistantText = true;
-						this.keepWorkflowExpandedUntilAssistantText = false;
+						if (this.runSawToolActivity) {
+							this.keepWorkflowExpandedUntilAssistantText = false;
+						}
 					}
 					this.scheduleStreamingUiReconcile(1800);
 					this.render();
@@ -2387,6 +2419,8 @@ export class ChatView {
 					this.scheduleStreamingUiReconcile(1800);
 					if ((last.thinking?.length || 0) % 100 === 0) this.render();
 				} else if (subtype === "toolcall_end") {
+					this.runSawToolActivity = true;
+					this.keepWorkflowExpandedUntilAssistantText = true;
 					const tc = assistantEvent.toolCall as Record<string, unknown>;
 					if (tc) {
 						const rawId = typeof tc.id === "string" ? tc.id.trim() : "";
@@ -2999,6 +3033,8 @@ export class ChatView {
 		});
 		this.autoFollowChat = true;
 		this.runHasAssistantText = false;
+		this.runSawToolActivity = false;
+		this.keepWorkflowExpandedUntilAssistantText = false;
 		this.render();
 		this.scrollToBottom(true);
 	}
@@ -3200,6 +3236,7 @@ export class ChatView {
 		}
 		this.pendingDeliveryMode = "prompt";
 		this.runHasAssistantText = false;
+		this.runSawToolActivity = false;
 		this.keepWorkflowExpandedUntilAssistantText = false;
 		this.onRunStateChange?.(false);
 	}
@@ -3737,13 +3774,13 @@ export class ChatView {
 		const command = this.pickToolArg(tc.args, ["command", "cmd", "shell", "script"]);
 		const path = this.pickToolArg(tc.args, ["path", "filePath", "targetPath", "from", "to"]);
 		const query = this.pickToolArg(tc.args, ["query", "pattern", "glob", "name"]);
-		if (name === "bash" && command) return `Ran ${truncate(command, 140)}`;
-		if ((name === "read" || name === "readfile") && path) return `Read ${truncate(path, 120)}`;
-		if ((name === "write" || name === "writefile") && path) return `Wrote ${truncate(path, 120)}`;
-		if (name === "edit" && path) return `Edited ${truncate(path, 120)}`;
-		if (name.includes("search") && query) return `Explored ${truncate(query, 120)}`;
-		if ((name === "list" || name.includes("ls")) && path) return `Explored ${truncate(path, 120)}`;
-		if (path) return `${tc.name} ${truncate(path, 120)}`;
+		if (name === "bash" && command) return `Ran ${truncate(command, 96)}`;
+		if ((name === "read" || name === "readfile") && path) return `Read ${truncate(path, 88)}`;
+		if ((name === "write" || name === "writefile") && path) return `Wrote ${truncate(path, 88)}`;
+		if (name === "edit" && path) return `Edited ${truncate(path, 88)}`;
+		if (name.includes("search") && query) return `Explored ${truncate(query, 88)}`;
+		if ((name === "list" || name.includes("ls")) && path) return `Explored ${truncate(path, 88)}`;
+		if (path) return `${tc.name} ${truncate(path, 88)}`;
 		return `Ran ${tc.name}`;
 	}
 
@@ -3920,7 +3957,7 @@ export class ChatView {
 		const summarySecondary = running > 0 ? `${total} running` : failed > 0 ? `${failed} failed` : `${total} complete`;
 		const hasFinalContent = Boolean(workflow.finalText || workflow.errorText);
 		const manualExpanded = this.isToolWorkflowExpanded(workflow.id);
-		const autoExpanded = this.keepWorkflowExpandedUntilAssistantText && workflow.isTerminal && !hasFinalContent;
+		const autoExpanded = !hasFinalContent && (this.keepWorkflowExpandedUntilAssistantText || workflow.isStreaming || running > 0);
 		const expanded = autoExpanded || manualExpanded;
 		if (!expanded) {
 			this.expandedToolGroupByWorkflowId.delete(workflow.id);

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3756,6 +3756,14 @@ export class ChatView {
 		return text;
 	}
 
+	private isStandaloneCodeBlockMarkdown(value: string): boolean {
+		const text = value.trim();
+		if (!text) return false;
+		if (/^```[^\n`]*\n[\s\S]*\n```$/.test(text)) return true;
+		if (/^~~~[^\n~]*\n[\s\S]*\n~~~$/.test(text)) return true;
+		return false;
+	}
+
 	private renderThinking(msg: UiMessage): TemplateResult | typeof nothing {
 		if (!msg.thinking) return nothing;
 		const expanded = msg.thinkingExpanded ?? false;
@@ -3847,11 +3855,19 @@ export class ChatView {
 		return this.expandedToolWorkflowIds.has(workflowId);
 	}
 
+	private clearWorkflowThinkingExpansion(workflowId: string): void {
+		for (const thinkingId of Array.from(this.expandedWorkflowThinkingIds)) {
+			if (thinkingId.startsWith(`${workflowId}:thinking:`)) {
+				this.expandedWorkflowThinkingIds.delete(thinkingId);
+			}
+		}
+	}
+
 	private toggleToolWorkflowExpanded(workflowId: string, autoExpanded = false, currentlyExpanded = false): void {
 		if (currentlyExpanded) {
 			this.expandedToolWorkflowIds.delete(workflowId);
 			this.expandedToolGroupByWorkflowId.delete(workflowId);
-			this.expandedWorkflowThinkingIds.delete(workflowId);
+			this.clearWorkflowThinkingExpansion(workflowId);
 			if (autoExpanded) {
 				this.collapsedAutoWorkflowIds.add(workflowId);
 			}
@@ -3862,15 +3878,15 @@ export class ChatView {
 		this.render();
 	}
 
-	private isWorkflowThinkingExpanded(workflowId: string): boolean {
-		return this.expandedWorkflowThinkingIds.has(workflowId);
+	private isWorkflowThinkingExpanded(thinkingId: string): boolean {
+		return this.expandedWorkflowThinkingIds.has(thinkingId);
 	}
 
-	private toggleWorkflowThinkingExpanded(workflowId: string): void {
-		if (this.expandedWorkflowThinkingIds.has(workflowId)) {
-			this.expandedWorkflowThinkingIds.delete(workflowId);
+	private toggleWorkflowThinkingExpanded(thinkingId: string): void {
+		if (this.expandedWorkflowThinkingIds.has(thinkingId)) {
+			this.expandedWorkflowThinkingIds.delete(thinkingId);
 		} else {
-			this.expandedWorkflowThinkingIds.add(workflowId);
+			this.expandedWorkflowThinkingIds.add(thinkingId);
 		}
 		this.render();
 	}
@@ -4069,12 +4085,55 @@ export class ChatView {
 		const summaryPrimary = durationLabel;
 		const summarySecondary = running > 0 ? `${total} running` : failed > 0 ? `${failed} failed` : total > 0 ? `${total} complete` : "";
 		const hasFinalContent = Boolean(workflow.finalText || workflow.errorText);
-		const thinkingExpanded = this.isWorkflowThinkingExpanded(workflow.id);
-		const thinkingAnimating = running === 0 && workflow.messages.some((entry) => entry.isThinkingStreaming);
-		const activeGroupId = workflow.toolGroups.find((group) => group.calls.some((tc) => tc.isRunning))?.id ?? null;
+		type WorkflowDetailEntry =
+			| {
+				kind: "thinking";
+				id: string;
+				text: string;
+				animating: boolean;
+			}
+			| {
+				kind: "group";
+				group: ToolCallGroup;
+			};
+		const detailEntries: WorkflowDetailEntry[] = [];
+		for (const message of workflow.messages) {
+			const normalizedThinking = this.normalizeThinkingText((message.thinking ?? "").replace(/^\s+/, ""));
+			if (normalizedThinking) {
+				const entryId = `${workflow.id}:thinking:${message.id}`;
+				const previous = detailEntries[detailEntries.length - 1];
+				if (previous && previous.kind === "thinking" && previous.text === normalizedThinking) {
+					previous.animating = previous.animating || Boolean(message.isThinkingStreaming);
+				} else {
+					detailEntries.push({
+						kind: "thinking",
+						id: entryId,
+						text: normalizedThinking,
+						animating: Boolean(message.isThinkingStreaming),
+					});
+				}
+			}
+			for (const toolCall of message.toolCalls) {
+				const preview = this.summarizeToolCall(toolCall);
+				const previous = detailEntries[detailEntries.length - 1];
+				if (previous && previous.kind === "group" && previous.group.toolName === toolCall.name && previous.group.preview === preview) {
+					previous.group.calls.push(toolCall);
+					continue;
+				}
+				detailEntries.push({
+					kind: "group",
+					group: {
+						id: `${toolCall.id}-group`,
+						toolName: toolCall.name,
+						preview,
+						calls: [toolCall],
+					},
+				});
+			}
+		}
 		if (!expanded) {
 			this.expandedToolGroupByWorkflowId.delete(workflow.id);
-			this.expandedWorkflowThinkingIds.delete(workflow.id);
+			this.clearWorkflowThinkingExpansion(workflow.id);
 		}
 
 		return html`
@@ -4097,19 +4156,22 @@ export class ChatView {
 						</button>
 						${expanded
 							? html`
-								${workflow.thinkingText
-									? html`
-										<div class="tool-workflow-thinking">
-											<button class="tool-workflow-thinking-toggle ${thinkingAnimating ? "animating" : "done"}" @click=${() => this.toggleWorkflowThinkingExpanded(workflow.id)}>
-												${thinkingAnimating && !activeGroupId ? html`<span class="tool-workflow-inline-pi" aria-hidden="true">${piGlyphIcon()}</span>` : nothing}
-												<span class="tool-workflow-thinking-text">Thinking…</span>
-											</button>
-											${thinkingExpanded ? html`<div class="tool-workflow-thinking-content">${workflow.thinkingText}</div>` : nothing}
-										</div>
-									`
-									: nothing}
 								<div class="tool-workflow-list">
-									${workflow.toolGroups.map((group) => {
+									${detailEntries.map((entry) => {
+										if (entry.kind === "thinking") {
+											const thinkingExpanded = this.isWorkflowThinkingExpanded(entry.id);
+											const thinkingAnimating = running === 0 && entry.animating;
+											return html`
+												<div class="tool-workflow-thinking">
+													<button class="tool-workflow-thinking-toggle ${thinkingAnimating ? "animating" : "done"}" @click=${() => this.toggleWorkflowThinkingExpanded(entry.id)}>
+														${thinkingAnimating ? html`<span class="tool-workflow-inline-pi" aria-hidden="true">${piGlyphIcon()}</span>` : nothing}
+														<span class="tool-workflow-thinking-text">Thinking…</span>
+													</button>
+													${thinkingExpanded ? html`<div class="tool-workflow-thinking-content">${entry.text}</div>` : nothing}
+												</div>
+											`;
+										}
+										const group = entry.group;
 										const count = group.calls.length;
 										const groupRunning = group.calls.some((tc) => tc.isRunning);
 										const groupFailed = group.calls.some((tc) => tc.isError);
@@ -4126,7 +4188,7 @@ export class ChatView {
 													class="tool-workflow-line ${groupRunning ? "running" : ""}"
 													@click=${() => this.toggleToolGroupExpanded(workflow.id, group.id)}
 												>
-													${groupRunning && activeGroupId === group.id ? html`<span class="tool-workflow-inline-pi" aria-hidden="true">${piGlyphIcon()}</span>` : nothing}
+													${groupRunning ? html`<span class="tool-workflow-inline-pi" aria-hidden="true">${piGlyphIcon()}</span>` : nothing}
 													<span class="tool-workflow-line-text ${groupRunning ? "running" : ""}">${this.renderToolPreview(group.preview)}</span>
 													${count > 1 ? html`<span class="tool-workflow-count">×${count}</span>` : nothing}
 												</button>
@@ -4186,8 +4248,10 @@ export class ChatView {
 	}
 
 	private renderAssistantMessage(msg: UiMessage): TemplateResult {
-		const canCopy = Boolean(msg.text.trim().length > 0 || (msg.errorText ?? "").trim().length > 0);
+		const trimmedText = msg.text.trim();
 		const errorLine = (msg.errorText ?? "").trim();
+		const standaloneCodeBlock = this.isStandaloneCodeBlockMarkdown(trimmedText);
+		const canCopy = Boolean(errorLine.length > 0 || (trimmedText.length > 0 && !standaloneCodeBlock));
 		const formattedErrorLine = errorLine
 			? (/^error\b[:\s-]*/i.test(errorLine) ? errorLine : `Error: ${errorLine}`)
 			: "";

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3861,8 +3861,7 @@ export class ChatView {
 			.filter(Boolean)
 			.join("\n");
 		const firstId = grouped[0]?.id ?? uid("workflow");
-		const lastId = grouped[grouped.length - 1]?.id ?? firstId;
-		const workflowId = `workflow-${firstId}-${lastId}`;
+		const workflowId = `workflow-${firstId}`;
 
 		return {
 			workflow: {
@@ -3894,7 +3893,6 @@ export class ChatView {
 		const total = workflow.toolCalls.length;
 		const running = workflow.toolCalls.filter((tc) => tc.isRunning).length;
 		const failed = workflow.toolCalls.filter((tc) => tc.isError).length;
-		const expanded = this.isToolWorkflowExpanded(workflow.id);
 		const durationMs =
 			workflow.startedAt > 0
 				? (running > 0 ? Date.now() : Math.max(workflow.endedAt, workflow.startedAt)) - workflow.startedAt
@@ -3903,17 +3901,27 @@ export class ChatView {
 		const summaryPrimary = running > 0 ? `Working for ${durationLabel}` : `Worked for ${durationLabel}`;
 		const summarySecondary = running > 0 ? `${total} running` : failed > 0 ? `${failed} failed` : `${total} complete`;
 		const hasFinalContent = Boolean(workflow.finalText || workflow.errorText);
-		const showMissingWrapUp = !hasFinalContent && running === 0 && !workflow.isStreaming;
+		const expanded = running > 0 || this.isToolWorkflowExpanded(workflow.id);
+		if (running === 0 && !this.isToolWorkflowExpanded(workflow.id)) {
+			this.expandedToolGroupByWorkflowId.delete(workflow.id);
+		}
 
 		return html`
 			<div class="chat-row assistant-row assistant-workflow-row" data-message-id=${workflow.id}>
 				<div class="message-shell assistant-message-shell">
 					<div class="assistant-block">
-						<button class="tool-workflow-summary" @click=${() => this.toggleToolWorkflowExpanded(workflow.id)}>
+						<button
+							class="tool-workflow-summary"
+							@click=${() => {
+								if (running > 0) return;
+								this.toggleToolWorkflowExpanded(workflow.id);
+							}}
+						>
 							<span class="workflow-divider" aria-hidden="true"></span>
 							<span class="workflow-summary-center">
 								<span class="workflow-summary-label">${summaryPrimary}</span>
 								<span class="workflow-summary-meta">${summarySecondary}</span>
+								<span class="workflow-summary-caret">${expanded ? "▾" : "▸"}</span>
 							</span>
 							<span class="workflow-divider" aria-hidden="true"></span>
 						</button>
@@ -3957,14 +3965,12 @@ export class ChatView {
 									? html`<div class="assistant-content ${workflow.isStreaming ? "streaming-cursor" : ""}"><markdown-block .content=${workflow.finalText}></markdown-block></div>`
 									: nothing}
 								${workflow.errorText ? html`<div class="assistant-error-line">${workflow.errorText}</div>` : nothing}
-								${showMissingWrapUp ? html`<div class="assistant-wrapup-missing">No final message returned for this tool run.</div>` : nothing}
 							`
 							: html`
 								${workflow.finalText
 									? html`<div class="assistant-content workflow-final-collapsed"><markdown-block .content=${workflow.finalText}></markdown-block></div>`
 									: nothing}
 								${workflow.errorText ? html`<div class="assistant-error-line">${workflow.errorText}</div>` : nothing}
-								${showMissingWrapUp ? html`<div class="assistant-wrapup-missing">No final message returned for this tool run.</div>` : nothing}
 							`}
 					</div>
 				</div>

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3664,8 +3664,18 @@ export class ChatView {
 		`;
 	}
 
+	private hasInlineWorkflowActivity(): boolean {
+		for (let index = 0; index < this.messages.length; index += 1) {
+			const msg = this.messages[index];
+			if (msg.role !== "assistant") continue;
+			if (this.collectAssistantWorkflow(index)) return true;
+		}
+		return false;
+	}
+
 	private shouldShowWorkingIndicator(): boolean {
 		if (!this.currentIsStreaming()) return false;
+		if (this.hasInlineWorkflowActivity()) return false;
 		return !this.runHasAssistantText;
 	}
 

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3797,6 +3797,7 @@ export class ChatView {
 			isStreaming: boolean;
 			startedAt: number;
 			endedAt: number;
+			isTerminal: boolean;
 		};
 		nextIndex: number;
 	} | null {
@@ -3863,6 +3864,7 @@ export class ChatView {
 		const firstId = grouped[0]?.id ?? uid("workflow");
 		const workflowId = `workflow-${firstId}`;
 
+		const nextIndex = Math.max(startIndex + 1, cursor);
 		return {
 			workflow: {
 				id: workflowId,
@@ -3874,8 +3876,9 @@ export class ChatView {
 				isStreaming: grouped.some((entry) => entry.isStreaming),
 				startedAt,
 				endedAt,
+				isTerminal: nextIndex >= this.messages.length,
 			},
-			nextIndex: Math.max(startIndex + 1, cursor),
+			nextIndex,
 		};
 	}
 
@@ -3889,6 +3892,7 @@ export class ChatView {
 		isStreaming: boolean;
 		startedAt: number;
 		endedAt: number;
+		isTerminal: boolean;
 	}): TemplateResult {
 		const total = workflow.toolCalls.length;
 		const running = workflow.toolCalls.filter((tc) => tc.isRunning).length;
@@ -3901,8 +3905,10 @@ export class ChatView {
 		const summaryPrimary = running > 0 ? `Working for ${durationLabel}` : `Worked for ${durationLabel}`;
 		const summarySecondary = running > 0 ? `${total} running` : failed > 0 ? `${failed} failed` : `${total} complete`;
 		const hasFinalContent = Boolean(workflow.finalText || workflow.errorText);
-		const expanded = running > 0 || this.isToolWorkflowExpanded(workflow.id);
-		if (running === 0 && !this.isToolWorkflowExpanded(workflow.id)) {
+		const manualExpanded = this.isToolWorkflowExpanded(workflow.id);
+		const autoExpanded = running > 0 || (workflow.isTerminal && this.currentIsStreaming() && !hasFinalContent);
+		const expanded = autoExpanded || manualExpanded;
+		if (!expanded) {
 			this.expandedToolGroupByWorkflowId.delete(workflow.id);
 		}
 
@@ -3913,7 +3919,7 @@ export class ChatView {
 						<button
 							class="tool-workflow-summary"
 							@click=${() => {
-								if (running > 0) return;
+								if (autoExpanded) return;
 								this.toggleToolWorkflowExpanded(workflow.id);
 							}}
 						>

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3902,7 +3902,7 @@ export class ChatView {
 				? (running > 0 ? Date.now() : Math.max(workflow.endedAt, workflow.startedAt)) - workflow.startedAt
 				: 0;
 		const durationLabel = durationMs > 0 ? formatDuration(durationMs) : "0s";
-		const summaryPrimary = running > 0 ? `Working for ${durationLabel}` : `Worked for ${durationLabel}`;
+		const summaryPrimary = durationLabel;
 		const summarySecondary = running > 0 ? `${total} running` : failed > 0 ? `${failed} failed` : `${total} complete`;
 		const hasFinalContent = Boolean(workflow.finalText || workflow.errorText);
 		const manualExpanded = this.isToolWorkflowExpanded(workflow.id);
@@ -3951,7 +3951,7 @@ export class ChatView {
 													class="tool-workflow-line"
 													@click=${() => this.toggleToolGroupExpanded(workflow.id, group.id)}
 												>
-													<span class="tool-workflow-line-text">${this.renderToolPreview(group.preview)}</span>
+													<span class="tool-workflow-line-text ${groupRunning ? "running" : ""}">${this.renderToolPreview(group.preview)}</span>
 													${count > 1 ? html`<span class="tool-workflow-count">×${count}</span>` : nothing}
 												</button>
 												${groupExpanded
@@ -3966,7 +3966,7 @@ export class ChatView {
 										`;
 									})}
 								</div>
-								${hasFinalContent ? html`<div class="assistant-final-divider"><span>Final message</span></div>` : nothing}
+								${hasFinalContent ? html`<div class="assistant-final-divider"><span>Agent</span></div>` : nothing}
 								${workflow.finalText
 									? html`<div class="assistant-content ${workflow.isStreaming ? "streaming-cursor" : ""}"><markdown-block .content=${workflow.finalText}></markdown-block></div>`
 									: nothing}

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3948,9 +3948,10 @@ export class ChatView {
 										return html`
 											<div class="tool-workflow-item">
 												<button
-													class="tool-workflow-line"
+													class="tool-workflow-line ${groupRunning ? "running" : ""}"
 													@click=${() => this.toggleToolGroupExpanded(workflow.id, group.id)}
 												>
+													${groupRunning ? html`<span class="tool-workflow-running-indicator" aria-hidden="true">•••</span>` : nothing}
 													<span class="tool-workflow-line-text ${groupRunning ? "running" : ""}">${this.renderToolPreview(group.preview)}</span>
 													${count > 1 ? html`<span class="tool-workflow-count">×${count}</span>` : nothing}
 												</button>

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3723,7 +3723,7 @@ export class ChatView {
 	private renderThinking(msg: UiMessage): TemplateResult | typeof nothing {
 		if (!msg.thinking) return nothing;
 		const expanded = msg.thinkingExpanded ?? false;
-		const label = "thinking…";
+		const label = "Thinking…";
 		const toggleClass = `thinking-toggle ${msg.isStreaming ? "animating" : "done"}`;
 		const thinkingText = this.normalizeThinkingText(msg.thinking.replace(/^\s+/, ""));
 		if (!thinkingText) return nothing;
@@ -3855,6 +3855,14 @@ export class ChatView {
 		return html`${verb} <span class="tool-file-target">${target}</span>`;
 	}
 
+	private isThinkingOnlyAssistantMessage(message: UiMessage | undefined): boolean {
+		if (!message || message.role !== "assistant") return false;
+		if (message.toolCalls.length > 0) return false;
+		if (message.text.trim().length > 0) return false;
+		if ((message.errorText ?? "").trim().length > 0) return false;
+		return Boolean((message.thinking ?? "").trim());
+	}
+
 	private collectAssistantWorkflow(startIndex: number): {
 		workflow: {
 			id: string;
@@ -3878,6 +3886,14 @@ export class ChatView {
 		let sawTools = false;
 		let consumedFinalMessage = false;
 		let cursor = startIndex;
+
+		const leadingThinking: UiMessage[] = [];
+		for (let index = startIndex - 1; index >= 0; index -= 1) {
+			const candidate = this.messages[index];
+			if (!this.isThinkingOnlyAssistantMessage(candidate)) break;
+			leadingThinking.unshift(candidate);
+		}
+		grouped.push(...leadingThinking);
 
 		while (cursor < this.messages.length) {
 			const candidate = this.messages[cursor];
@@ -3937,8 +3953,7 @@ export class ChatView {
 			.map((entry) => (entry.errorText ?? "").trim())
 			.filter(Boolean)
 			.join("\n");
-		const firstId = grouped[0]?.id ?? uid("workflow");
-		const workflowId = `workflow-${firstId}`;
+		const workflowId = `workflow-${start.id}`;
 
 		const nextIndex = Math.max(startIndex + 1, cursor);
 		return {
@@ -4016,9 +4031,9 @@ export class ChatView {
 								${workflow.thinkingText
 									? html`
 										<div class="tool-workflow-thinking">
-											<button class="tool-workflow-thinking-toggle ${autoExpanded ? "animating" : "done"}" @click=${() => this.toggleWorkflowThinkingExpanded(workflow.id)}>
+											<button class="tool-workflow-thinking-toggle ${running > 0 ? "animating" : "done"}" @click=${() => this.toggleWorkflowThinkingExpanded(workflow.id)}>
 												<span class="tool-workflow-thinking-caret">${thinkingExpanded ? "▾" : "▸"}</span>
-												${"thinking…".split("").map((char, index) => html`<span class="thinking-char" style=${`--thinking-char-index:${index};`}>${char}</span>`)}
+												<span class="tool-workflow-thinking-text">Thinking…</span>
 											</button>
 											${thinkingExpanded ? html`<div class="tool-workflow-thinking-content">${workflow.thinkingText}</div>` : nothing}
 										</div>
@@ -4079,6 +4094,16 @@ export class ChatView {
 		const rows: TemplateResult[] = [];
 		for (let index = 0; index < this.messages.length; index += 1) {
 			const msg = this.messages[index];
+			if (this.isThinkingOnlyAssistantMessage(msg)) {
+				let lookahead = index + 1;
+				while (lookahead < this.messages.length && this.isThinkingOnlyAssistantMessage(this.messages[lookahead])) {
+					lookahead += 1;
+				}
+				const next = this.messages[lookahead];
+				if (next?.role === "assistant" && next.toolCalls.length > 0) {
+					continue;
+				}
+			}
 			if (msg.role === "assistant" && msg.toolCalls.length > 0) {
 				const workflowCandidate = this.collectAssistantWorkflow(index);
 				if (workflowCandidate) {

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -438,6 +438,7 @@ export class ChatView {
 	private autoFollowChat = true;
 	private expandedToolWorkflowIds = new Set<string>();
 	private expandedToolGroupByWorkflowId = new Map<string, string>();
+	private expandedWorkflowThinkingIds = new Set<string>();
 	private selectedSkillDraft: ComposerSkillDraft | null = null;
 	private slashPaletteOpen = false;
 	private slashPaletteQuery = "";
@@ -585,6 +586,7 @@ export class ChatView {
 		this.slashSkillsUpdatedAt = 0;
 		this.expandedToolWorkflowIds.clear();
 		this.expandedToolGroupByWorkflowId.clear();
+		this.expandedWorkflowThinkingIds.clear();
 		this.compactionCycle = null;
 		this.keepWorkflowExpandedUntilAssistantText = false;
 		if (!path) {
@@ -618,6 +620,7 @@ export class ChatView {
 		this.slashPaletteIndex = 0;
 		this.expandedToolWorkflowIds.clear();
 		this.expandedToolGroupByWorkflowId.clear();
+		this.expandedWorkflowThinkingIds.clear();
 		this.compactionCycle = null;
 		this.runHasAssistantText = false;
 		this.runSawToolActivity = false;
@@ -1029,6 +1032,7 @@ export class ChatView {
 			this.messages = this.mapBackendMessages(backendMessages);
 			this.expandedToolWorkflowIds.clear();
 			this.expandedToolGroupByWorkflowId.clear();
+			this.expandedWorkflowThinkingIds.clear();
 			this.forkEntryIdByMessageId.clear();
 			this.lastAssistantContextTokens = this.deriveLatestAssistantContextTokens(backendMessages);
 			if (state.isStreaming) {
@@ -3811,8 +3815,22 @@ export class ChatView {
 		if (this.expandedToolWorkflowIds.has(workflowId)) {
 			this.expandedToolWorkflowIds.delete(workflowId);
 			this.expandedToolGroupByWorkflowId.delete(workflowId);
+			this.expandedWorkflowThinkingIds.delete(workflowId);
 		} else {
 			this.expandedToolWorkflowIds.add(workflowId);
+		}
+		this.render();
+	}
+
+	private isWorkflowThinkingExpanded(workflowId: string): boolean {
+		return this.expandedWorkflowThinkingIds.has(workflowId);
+	}
+
+	private toggleWorkflowThinkingExpanded(workflowId: string): void {
+		if (this.expandedWorkflowThinkingIds.has(workflowId)) {
+			this.expandedWorkflowThinkingIds.delete(workflowId);
+		} else {
+			this.expandedWorkflowThinkingIds.add(workflowId);
 		}
 		this.render();
 	}
@@ -3968,8 +3986,10 @@ export class ChatView {
 		const manualExpanded = this.isToolWorkflowExpanded(workflow.id);
 		const autoExpanded = workflow.isTerminal && this.keepWorkflowExpandedUntilAssistantText && (running > 0 || this.runSawToolActivity);
 		const expanded = autoExpanded || manualExpanded;
+		const thinkingExpanded = this.isWorkflowThinkingExpanded(workflow.id);
 		if (!expanded) {
 			this.expandedToolGroupByWorkflowId.delete(workflow.id);
+			this.expandedWorkflowThinkingIds.delete(workflow.id);
 		}
 
 		return html`
@@ -3996,10 +4016,11 @@ export class ChatView {
 								${workflow.thinkingText
 									? html`
 										<div class="tool-workflow-thinking">
-											<div class="tool-workflow-thinking-label ${autoExpanded ? "animating" : "done"}">
+											<button class="tool-workflow-thinking-toggle ${autoExpanded ? "animating" : "done"}" @click=${() => this.toggleWorkflowThinkingExpanded(workflow.id)}>
+												<span class="tool-workflow-thinking-caret">${thinkingExpanded ? "▾" : "▸"}</span>
 												${"thinking…".split("").map((char, index) => html`<span class="thinking-char" style=${`--thinking-char-index:${index};`}>${char}</span>`)}
-											</div>
-											<div class="tool-workflow-thinking-content">${workflow.thinkingText}</div>
+											</button>
+											${thinkingExpanded ? html`<div class="tool-workflow-thinking-content">${workflow.thinkingText}</div>` : nothing}
 										</div>
 									`
 									: nothing}

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -436,7 +436,7 @@ export class ChatView {
 	private historyQuery = "";
 	private historyRoleFilter: UiRole | "all" = "all";
 	private autoFollowChat = true;
-	private expandedToolWorkflowMessageIds = new Set<string>();
+	private expandedToolWorkflowIds = new Set<string>();
 	private selectedSkillDraft: ComposerSkillDraft | null = null;
 	private slashPaletteOpen = false;
 	private slashPaletteQuery = "";
@@ -580,7 +580,7 @@ export class ChatView {
 		this.slashPaletteQuery = "";
 		this.slashPaletteIndex = 0;
 		this.slashSkillsUpdatedAt = 0;
-		this.expandedToolWorkflowMessageIds.clear();
+		this.expandedToolWorkflowIds.clear();
 		this.compactionCycle = null;
 		if (!path) {
 			this.bindingStatusText = null;
@@ -610,7 +610,7 @@ export class ChatView {
 		this.slashPaletteOpen = false;
 		this.slashPaletteQuery = "";
 		this.slashPaletteIndex = 0;
-		this.expandedToolWorkflowMessageIds.clear();
+		this.expandedToolWorkflowIds.clear();
 		this.compactionCycle = null;
 		this.runHasAssistantText = false;
 		this.clearWorkingStatusTimer(true);
@@ -1016,7 +1016,7 @@ export class ChatView {
 			this.lastBackendRefreshError = null;
 			this.onStateChange?.(state);
 			this.messages = this.mapBackendMessages(backendMessages);
-			this.expandedToolWorkflowMessageIds.clear();
+			this.expandedToolWorkflowIds.clear();
 			this.forkEntryIdByMessageId.clear();
 			this.lastAssistantContextTokens = this.deriveLatestAssistantContextTokens(backendMessages);
 			if (state.isStreaming) {
@@ -3641,12 +3641,33 @@ export class ChatView {
 		`;
 	}
 
+	private normalizeThinkingText(value: string): string {
+		let text = value.replace(/^\s*thinking\.\.\.\s*/i, "").trim();
+		if (!text) return "";
+		const paragraphs = text
+			.split(/\n{2,}/)
+			.map((part) => part.trim())
+			.filter(Boolean);
+		const deduped: string[] = [];
+		for (const part of paragraphs) {
+			if (deduped[deduped.length - 1] === part) continue;
+			deduped.push(part);
+		}
+		text = deduped.join("\n\n").trim();
+		const half = Math.floor(text.length / 2);
+		if (text.length > 40 && text.length % 2 === 0 && text.slice(0, half) === text.slice(half)) {
+			text = text.slice(0, half).trim();
+		}
+		return text;
+	}
+
 	private renderThinking(msg: UiMessage): TemplateResult | typeof nothing {
 		if (!msg.thinking) return nothing;
 		const expanded = msg.thinkingExpanded ?? false;
 		const label = "thinking…";
 		const toggleClass = `thinking-toggle ${msg.isStreaming ? "animating" : "done"}`;
-		const thinkingText = msg.thinking.replace(/^\s+/, "");
+		const thinkingText = this.normalizeThinkingText(msg.thinking.replace(/^\s+/, ""));
+		if (!thinkingText) return nothing;
 		return html`
 			<div class="thinking-block ${expanded ? "expanded" : ""}">
 				<button
@@ -3727,138 +3748,231 @@ export class ChatView {
 		return groups;
 	}
 
-	private isToolWorkflowExpanded(msg: UiMessage): boolean {
-		if (this.expandedToolWorkflowMessageIds.has(msg.id)) return true;
-		return msg.toolCalls.some((tc) => tc.isRunning);
+	private isToolWorkflowExpanded(workflowId: string): boolean {
+		return this.expandedToolWorkflowIds.has(workflowId);
 	}
 
-	private toggleToolWorkflowExpanded(msg: UiMessage): void {
-		if (this.isToolWorkflowExpanded(msg)) {
-			this.expandedToolWorkflowMessageIds.delete(msg.id);
-			for (const tc of msg.toolCalls) tc.isExpanded = false;
+	private toggleToolWorkflowExpanded(workflowId: string): void {
+		if (this.expandedToolWorkflowIds.has(workflowId)) {
+			this.expandedToolWorkflowIds.delete(workflowId);
 		} else {
-			this.expandedToolWorkflowMessageIds.add(msg.id);
+			this.expandedToolWorkflowIds.add(workflowId);
 		}
 		this.render();
 	}
 
-	private toggleToolCallGroupExpanded(group: ToolCallGroup): void {
-		const expanded = group.calls.some((tc) => tc.isExpanded);
-		for (const tc of group.calls) tc.isExpanded = !expanded;
-		this.render();
+	private renderToolPreview(preview: string): TemplateResult {
+		const match = preview.match(/^(Edited|Wrote|Read)\s+(.+)$/);
+		if (!match) return html`${preview}`;
+		const [, verb, target] = match;
+		return html`${verb} <span class="tool-file-target">${target}</span>`;
 	}
 
-	private renderToolWorkflow(msg: UiMessage): TemplateResult | typeof nothing {
-		if (msg.toolCalls.length === 0) return nothing;
-		const total = msg.toolCalls.length;
-		const running = msg.toolCalls.filter((tc) => tc.isRunning).length;
-		const failed = msg.toolCalls.filter((tc) => tc.isError).length;
-		const expanded = this.isToolWorkflowExpanded(msg);
-		const groups = this.buildToolCallGroups(msg.toolCalls);
-		const startedAt = msg.toolCalls.reduce((min, tc) => {
+	private collectAssistantWorkflow(startIndex: number): {
+		workflow: {
+			id: string;
+			messages: UiMessage[];
+			toolCalls: ToolCallBlock[];
+			toolGroups: ToolCallGroup[];
+			finalText: string;
+			errorText: string;
+			isStreaming: boolean;
+			startedAt: number;
+			endedAt: number;
+		};
+		nextIndex: number;
+	} | null {
+		const start = this.messages[startIndex];
+		if (!start || start.role !== "assistant" || start.toolCalls.length === 0) return null;
+
+		const grouped: UiMessage[] = [];
+		let sawTools = false;
+		let consumedFinalMessage = false;
+		let cursor = startIndex;
+
+		while (cursor < this.messages.length) {
+			const candidate = this.messages[cursor];
+			if (candidate.role !== "assistant") break;
+			const hasTools = candidate.toolCalls.length > 0;
+			const hasText = candidate.text.trim().length > 0;
+			const hasThinking = Boolean((candidate.thinking ?? "").trim());
+			const hasError = Boolean((candidate.errorText ?? "").trim());
+
+			if (hasTools) {
+				grouped.push(candidate);
+				sawTools = true;
+				cursor += 1;
+				continue;
+			}
+
+			if (!sawTools) break;
+
+			if (!consumedFinalMessage && (hasText || hasError)) {
+				grouped.push(candidate);
+				consumedFinalMessage = true;
+				cursor += 1;
+				break;
+			}
+
+			if (!consumedFinalMessage && hasThinking) {
+				grouped.push(candidate);
+				cursor += 1;
+				continue;
+			}
+
+			break;
+		}
+
+		const toolCalls = grouped.flatMap((entry) => entry.toolCalls);
+		if (toolCalls.length === 0) return null;
+
+		const startedAt = toolCalls.reduce((min, tc) => {
 			if (!tc.startedAt) return min;
 			return min === 0 ? tc.startedAt : Math.min(min, tc.startedAt);
 		}, 0);
-		const endedAt = msg.toolCalls.reduce((max, tc) => {
+		const endedAt = toolCalls.reduce((max, tc) => {
 			if (!tc.endedAt) return max;
 			return Math.max(max, tc.endedAt);
 		}, 0);
-		const duration = startedAt > 0 ? formatDuration((running > 0 ? Date.now() : Math.max(endedAt, startedAt)) - startedAt) : null;
-		const primaryLabel = running > 0 ? `Working with ${total} tool call${total === 1 ? "" : "s"}` : duration ? `Worked for ${duration}` : `Worked with ${total} tool call${total === 1 ? "" : "s"}`;
-		const secondaryLabel = running > 0 ? "in progress" : failed > 0 ? `${failed} failed` : `${total} complete`;
-		const showSummary = total > 1 || groups.length > 1;
-		const showDetails = showSummary ? expanded : true;
+		const finalText = grouped
+			.map((entry) => entry.text.trim())
+			.filter(Boolean)
+			.join("\n\n");
+		const errorText = grouped
+			.map((entry) => (entry.errorText ?? "").trim())
+			.filter(Boolean)
+			.join("\n");
+		const firstId = grouped[0]?.id ?? uid("workflow");
+		const lastId = grouped[grouped.length - 1]?.id ?? firstId;
+		const workflowId = `workflow-${firstId}-${lastId}`;
 
-		const workflowList = html`
-			<div class="tool-workflow-list">
-				${groups.map((group) => {
-					const count = group.calls.length;
-					const groupExpanded = group.calls.some((tc) => tc.isExpanded);
-					const groupRunning = group.calls.some((tc) => tc.isRunning);
-					const groupFailed = group.calls.some((tc) => tc.isError);
-					return html`
-						<div class="tool-workflow-item ${groupExpanded ? "expanded" : ""}">
-							<button class="tool-workflow-line" @click=${() => this.toggleToolCallGroupExpanded(group)}>
-								<span class="tool-workflow-line-text">${group.preview}</span>
-								${count > 1 ? html`<span class="tool-workflow-count">×${count}</span>` : nothing}
-								<span class="tool-workflow-state ${groupRunning ? "running" : groupFailed ? "error" : "done"}">${groupRunning ? "running" : groupFailed ? "failed" : "done"}</span>
-								<span class="tool-workflow-caret">${groupExpanded ? "▾" : "▸"}</span>
-							</button>
-							${groupExpanded
-								? html`
-									<div class="tool-workflow-details">
-										${group.calls.map((call, index) => {
-											const output = (call.streamingOutput ?? call.result ?? "").trimEnd();
-											const hasOutput = output.length > 0;
-											const placeholder = call.isRunning ? "Waiting for tool output…" : "No output reported.";
-											return html`
-												<div class="tool-workflow-detail-run">
-													${group.calls.length > 1 ? html`<div class="tool-workflow-detail-label">Run ${index + 1}</div>` : nothing}
-													<pre class="tool-workflow-output ${hasOutput ? "" : "tool-output-empty"}">${hasOutput ? output : placeholder}${call.isRunning
-														? html`<span class="streaming-inline"></span>`
-														: nothing}</pre>
-												</div>
-											`;
-										})}
-									</div>
-								`
-								: nothing}
-						</div>
-					`;
-				})}
-			</div>
-		`;
+		return {
+			workflow: {
+				id: workflowId,
+				messages: grouped,
+				toolCalls,
+				toolGroups: this.buildToolCallGroups(toolCalls),
+				finalText,
+				errorText,
+				isStreaming: grouped.some((entry) => entry.isStreaming),
+				startedAt,
+				endedAt,
+			},
+			nextIndex: Math.max(startIndex + 1, cursor),
+		};
+	}
 
-		if (!showSummary) {
-			return html`<div class="tool-workflow tool-workflow-flat">${workflowList}</div>`;
-		}
+	private renderAssistantWorkflow(workflow: {
+		id: string;
+		messages: UiMessage[];
+		toolCalls: ToolCallBlock[];
+		toolGroups: ToolCallGroup[];
+		finalText: string;
+		errorText: string;
+		isStreaming: boolean;
+		startedAt: number;
+		endedAt: number;
+	}): TemplateResult {
+		const total = workflow.toolCalls.length;
+		const running = workflow.toolCalls.filter((tc) => tc.isRunning).length;
+		const failed = workflow.toolCalls.filter((tc) => tc.isError).length;
+		const expanded = this.isToolWorkflowExpanded(workflow.id);
+		const durationMs =
+			workflow.startedAt > 0
+				? (running > 0 ? Date.now() : Math.max(workflow.endedAt, workflow.startedAt)) - workflow.startedAt
+				: 0;
+		const durationLabel = durationMs > 0 ? formatDuration(durationMs) : "0s";
+		const summaryPrimary = running > 0 ? `Working for ${durationLabel}` : `Worked for ${durationLabel}`;
+		const summarySecondary = running > 0 ? `${total} running` : failed > 0 ? `${failed} failed` : `${total} complete`;
+		const showMissingWrapUp = !workflow.finalText && !workflow.errorText && running === 0 && !workflow.isStreaming;
 
 		return html`
-			<div class="tool-workflow ${expanded ? "expanded" : ""}">
-				<button class="tool-workflow-summary" @click=${() => this.toggleToolWorkflowExpanded(msg)}>
-					<span class="workflow-divider" aria-hidden="true"></span>
-					<span class="workflow-summary-label">${primaryLabel}</span>
-					<span class="workflow-summary-meta">${secondaryLabel}</span>
-					<span class="workflow-summary-caret">${expanded ? "▾" : "▸"}</span>
-					<span class="workflow-divider" aria-hidden="true"></span>
-				</button>
-				${showDetails ? workflowList : nothing}
+			<div class="chat-row assistant-row assistant-workflow-row" data-message-id=${workflow.id}>
+				<div class="message-shell assistant-message-shell">
+					<div class="assistant-block">
+						<button class="tool-workflow-summary" @click=${() => this.toggleToolWorkflowExpanded(workflow.id)}>
+							<span class="workflow-divider" aria-hidden="true"></span>
+							<span class="workflow-summary-label">${summaryPrimary}</span>
+							<span class="workflow-summary-meta">${summarySecondary}</span>
+							<span class="workflow-divider" aria-hidden="true"></span>
+						</button>
+						${expanded
+							? html`
+								<div class="tool-workflow-list">
+									${workflow.toolGroups.map((group) => {
+										const count = group.calls.length;
+										const groupRunning = group.calls.some((tc) => tc.isRunning);
+										const groupFailed = group.calls.some((tc) => tc.isError);
+										const output =
+											[...group.calls]
+												.reverse()
+												.map((call) => (call.streamingOutput ?? call.result ?? "").trim())
+												.find((value) => value.length > 0) ?? "";
+										const showOutput = output.length > 0;
+										return html`
+											<div class="tool-workflow-item">
+												<div class="tool-workflow-line ${groupRunning ? "running" : groupFailed ? "error" : "done"}">
+													<span class="tool-workflow-line-text">${this.renderToolPreview(group.preview)}</span>
+													${count > 1 ? html`<span class="tool-workflow-count">×${count}</span>` : nothing}
+													<span class="tool-workflow-state ${groupRunning ? "running" : groupFailed ? "error" : "done"}">${groupRunning ? "running" : groupFailed ? "failed" : "done"}</span>
+												</div>
+												${showOutput ? html`<pre class="tool-workflow-output">${output}</pre>` : nothing}
+											</div>
+										`;
+									})}
+								</div>
+								${workflow.finalText || workflow.errorText ? html`<div class="assistant-final-divider"><span>Final message</span></div>` : nothing}
+								${workflow.finalText
+									? html`<div class="assistant-content ${workflow.isStreaming ? "streaming-cursor" : ""}"><markdown-block .content=${workflow.finalText}></markdown-block></div>`
+									: nothing}
+								${workflow.errorText ? html`<div class="assistant-error-line">${workflow.errorText}</div>` : nothing}
+								${showMissingWrapUp ? html`<div class="assistant-wrapup-missing">No final message returned for this tool run.</div>` : nothing}
+							`
+							: nothing}
+					</div>
+				</div>
 			</div>
 		`;
 	}
 
-	private hasAssistantTextAfter(messages: UiMessage[], index: number): boolean {
-		for (let i = index + 1; i < messages.length; i += 1) {
-			const candidate = messages[i];
-			if (candidate.role !== "assistant") continue;
-			if (candidate.text.trim().length > 0) return true;
+	private renderMessageTimeline(): TemplateResult[] {
+		const rows: TemplateResult[] = [];
+		for (let index = 0; index < this.messages.length; index += 1) {
+			const msg = this.messages[index];
+			if (msg.role === "assistant" && msg.toolCalls.length > 0) {
+				const workflowCandidate = this.collectAssistantWorkflow(index);
+				if (workflowCandidate) {
+					rows.push(this.renderAssistantWorkflow(workflowCandidate.workflow));
+					index = workflowCandidate.nextIndex - 1;
+					continue;
+				}
+			}
+			if (msg.role === "user") {
+				rows.push(this.renderUserMessage(msg));
+				continue;
+			}
+			if (msg.role === "assistant") {
+				rows.push(this.renderAssistantMessage(msg));
+				continue;
+			}
+			rows.push(this.renderSystemMessage(msg));
 		}
-		return false;
+		return rows;
 	}
 
-	private renderAssistantMessage(msg: UiMessage, context: { previous: UiMessage | null; index: number; all: UiMessage[] }): TemplateResult {
+	private renderAssistantMessage(msg: UiMessage): TemplateResult {
 		const canCopy = Boolean(msg.text.trim().length > 0 || (msg.errorText ?? "").trim().length > 0);
 		const errorLine = (msg.errorText ?? "").trim();
 		const formattedErrorLine = errorLine
 			? (/^error\b[:\s-]*/i.test(errorLine) ? errorLine : `Error: ${errorLine}`)
 			: "";
-		const hasToolWorkflow = msg.toolCalls.length > 0;
-		const hasText = msg.text.trim().length > 0;
-		const previousHasTools = Boolean(context.previous?.role === "assistant" && context.previous.toolCalls.length > 0);
-		const showFinalDivider = hasText && (hasToolWorkflow || previousHasTools);
-		const shouldRenderThinking = Boolean(msg.thinking) && !(hasToolWorkflow && !hasText);
-		const hasLaterAssistantText = this.hasAssistantTextAfter(context.all, context.index);
-		const showMissingWrapUp = hasToolWorkflow && !hasText && !msg.isStreaming && !this.currentIsStreaming() && !hasLaterAssistantText;
 
 		return html`
-			<div class="chat-row assistant-row ${hasToolWorkflow && !hasText ? "assistant-tool-only-row" : ""}" data-message-id=${msg.id}>
+			<div class="chat-row assistant-row" data-message-id=${msg.id}>
 				<div class="message-shell assistant-message-shell">
 					<div class="assistant-block">
-						${hasToolWorkflow ? this.renderToolWorkflow(msg) : nothing}
-						${shouldRenderThinking ? this.renderThinking(msg) : nothing}
-						${showFinalDivider ? html`<div class="assistant-final-divider"><span>Final message</span></div>` : nothing}
-						${showMissingWrapUp ? html`<div class="assistant-wrapup-missing">No final message returned for this tool run.</div>` : nothing}
-						${hasText
+						${this.renderThinking(msg)}
+						${msg.text
 							? html`
 								<div class="assistant-content ${msg.isStreaming ? "streaming-cursor" : ""}">
 									<markdown-block .content=${msg.text}></markdown-block>
@@ -5026,17 +5140,7 @@ export class ChatView {
 					${!hasProject
 						? this.renderWelcomeDashboard()
 						: hasMessages
-							? html`${this.messages.map((m, index, all) => {
-									if (m.role === "user") return this.renderUserMessage(m);
-									if (m.role === "assistant") {
-										return this.renderAssistantMessage(m, {
-											previous: index > 0 ? all[index - 1] ?? null : null,
-											index,
-											all,
-										});
-									}
-									return this.renderSystemMessage(m);
-								})}`
+							? html`${this.renderMessageTimeline()}`
 							: this.bindingStatusText
 								? this.renderBindingState()
 								: this.renderEmptyState()}

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -48,6 +48,7 @@ interface UiMessage {
 	thinking?: string;
 	thinkingExpanded?: boolean;
 	thinkingScrollTop?: number;
+	isThinkingStreaming?: boolean;
 	isStreaming?: boolean;
 	errorText?: string;
 	deliveryMode?: DeliveryMode;
@@ -1171,6 +1172,7 @@ export class ChatView {
 						text,
 						thinking: thinking || undefined,
 						thinkingExpanded: this.allThinkingExpanded,
+						isThinkingStreaming: false,
 						toolCalls,
 					});
 					break;
@@ -2299,6 +2301,7 @@ export class ChatView {
 				const last = this.messages[this.messages.length - 1];
 				if (last && last.role === "assistant") {
 					last.isStreaming = false;
+					last.isThinkingStreaming = false;
 				}
 				this.retryStatus = "";
 				const runError = this.extractRuntimeErrorMessage(event);
@@ -2343,6 +2346,7 @@ export class ChatView {
 						errorText: assistantError || undefined,
 						toolCalls: [],
 						isStreaming: true,
+						isThinkingStreaming: false,
 						thinkingExpanded: this.allThinkingExpanded,
 					});
 					if (initialText.trim().length > 0) {
@@ -2393,6 +2397,7 @@ export class ChatView {
 				if (subtype === "error") {
 					if (last?.role === "assistant") {
 						last.isStreaming = false;
+						last.isThinkingStreaming = false;
 						const streamError = this.extractRuntimeErrorMessage(assistantEvent) || this.extractRuntimeErrorMessage(event);
 						if (streamError) {
 							last.errorText = streamError;
@@ -2407,6 +2412,7 @@ export class ChatView {
 				if (subtype === "text_delta") {
 					const partialText = this.extractAssistantPartialContent(assistantEvent, "text");
 					last.text = this.mergeStreamingText(last.text, partialText, assistantEvent.delta);
+					last.isThinkingStreaming = false;
 					if (last.text.trim().length > 0) {
 						this.runHasAssistantText = true;
 						if (this.runSawToolActivity) {
@@ -2420,11 +2426,13 @@ export class ChatView {
 					const partialThinking = this.extractAssistantPartialContent(assistantEvent, "thinking");
 					const currentThinking = last.thinking || "";
 					last.thinking = this.mergeStreamingText(currentThinking, partialThinking, assistantEvent.delta);
+					last.isThinkingStreaming = true;
 					this.scheduleStreamingUiReconcile(1800);
 					if ((last.thinking?.length || 0) % 100 === 0) this.render();
 				} else if (subtype === "toolcall_end") {
 					this.runSawToolActivity = true;
 					this.keepWorkflowExpandedUntilAssistantText = true;
+					last.isThinkingStreaming = false;
 					const tc = assistantEvent.toolCall as Record<string, unknown>;
 					if (tc) {
 						const rawId = typeof tc.id === "string" ? tc.id.trim() : "";
@@ -2459,6 +2467,7 @@ export class ChatView {
 				if (turnRole === "assistant") {
 					const last = this.messages[this.messages.length - 1];
 					if (last?.role === "assistant") {
+						last.isThinkingStreaming = false;
 						const turnError = this.extractAssistantMessageError(turnMessage);
 						if (turnError) {
 							last.errorText = turnError;
@@ -2473,6 +2482,7 @@ export class ChatView {
 				const last = this.messages[this.messages.length - 1];
 				if (last?.role === "assistant") {
 					last.isStreaming = false;
+					last.isThinkingStreaming = false;
 					const completed = event.message as Record<string, unknown> | undefined;
 					const completedError = this.extractAssistantMessageError(completed);
 					if (completedError) {
@@ -3226,6 +3236,7 @@ export class ChatView {
 		for (const message of this.messages) {
 			if (message.role !== "assistant") continue;
 			message.isStreaming = false;
+			message.isThinkingStreaming = false;
 			for (const toolCall of message.toolCalls) {
 				toolCall.isRunning = false;
 				toolCall.streamingOutput = undefined;
@@ -3880,20 +3891,15 @@ export class ChatView {
 		nextIndex: number;
 	} | null {
 		const start = this.messages[startIndex];
-		if (!start || start.role !== "assistant" || start.toolCalls.length === 0) return null;
+		if (!start || start.role !== "assistant") return null;
+		const startIsThinkingOnly = this.isThinkingOnlyAssistantMessage(start);
+		const startHasTools = start.toolCalls.length > 0;
+		if (!startIsThinkingOnly && !startHasTools) return null;
 
 		const grouped: UiMessage[] = [];
 		let sawTools = false;
 		let consumedFinalMessage = false;
 		let cursor = startIndex;
-
-		const leadingThinking: UiMessage[] = [];
-		for (let index = startIndex - 1; index >= 0; index -= 1) {
-			const candidate = this.messages[index];
-			if (!this.isThinkingOnlyAssistantMessage(candidate)) break;
-			leadingThinking.unshift(candidate);
-		}
-		grouped.push(...leadingThinking);
 
 		while (cursor < this.messages.length) {
 			const candidate = this.messages[cursor];
@@ -3910,7 +3916,14 @@ export class ChatView {
 				continue;
 			}
 
-			if (!sawTools) break;
+			if (!sawTools) {
+				if (hasThinking && !hasText && !hasError) {
+					grouped.push(candidate);
+					cursor += 1;
+					continue;
+				}
+				break;
+			}
 
 			if (!consumedFinalMessage && (hasText || hasError)) {
 				grouped.push(candidate);
@@ -3928,8 +3941,11 @@ export class ChatView {
 			break;
 		}
 
+		if (grouped.length === 0) return null;
 		const toolCalls = grouped.flatMap((entry) => entry.toolCalls);
-		if (toolCalls.length === 0) return null;
+		const isProvisionalWorkflow =
+			toolCalls.length === 0 && this.currentIsStreaming() && this.keepWorkflowExpandedUntilAssistantText && !this.runHasAssistantText;
+		if (toolCalls.length === 0 && !isProvisionalWorkflow) return null;
 
 		const startedAt = toolCalls.reduce((min, tc) => {
 			if (!tc.startedAt) return min;
@@ -3953,7 +3969,7 @@ export class ChatView {
 			.map((entry) => (entry.errorText ?? "").trim())
 			.filter(Boolean)
 			.join("\n");
-		const workflowId = `workflow-${start.id}`;
+		const workflowId = `workflow-${grouped[0]?.id ?? start.id}`;
 
 		const nextIndex = Math.max(startIndex + 1, cursor);
 		return {
@@ -3996,12 +4012,13 @@ export class ChatView {
 				: 0;
 		const durationLabel = durationMs > 0 ? formatDuration(durationMs) : "0s";
 		const summaryPrimary = durationLabel;
-		const summarySecondary = running > 0 ? `${total} running` : failed > 0 ? `${failed} failed` : `${total} complete`;
+		const summarySecondary = total === 0 ? "thinking" : running > 0 ? `${total} running` : failed > 0 ? `${failed} failed` : `${total} complete`;
 		const hasFinalContent = Boolean(workflow.finalText || workflow.errorText);
 		const manualExpanded = this.isToolWorkflowExpanded(workflow.id);
-		const autoExpanded = workflow.isTerminal && this.keepWorkflowExpandedUntilAssistantText && (running > 0 || this.runSawToolActivity);
+		const autoExpanded = workflow.isTerminal && this.keepWorkflowExpandedUntilAssistantText && (running > 0 || this.runSawToolActivity || total === 0);
 		const expanded = autoExpanded || manualExpanded;
 		const thinkingExpanded = this.isWorkflowThinkingExpanded(workflow.id);
+		const thinkingAnimating = running === 0 && workflow.messages.some((entry) => entry.isThinkingStreaming);
 		if (!expanded) {
 			this.expandedToolGroupByWorkflowId.delete(workflow.id);
 			this.expandedWorkflowThinkingIds.delete(workflow.id);
@@ -4031,8 +4048,7 @@ export class ChatView {
 								${workflow.thinkingText
 									? html`
 										<div class="tool-workflow-thinking">
-											<button class="tool-workflow-thinking-toggle ${running > 0 ? "animating" : "done"}" @click=${() => this.toggleWorkflowThinkingExpanded(workflow.id)}>
-												<span class="tool-workflow-thinking-caret">${thinkingExpanded ? "▾" : "▸"}</span>
+											<button class="tool-workflow-thinking-toggle ${thinkingAnimating ? "animating" : "done"}" @click=${() => this.toggleWorkflowThinkingExpanded(workflow.id)}>
 												<span class="tool-workflow-thinking-text">Thinking…</span>
 											</button>
 											${thinkingExpanded ? html`<div class="tool-workflow-thinking-content">${workflow.thinkingText}</div>` : nothing}
@@ -4094,17 +4110,7 @@ export class ChatView {
 		const rows: TemplateResult[] = [];
 		for (let index = 0; index < this.messages.length; index += 1) {
 			const msg = this.messages[index];
-			if (this.isThinkingOnlyAssistantMessage(msg)) {
-				let lookahead = index + 1;
-				while (lookahead < this.messages.length && this.isThinkingOnlyAssistantMessage(this.messages[lookahead])) {
-					lookahead += 1;
-				}
-				const next = this.messages[lookahead];
-				if (next?.role === "assistant" && next.toolCalls.length > 0) {
-					continue;
-				}
-			}
-			if (msg.role === "assistant" && msg.toolCalls.length > 0) {
+			if (msg.role === "assistant") {
 				const workflowCandidate = this.collectAssistantWorkflow(index);
 				if (workflowCandidate) {
 					rows.push(this.renderAssistantWorkflow(workflowCandidate.workflow));

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3671,8 +3671,26 @@ export class ChatView {
 		`;
 	}
 
+	private hasExpandedWorkflowInTimeline(): boolean {
+		for (let index = 0; index < this.messages.length; index += 1) {
+			const msg = this.messages[index];
+			if (msg.role !== "assistant") continue;
+			const workflowCandidate = this.collectAssistantWorkflow(index);
+			if (!workflowCandidate) continue;
+			const { expanded } = this.resolveWorkflowExpansionState(
+				workflowCandidate.workflow.id,
+				workflowCandidate.workflow.toolCalls,
+				workflowCandidate.workflow.isTerminal,
+			);
+			if (expanded) return true;
+			index = workflowCandidate.nextIndex - 1;
+		}
+		return false;
+	}
+
 	private shouldShowWorkingIndicator(): boolean {
 		if (!this.currentIsStreaming()) return false;
+		if (this.hasExpandedWorkflowInTimeline()) return false;
 		return !this.runHasAssistantText;
 	}
 
@@ -4001,6 +4019,29 @@ export class ChatView {
 		};
 	}
 
+	private resolveWorkflowExpansionState(
+		workflowId: string,
+		toolCalls: ToolCallBlock[],
+		isTerminal: boolean,
+	): {
+		total: number;
+		running: number;
+		autoExpanded: boolean;
+		expanded: boolean;
+	} {
+		const total = toolCalls.length;
+		const running = toolCalls.filter((tc) => tc.isRunning).length;
+		const manualExpanded = this.isToolWorkflowExpanded(workflowId);
+		const autoExpanded = isTerminal && this.keepWorkflowExpandedUntilAssistantText && (running > 0 || this.runSawToolActivity || total === 0);
+		const expanded = (autoExpanded && !this.collapsedAutoWorkflowIds.has(workflowId)) || manualExpanded;
+		return {
+			total,
+			running,
+			autoExpanded,
+			expanded,
+		};
+	}
+
 	private renderAssistantWorkflow(workflow: {
 		id: string;
 		messages: UiMessage[];
@@ -4014,8 +4055,11 @@ export class ChatView {
 		endedAt: number;
 		isTerminal: boolean;
 	}): TemplateResult {
-		const total = workflow.toolCalls.length;
-		const running = workflow.toolCalls.filter((tc) => tc.isRunning).length;
+		const { total, running, autoExpanded, expanded } = this.resolveWorkflowExpansionState(
+			workflow.id,
+			workflow.toolCalls,
+			workflow.isTerminal,
+		);
 		const failed = workflow.toolCalls.filter((tc) => tc.isError).length;
 		const durationMs =
 			workflow.startedAt > 0
@@ -4025,14 +4069,9 @@ export class ChatView {
 		const summaryPrimary = durationLabel;
 		const summarySecondary = running > 0 ? `${total} running` : failed > 0 ? `${failed} failed` : total > 0 ? `${total} complete` : "";
 		const hasFinalContent = Boolean(workflow.finalText || workflow.errorText);
-		const manualExpanded = this.isToolWorkflowExpanded(workflow.id);
-		const autoExpanded = workflow.isTerminal && this.keepWorkflowExpandedUntilAssistantText && (running > 0 || this.runSawToolActivity || total === 0);
-		if (!autoExpanded) {
-			this.collapsedAutoWorkflowIds.delete(workflow.id);
-		}
-		const expanded = (autoExpanded && !this.collapsedAutoWorkflowIds.has(workflow.id)) || manualExpanded;
 		const thinkingExpanded = this.isWorkflowThinkingExpanded(workflow.id);
 		const thinkingAnimating = running === 0 && workflow.messages.some((entry) => entry.isThinkingStreaming);
+		const activeGroupId = workflow.toolGroups.find((group) => group.calls.some((tc) => tc.isRunning))?.id ?? null;
 		if (!expanded) {
 			this.expandedToolGroupByWorkflowId.delete(workflow.id);
 			this.expandedWorkflowThinkingIds.delete(workflow.id);
@@ -4062,6 +4101,7 @@ export class ChatView {
 									? html`
 										<div class="tool-workflow-thinking">
 											<button class="tool-workflow-thinking-toggle ${thinkingAnimating ? "animating" : "done"}" @click=${() => this.toggleWorkflowThinkingExpanded(workflow.id)}>
+												${thinkingAnimating && !activeGroupId ? html`<span class="tool-workflow-inline-pi" aria-hidden="true">${piGlyphIcon()}</span>` : nothing}
 												<span class="tool-workflow-thinking-text">Thinking…</span>
 											</button>
 											${thinkingExpanded ? html`<div class="tool-workflow-thinking-content">${workflow.thinkingText}</div>` : nothing}
@@ -4086,6 +4126,7 @@ export class ChatView {
 													class="tool-workflow-line ${groupRunning ? "running" : ""}"
 													@click=${() => this.toggleToolGroupExpanded(workflow.id, group.id)}
 												>
+													${groupRunning && activeGroupId === group.id ? html`<span class="tool-workflow-inline-pi" aria-hidden="true">${piGlyphIcon()}</span>` : nothing}
 													<span class="tool-workflow-line-text ${groupRunning ? "running" : ""}">${this.renderToolPreview(group.preview)}</span>
 													${count > 1 ? html`<span class="tool-workflow-count">×${count}</span>` : nothing}
 												</button>

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -440,6 +440,7 @@ export class ChatView {
 	private expandedToolWorkflowIds = new Set<string>();
 	private expandedToolGroupByWorkflowId = new Map<string, string>();
 	private expandedWorkflowThinkingIds = new Set<string>();
+	private collapsedAutoWorkflowIds = new Set<string>();
 	private selectedSkillDraft: ComposerSkillDraft | null = null;
 	private slashPaletteOpen = false;
 	private slashPaletteQuery = "";
@@ -588,6 +589,7 @@ export class ChatView {
 		this.expandedToolWorkflowIds.clear();
 		this.expandedToolGroupByWorkflowId.clear();
 		this.expandedWorkflowThinkingIds.clear();
+		this.collapsedAutoWorkflowIds.clear();
 		this.compactionCycle = null;
 		this.keepWorkflowExpandedUntilAssistantText = false;
 		if (!path) {
@@ -622,6 +624,7 @@ export class ChatView {
 		this.expandedToolWorkflowIds.clear();
 		this.expandedToolGroupByWorkflowId.clear();
 		this.expandedWorkflowThinkingIds.clear();
+		this.collapsedAutoWorkflowIds.clear();
 		this.compactionCycle = null;
 		this.runHasAssistantText = false;
 		this.runSawToolActivity = false;
@@ -1034,6 +1037,7 @@ export class ChatView {
 			this.expandedToolWorkflowIds.clear();
 			this.expandedToolGroupByWorkflowId.clear();
 			this.expandedWorkflowThinkingIds.clear();
+			this.collapsedAutoWorkflowIds.clear();
 			this.forkEntryIdByMessageId.clear();
 			this.lastAssistantContextTokens = this.deriveLatestAssistantContextTokens(backendMessages);
 			if (state.isStreaming) {
@@ -2281,6 +2285,7 @@ export class ChatView {
 				this.runHasAssistantText = false;
 				this.runSawToolActivity = false;
 				this.keepWorkflowExpandedUntilAssistantText = true;
+				this.collapsedAutoWorkflowIds.clear();
 				if (this.state) {
 					this.state = { ...this.state, isStreaming: true };
 					this.onStateChange?.(this.state);
@@ -3049,6 +3054,7 @@ export class ChatView {
 		this.runHasAssistantText = false;
 		this.runSawToolActivity = false;
 		this.keepWorkflowExpandedUntilAssistantText = false;
+		this.collapsedAutoWorkflowIds.clear();
 		this.render();
 		this.scrollToBottom(true);
 	}
@@ -3253,6 +3259,7 @@ export class ChatView {
 		this.runHasAssistantText = false;
 		this.runSawToolActivity = false;
 		this.keepWorkflowExpandedUntilAssistantText = false;
+		this.collapsedAutoWorkflowIds.clear();
 		this.onRunStateChange?.(false);
 	}
 
@@ -3664,18 +3671,8 @@ export class ChatView {
 		`;
 	}
 
-	private hasInlineWorkflowActivity(): boolean {
-		for (let index = 0; index < this.messages.length; index += 1) {
-			const msg = this.messages[index];
-			if (msg.role !== "assistant") continue;
-			if (this.collectAssistantWorkflow(index)) return true;
-		}
-		return false;
-	}
-
 	private shouldShowWorkingIndicator(): boolean {
 		if (!this.currentIsStreaming()) return false;
-		if (this.hasInlineWorkflowActivity()) return false;
 		return !this.runHasAssistantText;
 	}
 
@@ -3832,13 +3829,17 @@ export class ChatView {
 		return this.expandedToolWorkflowIds.has(workflowId);
 	}
 
-	private toggleToolWorkflowExpanded(workflowId: string): void {
-		if (this.expandedToolWorkflowIds.has(workflowId)) {
+	private toggleToolWorkflowExpanded(workflowId: string, autoExpanded = false, currentlyExpanded = false): void {
+		if (currentlyExpanded) {
 			this.expandedToolWorkflowIds.delete(workflowId);
 			this.expandedToolGroupByWorkflowId.delete(workflowId);
 			this.expandedWorkflowThinkingIds.delete(workflowId);
+			if (autoExpanded) {
+				this.collapsedAutoWorkflowIds.add(workflowId);
+			}
 		} else {
 			this.expandedToolWorkflowIds.add(workflowId);
+			this.collapsedAutoWorkflowIds.delete(workflowId);
 		}
 		this.render();
 	}
@@ -4022,11 +4023,14 @@ export class ChatView {
 				: 0;
 		const durationLabel = durationMs > 0 ? formatDuration(durationMs) : "0s";
 		const summaryPrimary = durationLabel;
-		const summarySecondary = total === 0 ? "thinking" : running > 0 ? `${total} running` : failed > 0 ? `${failed} failed` : `${total} complete`;
+		const summarySecondary = running > 0 ? `${total} running` : failed > 0 ? `${failed} failed` : total > 0 ? `${total} complete` : "";
 		const hasFinalContent = Boolean(workflow.finalText || workflow.errorText);
 		const manualExpanded = this.isToolWorkflowExpanded(workflow.id);
 		const autoExpanded = workflow.isTerminal && this.keepWorkflowExpandedUntilAssistantText && (running > 0 || this.runSawToolActivity || total === 0);
-		const expanded = autoExpanded || manualExpanded;
+		if (!autoExpanded) {
+			this.collapsedAutoWorkflowIds.delete(workflow.id);
+		}
+		const expanded = (autoExpanded && !this.collapsedAutoWorkflowIds.has(workflow.id)) || manualExpanded;
 		const thinkingExpanded = this.isWorkflowThinkingExpanded(workflow.id);
 		const thinkingAnimating = running === 0 && workflow.messages.some((entry) => entry.isThinkingStreaming);
 		if (!expanded) {
@@ -4041,14 +4045,13 @@ export class ChatView {
 						<button
 							class="tool-workflow-summary"
 							@click=${() => {
-								if (autoExpanded) return;
-								this.toggleToolWorkflowExpanded(workflow.id);
+								this.toggleToolWorkflowExpanded(workflow.id, autoExpanded, expanded);
 							}}
 						>
 							<span class="workflow-divider" aria-hidden="true"></span>
 							<span class="workflow-summary-center">
 								<span class="workflow-summary-label">${summaryPrimary}</span>
-								<span class="workflow-summary-meta">${summarySecondary}</span>
+								${summarySecondary ? html`<span class="workflow-summary-meta">${summarySecondary}</span>` : nothing}
 								<span class="workflow-summary-caret">${expanded ? "▾" : "▸"}</span>
 							</span>
 							<span class="workflow-divider" aria-hidden="true"></span>

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -1169,12 +1169,16 @@ export class ChatView {
 						}
 					}
 
+					const normalizedThinking = thinking.trim();
+					if (text.trim().length === 0 && normalizedThinking.length === 0 && toolCalls.length === 0) {
+						break;
+					}
 					mapped.push({
 						id: uid("assistant"),
 						sessionEntryId,
 						role: "assistant",
 						text,
-						thinking: thinking || undefined,
+						thinking: normalizedThinking || undefined,
 						thinkingExpanded: this.allThinkingExpanded,
 						isThinkingStreaming: false,
 						toolCalls,
@@ -2344,15 +2348,12 @@ export class ChatView {
 					}
 					const initialText = this.extractText(msg.content);
 					const assistantError = this.extractAssistantMessageError(msg);
-					this.messages.push({
-						id: uid("assistant"),
-						role: "assistant",
+					if (initialText.trim().length === 0 && !assistantError) {
+						break;
+					}
+					this.ensureStreamingAssistantMessage({
 						text: initialText,
 						errorText: assistantError || undefined,
-						toolCalls: [],
-						isStreaming: true,
-						isThinkingStreaming: false,
-						thinkingExpanded: this.allThinkingExpanded,
 					});
 					if (initialText.trim().length > 0) {
 						this.runHasAssistantText = true;
@@ -2397,28 +2398,25 @@ export class ChatView {
 				const assistantEvent = event.assistantMessageEvent as Record<string, unknown>;
 				if (!assistantEvent) break;
 				const subtype = typeof assistantEvent.type === "string" ? assistantEvent.type : "";
-				const last = this.messages[this.messages.length - 1];
 
 				if (subtype === "error") {
-					if (last?.role === "assistant") {
-						last.isStreaming = false;
-						last.isThinkingStreaming = false;
-						const streamError = this.extractRuntimeErrorMessage(assistantEvent) || this.extractRuntimeErrorMessage(event);
-						if (streamError) {
-							last.errorText = streamError;
-						}
+					const streamError = this.extractRuntimeErrorMessage(assistantEvent) || this.extractRuntimeErrorMessage(event);
+					const assistant = this.ensureStreamingAssistantMessage(streamError ? { errorText: streamError } : undefined);
+					assistant.isStreaming = false;
+					assistant.isThinkingStreaming = false;
+					if (streamError) {
+						assistant.errorText = streamError;
 					}
 					this.render();
 					break;
 				}
 
-				if (!last || last.role !== "assistant") break;
-
 				if (subtype === "text_delta") {
+					const assistant = this.ensureStreamingAssistantMessage();
 					const partialText = this.extractAssistantPartialContent(assistantEvent, "text");
-					last.text = this.mergeStreamingText(last.text, partialText, assistantEvent.delta);
-					last.isThinkingStreaming = false;
-					if (last.text.trim().length > 0) {
+					assistant.text = this.mergeStreamingText(assistant.text, partialText, assistantEvent.delta);
+					assistant.isThinkingStreaming = false;
+					if (assistant.text.trim().length > 0) {
 						this.runHasAssistantText = true;
 						if (this.runSawToolActivity) {
 							this.keepWorkflowExpandedUntilAssistantText = false;
@@ -2428,21 +2426,23 @@ export class ChatView {
 					this.render();
 					this.scrollToBottom();
 				} else if (subtype === "thinking_delta" || subtype === "reasoning_delta" || subtype.includes("thinking") || subtype.includes("reason")) {
+					const assistant = this.ensureStreamingAssistantMessage();
 					const partialThinking = this.extractAssistantPartialContent(assistantEvent, "thinking");
-					const currentThinking = last.thinking || "";
-					last.thinking = this.mergeStreamingText(currentThinking, partialThinking, assistantEvent.delta);
-					last.isThinkingStreaming = true;
+					const currentThinking = assistant.thinking || "";
+					assistant.thinking = this.mergeStreamingText(currentThinking, partialThinking, assistantEvent.delta);
+					assistant.isThinkingStreaming = true;
 					this.scheduleStreamingUiReconcile(1800);
-					if ((last.thinking?.length || 0) % 100 === 0) this.render();
+					if ((assistant.thinking?.length || 0) % 100 === 0) this.render();
 				} else if (subtype === "toolcall_end") {
 					this.runSawToolActivity = true;
 					this.keepWorkflowExpandedUntilAssistantText = true;
-					last.isThinkingStreaming = false;
+					const assistant = this.ensureStreamingAssistantMessage();
+					assistant.isThinkingStreaming = false;
 					const tc = assistantEvent.toolCall as Record<string, unknown>;
 					if (tc) {
 						const rawId = typeof tc.id === "string" ? tc.id.trim() : "";
 						const id = rawId || uid("tc");
-						const existing = last.toolCalls.find((entry) => entry.id === id);
+						const existing = assistant.toolCalls.find((entry) => entry.id === id);
 						if (existing) {
 							existing.name = typeof tc.name === "string" && tc.name.trim().length > 0 ? tc.name : existing.name;
 							existing.args = ((tc.arguments ?? existing.args) as Record<string, unknown>) || existing.args;
@@ -2451,7 +2451,7 @@ export class ChatView {
 							existing.startedAt = existing.startedAt ?? Date.now();
 							existing.endedAt = undefined;
 						} else {
-							last.toolCalls.push({
+							assistant.toolCalls.push({
 								id,
 								name: (tc.name as string) || "tool",
 								args: ((tc.arguments ?? {}) as Record<string, unknown>) || {},
@@ -3027,6 +3027,39 @@ export class ChatView {
 	private cloneImages(images?: PendingImage[]): PendingImage[] {
 		if (!images || images.length === 0) return [];
 		return images.map((img) => ({ ...img, id: uid("img") }));
+	}
+
+	private hasRenderableAssistantContent(msg: UiMessage): boolean {
+		if (msg.role !== "assistant") return false;
+		if (msg.toolCalls.length > 0) return true;
+		if (msg.text.trim().length > 0) return true;
+		if ((msg.thinking ?? "").trim().length > 0) return true;
+		return (msg.errorText ?? "").trim().length > 0;
+	}
+
+	private ensureStreamingAssistantMessage(seed?: { text?: string; errorText?: string }): UiMessage {
+		const last = this.messages[this.messages.length - 1];
+		if (last?.role === "assistant" && last.isStreaming) {
+			if (seed?.text && seed.text.trim().length > 0 && last.text.trim().length === 0) {
+				last.text = seed.text;
+			}
+			if (seed?.errorText && !last.errorText) {
+				last.errorText = seed.errorText;
+			}
+			return last;
+		}
+		const next: UiMessage = {
+			id: uid("assistant"),
+			role: "assistant",
+			text: seed?.text ?? "",
+			errorText: seed?.errorText,
+			toolCalls: [],
+			isStreaming: true,
+			isThinkingStreaming: false,
+			thinkingExpanded: this.allThinkingExpanded,
+		};
+		this.messages.push(next);
+		return next;
 	}
 
 	private messagePreview(msg: UiMessage): string {
@@ -4239,6 +4272,9 @@ export class ChatView {
 				continue;
 			}
 			if (msg.role === "assistant") {
+				if (!this.hasRenderableAssistantContent(msg)) {
+					continue;
+				}
 				rows.push(this.renderAssistantMessage(msg));
 				continue;
 			}

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -437,6 +437,7 @@ export class ChatView {
 	private historyRoleFilter: UiRole | "all" = "all";
 	private autoFollowChat = true;
 	private expandedToolWorkflowIds = new Set<string>();
+	private expandedToolGroupByWorkflowId = new Map<string, string>();
 	private selectedSkillDraft: ComposerSkillDraft | null = null;
 	private slashPaletteOpen = false;
 	private slashPaletteQuery = "";
@@ -581,6 +582,7 @@ export class ChatView {
 		this.slashPaletteIndex = 0;
 		this.slashSkillsUpdatedAt = 0;
 		this.expandedToolWorkflowIds.clear();
+		this.expandedToolGroupByWorkflowId.clear();
 		this.compactionCycle = null;
 		if (!path) {
 			this.bindingStatusText = null;
@@ -611,6 +613,7 @@ export class ChatView {
 		this.slashPaletteQuery = "";
 		this.slashPaletteIndex = 0;
 		this.expandedToolWorkflowIds.clear();
+		this.expandedToolGroupByWorkflowId.clear();
 		this.compactionCycle = null;
 		this.runHasAssistantText = false;
 		this.clearWorkingStatusTimer(true);
@@ -1017,6 +1020,7 @@ export class ChatView {
 			this.onStateChange?.(state);
 			this.messages = this.mapBackendMessages(backendMessages);
 			this.expandedToolWorkflowIds.clear();
+			this.expandedToolGroupByWorkflowId.clear();
 			this.forkEntryIdByMessageId.clear();
 			this.lastAssistantContextTokens = this.deriveLatestAssistantContextTokens(backendMessages);
 			if (state.isStreaming) {
@@ -3755,14 +3759,28 @@ export class ChatView {
 	private toggleToolWorkflowExpanded(workflowId: string): void {
 		if (this.expandedToolWorkflowIds.has(workflowId)) {
 			this.expandedToolWorkflowIds.delete(workflowId);
+			this.expandedToolGroupByWorkflowId.delete(workflowId);
 		} else {
 			this.expandedToolWorkflowIds.add(workflowId);
 		}
 		this.render();
 	}
 
+	private isToolGroupExpanded(workflowId: string, groupId: string): boolean {
+		return this.expandedToolGroupByWorkflowId.get(workflowId) === groupId;
+	}
+
+	private toggleToolGroupExpanded(workflowId: string, groupId: string): void {
+		if (this.expandedToolGroupByWorkflowId.get(workflowId) === groupId) {
+			this.expandedToolGroupByWorkflowId.delete(workflowId);
+		} else {
+			this.expandedToolGroupByWorkflowId.set(workflowId, groupId);
+		}
+		this.render();
+	}
+
 	private renderToolPreview(preview: string): TemplateResult {
-		const match = preview.match(/^(Edited|Wrote|Read)\s+(.+)$/);
+		const match = preview.match(/^(Edited|Wrote)\s+(.+)$/);
 		if (!match) return html`${preview}`;
 		const [, verb, target] = match;
 		return html`${verb} <span class="tool-file-target">${target}</span>`;
@@ -3884,7 +3902,8 @@ export class ChatView {
 		const durationLabel = durationMs > 0 ? formatDuration(durationMs) : "0s";
 		const summaryPrimary = running > 0 ? `Working for ${durationLabel}` : `Worked for ${durationLabel}`;
 		const summarySecondary = running > 0 ? `${total} running` : failed > 0 ? `${failed} failed` : `${total} complete`;
-		const showMissingWrapUp = !workflow.finalText && !workflow.errorText && running === 0 && !workflow.isStreaming;
+		const hasFinalContent = Boolean(workflow.finalText || workflow.errorText);
+		const showMissingWrapUp = !hasFinalContent && running === 0 && !workflow.isStreaming;
 
 		return html`
 			<div class="chat-row assistant-row assistant-workflow-row" data-message-id=${workflow.id}>
@@ -3892,8 +3911,10 @@ export class ChatView {
 					<div class="assistant-block">
 						<button class="tool-workflow-summary" @click=${() => this.toggleToolWorkflowExpanded(workflow.id)}>
 							<span class="workflow-divider" aria-hidden="true"></span>
-							<span class="workflow-summary-label">${summaryPrimary}</span>
-							<span class="workflow-summary-meta">${summarySecondary}</span>
+							<span class="workflow-summary-center">
+								<span class="workflow-summary-label">${summaryPrimary}</span>
+								<span class="workflow-summary-meta">${summarySecondary}</span>
+							</span>
 							<span class="workflow-divider" aria-hidden="true"></span>
 						</button>
 						${expanded
@@ -3903,32 +3924,48 @@ export class ChatView {
 										const count = group.calls.length;
 										const groupRunning = group.calls.some((tc) => tc.isRunning);
 										const groupFailed = group.calls.some((tc) => tc.isError);
+										const groupExpanded = this.isToolGroupExpanded(workflow.id, group.id);
 										const output =
 											[...group.calls]
 												.reverse()
 												.map((call) => (call.streamingOutput ?? call.result ?? "").trim())
 												.find((value) => value.length > 0) ?? "";
-										const showOutput = output.length > 0;
+										const statusLabel = groupRunning ? "running" : groupFailed ? "failed" : "success";
 										return html`
 											<div class="tool-workflow-item">
-												<div class="tool-workflow-line ${groupRunning ? "running" : groupFailed ? "error" : "done"}">
+												<button
+													class="tool-workflow-line"
+													@click=${() => this.toggleToolGroupExpanded(workflow.id, group.id)}
+												>
 													<span class="tool-workflow-line-text">${this.renderToolPreview(group.preview)}</span>
 													${count > 1 ? html`<span class="tool-workflow-count">×${count}</span>` : nothing}
-													<span class="tool-workflow-state ${groupRunning ? "running" : groupFailed ? "error" : "done"}">${groupRunning ? "running" : groupFailed ? "failed" : "done"}</span>
-												</div>
-												${showOutput ? html`<pre class="tool-workflow-output">${output}</pre>` : nothing}
+												</button>
+												${groupExpanded
+													? html`
+														<div class="tool-workflow-details">
+															<pre class="tool-workflow-output">${output || "No output reported."}${groupRunning ? html`<span class="streaming-inline"></span>` : nothing}</pre>
+															<div class="tool-workflow-detail-meta"><span class="tool-workflow-detail-status ${groupRunning ? "running" : groupFailed ? "error" : "done"}">${statusLabel}</span></div>
+														</div>
+													`
+													: nothing}
 											</div>
 										`;
 									})}
 								</div>
-								${workflow.finalText || workflow.errorText ? html`<div class="assistant-final-divider"><span>Final message</span></div>` : nothing}
+								${hasFinalContent ? html`<div class="assistant-final-divider"><span>Final message</span></div>` : nothing}
 								${workflow.finalText
 									? html`<div class="assistant-content ${workflow.isStreaming ? "streaming-cursor" : ""}"><markdown-block .content=${workflow.finalText}></markdown-block></div>`
 									: nothing}
 								${workflow.errorText ? html`<div class="assistant-error-line">${workflow.errorText}</div>` : nothing}
 								${showMissingWrapUp ? html`<div class="assistant-wrapup-missing">No final message returned for this tool run.</div>` : nothing}
 							`
-							: nothing}
+							: html`
+								${workflow.finalText
+									? html`<div class="assistant-content workflow-final-collapsed"><markdown-block .content=${workflow.finalText}></markdown-block></div>`
+									: nothing}
+								${workflow.errorText ? html`<div class="assistant-error-line">${workflow.errorText}</div>` : nothing}
+								${showMissingWrapUp ? html`<div class="assistant-wrapup-missing">No final message returned for this tool run.</div>` : nothing}
+							`}
 					</div>
 				</div>
 			</div>

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -2,6 +2,7 @@
  * ChatView - rich RPC chat surface for Pi Desktop
  */
 
+import "@mariozechner/mini-lit/dist/CodeBlock.js";
 import "@mariozechner/mini-lit/dist/MarkdownBlock.js";
 import { html, nothing, render, type TemplateResult } from "lit";
 import {
@@ -33,6 +34,8 @@ interface ToolCallBlock {
 	isError?: boolean;
 	isRunning: boolean;
 	isExpanded: boolean;
+	startedAt?: number;
+	endedAt?: number;
 }
 
 interface UiMessage {
@@ -130,6 +133,24 @@ interface SlashPaletteItem {
 	skillName?: string;
 }
 
+interface ToolCallGroup {
+	id: string;
+	toolName: string;
+	preview: string;
+	calls: ToolCallBlock[];
+}
+
+interface CompactionCycleState {
+	id: string;
+	status: "running" | "done" | "aborted" | "error";
+	startedAt: number;
+	endedAt: number | null;
+	summary: string;
+	errorMessage: string | null;
+	details: string[];
+	expanded: boolean;
+}
+
 function uid(prefix = "id"): string {
 	return `${prefix}_${Math.random().toString(36).slice(2, 8)}_${Date.now().toString(36)}`;
 }
@@ -164,6 +185,16 @@ function formatAge(ts: number): string {
 	if (diff < hour) return `${Math.floor(diff / minute)}m ago`;
 	if (diff < day) return `${Math.floor(diff / hour)}h ago`;
 	return `${Math.floor(diff / day)}d ago`;
+}
+
+function formatDuration(ms: number): string {
+	const totalSeconds = Math.max(1, Math.round(ms / 1000));
+	const hours = Math.floor(totalSeconds / 3600);
+	const minutes = Math.floor((totalSeconds % 3600) / 60);
+	const seconds = totalSeconds % 60;
+	if (hours > 0) return `${hours}h ${minutes}m`;
+	if (minutes > 0) return `${minutes}m ${seconds}s`;
+	return `${seconds}s`;
 }
 
 function readNumberPath(source: Record<string, unknown>, path: string): number | null {
@@ -387,7 +418,7 @@ export class ChatView {
 	private notices: Notice[] = [];
 	private allThinkingExpanded = false;
 	private retryStatus = "";
-	private compactionStatus = "";
+	private compactionCycle: CompactionCycleState | null = null;
 	private lastRuntimeNoticeSignature = "";
 	private lastRuntimeNoticeAt = 0;
 	private pendingDeliveryMode: DeliveryMode = "prompt";
@@ -405,6 +436,7 @@ export class ChatView {
 	private historyQuery = "";
 	private historyRoleFilter: UiRole | "all" = "all";
 	private autoFollowChat = true;
+	private expandedToolWorkflowMessageIds = new Set<string>();
 	private selectedSkillDraft: ComposerSkillDraft | null = null;
 	private slashPaletteOpen = false;
 	private slashPaletteQuery = "";
@@ -437,6 +469,9 @@ export class ChatView {
 	private workingStatusTimer: ReturnType<typeof setTimeout> | null = null;
 	private disconnectNoticeTimer: ReturnType<typeof setTimeout> | null = null;
 	private streamingReconcileTimer: ReturnType<typeof setTimeout> | null = null;
+	private composerResizeObserver: ResizeObserver | null = null;
+	private observedComposerElement: HTMLElement | null = null;
+	private composerOffsetPx = 196;
 	private sessionStats: SessionStatsSummary = {
 		tokens: null,
 		lifetimeTokens: null,
@@ -545,6 +580,8 @@ export class ChatView {
 		this.slashPaletteQuery = "";
 		this.slashPaletteIndex = 0;
 		this.slashSkillsUpdatedAt = 0;
+		this.expandedToolWorkflowMessageIds.clear();
+		this.compactionCycle = null;
 		if (!path) {
 			this.bindingStatusText = null;
 			this.welcomeHeadlineIndex = (this.welcomeHeadlineIndex + 1) % this.welcomeHeadlines.length;
@@ -573,6 +610,8 @@ export class ChatView {
 		this.slashPaletteOpen = false;
 		this.slashPaletteQuery = "";
 		this.slashPaletteIndex = 0;
+		this.expandedToolWorkflowMessageIds.clear();
+		this.compactionCycle = null;
 		this.runHasAssistantText = false;
 		this.clearWorkingStatusTimer(true);
 		this.bindingStatusText = projectPath ? (statusText ?? "Loading session…") : null;
@@ -753,7 +792,6 @@ export class ChatView {
 			{ id: "action:rename-session", section: "Actions" as const, label: "Rename session", hint: "Rename current session" },
 			{ id: "action:open-terminal", section: "Actions" as const, label: "Open terminal", hint: "Switch to terminal pane" },
 			{ id: "action:compact", section: "Actions" as const, label: "Compact context", hint: "Run session compaction now" },
-			{ id: "action:fork", section: "Actions" as const, label: "Fork from message", hint: "Create fork from session history" },
 			{ id: "action:history", section: "Actions" as const, label: "Open history", hint: "Browse current session history" },
 			{ id: "action:copy-last", section: "Actions" as const, label: "Copy last answer", hint: "Copy latest assistant response" },
 			{ id: "action:export-html", section: "Actions" as const, label: "Export HTML", hint: "Export conversation to HTML" },
@@ -818,9 +856,6 @@ export class ChatView {
 				return;
 			case "action:compact":
 				void this.compactNow();
-				return;
-			case "action:fork":
-				this.openHistoryViewerForFork({ loading: false, sessionName: this.state?.sessionName ?? null });
 				return;
 			case "action:history":
 				this.openHistoryViewer();
@@ -944,6 +979,9 @@ export class ChatView {
 		}
 		this.nativeFileDropUnlisteners = [];
 		this.unbindModelPickerGlobalListeners();
+		this.composerResizeObserver?.disconnect();
+		this.composerResizeObserver = null;
+		this.observedComposerElement = null;
 	}
 
 	async refreshFromBackend(options: { throwOnError?: boolean } = {}): Promise<void> {
@@ -978,6 +1016,7 @@ export class ChatView {
 			this.lastBackendRefreshError = null;
 			this.onStateChange?.(state);
 			this.messages = this.mapBackendMessages(backendMessages);
+			this.expandedToolWorkflowMessageIds.clear();
 			this.forkEntryIdByMessageId.clear();
 			this.lastAssistantContextTokens = this.deriveLatestAssistantContextTokens(backendMessages);
 			if (state.isStreaming) {
@@ -1080,6 +1119,8 @@ export class ChatView {
 								args: (p.arguments as Record<string, unknown>) ?? {},
 								isRunning: false,
 								isExpanded: false,
+								startedAt: pickNumber(p, ["startedAt", "startTime", "timestamp", "ts"]) ?? undefined,
+								endedAt: pickNumber(p, ["endedAt", "endTime"]) ?? undefined,
 							};
 							toolCalls.push(tc);
 							toolCallMap.set(tc.id, tc);
@@ -1107,15 +1148,32 @@ export class ChatView {
 						tool.isError = isError;
 						tool.isRunning = false;
 						tool.isExpanded = false;
+						tool.endedAt = Date.now();
+						if (!tool.startedAt) tool.startedAt = tool.endedAt;
 					} else {
-						mapped.push({
-							id: uid("toolResult"),
-							sessionEntryId,
-							role: "system",
-							text: `Tool result${isError ? " (error)" : ""}:\n${content || "(no output)"}`,
-							label: "tool-result",
-							toolCalls: [],
-						});
+						const target = [...mapped].reverse().find((entry) => entry.role === "assistant");
+						if (target) {
+							target.toolCalls.push({
+								id: toolCallId || uid("tc"),
+								name: (typeof raw.toolName === "string" && raw.toolName.trim().length > 0 ? raw.toolName : "tool") as string,
+								args: {},
+								result: content || "(no output)",
+								isError,
+								isRunning: false,
+								isExpanded: false,
+								startedAt: Date.now(),
+								endedAt: Date.now(),
+							});
+						} else {
+							mapped.push({
+								id: uid("toolResult"),
+								sessionEntryId,
+								role: "system",
+								text: `Tool result${isError ? " (error)" : ""}:\n${content || "(no output)"}`,
+								label: "tool-result",
+								toolCalls: [],
+							});
+						}
 					}
 					break;
 				}
@@ -2267,14 +2325,10 @@ export class ChatView {
 						tool.isRunning = false;
 						tool.streamingOutput = undefined;
 						tool.isExpanded = false;
+						tool.endedAt = Date.now();
+						if (!tool.startedAt) tool.startedAt = tool.endedAt;
 					} else {
-						this.messages.push({
-							id: uid("toolResult"),
-							role: "system",
-							text: `Tool result${isError ? " (error)" : ""}:\n${output || "(no output)"}`,
-							label: "tool-result",
-							toolCalls: [],
-						});
+						this.attachOrphanToolResult(toolName, output, isError);
 					}
 					this.render();
 					this.scrollToBottom();
@@ -2326,6 +2380,8 @@ export class ChatView {
 							existing.args = ((tc.arguments ?? existing.args) as Record<string, unknown>) || existing.args;
 							existing.isRunning = true;
 							existing.isExpanded = false;
+							existing.startedAt = existing.startedAt ?? Date.now();
+							existing.endedAt = undefined;
 						} else {
 							last.toolCalls.push({
 								id,
@@ -2333,6 +2389,7 @@ export class ChatView {
 								args: ((tc.arguments ?? {}) as Record<string, unknown>) || {},
 								isRunning: true,
 								isExpanded: false,
+								startedAt: Date.now(),
 							});
 						}
 						this.render();
@@ -2379,6 +2436,8 @@ export class ChatView {
 				if (tool) {
 					tool.isRunning = true;
 					tool.isExpanded = false;
+					tool.startedAt = tool.startedAt ?? Date.now();
+					tool.endedAt = undefined;
 					this.render();
 				}
 				break;
@@ -2420,29 +2479,75 @@ export class ChatView {
 					tool.result = tool.result || "(no output)";
 				}
 				tool.isExpanded = false;
+				tool.endedAt = Date.now();
+				if (!tool.startedAt) tool.startedAt = tool.endedAt;
 				this.render();
 				this.scrollToBottom();
 				break;
 			}
 
 			case "auto_compaction_start": {
-				this.compactionStatus = "Compacting context…";
-				this.appendRuntimeSystemLine("Compacting context…");
+				this.compactionCycle = {
+					id: uid("compaction"),
+					status: "running",
+					startedAt: Date.now(),
+					endedAt: null,
+					summary: "Compacting context…",
+					errorMessage: null,
+					details: ["Compaction started"],
+					expanded: true,
+				};
+				this.render();
+				break;
+			}
+
+			case "auto_compaction_update":
+			case "auto_compaction_progress": {
+				if (!this.compactionCycle) break;
+				const detail =
+					pickString(event, ["message", "status", "phase", "step", "detail"]) ||
+					this.extractToolOutput(event.detail ?? event.payload ?? event).trim();
+				if (detail) {
+					const cleaned = truncate(detail.replace(/\s+/g, " ").trim(), 220);
+					if (cleaned && this.compactionCycle.details[this.compactionCycle.details.length - 1] !== cleaned) {
+						this.compactionCycle.details.push(cleaned);
+					}
+				}
 				this.render();
 				break;
 			}
 
 			case "auto_compaction_end": {
-				this.compactionStatus = "";
 				const aborted = Boolean(event.aborted);
 				const errorMessage = this.extractRuntimeErrorMessage(event);
+				if (!this.compactionCycle) {
+					this.compactionCycle = {
+						id: uid("compaction"),
+						status: "running",
+						startedAt: Date.now(),
+						endedAt: null,
+						summary: "Compacting context…",
+						errorMessage: null,
+						details: [],
+						expanded: true,
+					};
+				}
+				this.compactionCycle.endedAt = Date.now();
 				if (aborted) {
-					this.appendRuntimeSystemLine("Auto-compaction aborted");
+					this.compactionCycle.status = "aborted";
+					this.compactionCycle.summary = "Compaction aborted";
+					this.compactionCycle.details.push("Compaction was aborted before completion.");
 					this.pushNotice("Auto-compaction aborted", "info");
 				} else if (errorMessage) {
+					this.compactionCycle.status = "error";
+					this.compactionCycle.summary = "Compaction failed";
+					this.compactionCycle.errorMessage = truncate(errorMessage, 220);
+					this.compactionCycle.details.push(`Failure: ${truncate(errorMessage, 220)}`);
 					this.pushRuntimeNotice(`Auto-compaction failed: ${truncate(errorMessage, 180)}`, "error", 2600);
 				} else {
-					this.appendRuntimeSystemLine("Auto-compaction complete");
+					this.compactionCycle.status = "done";
+					this.compactionCycle.summary = "Compaction complete";
+					this.compactionCycle.details.push("Compaction completed successfully.");
 					this.pushNotice("Auto-compaction complete", "success");
 				}
 				this.render();
@@ -2556,6 +2661,39 @@ export class ChatView {
 			}
 		}
 		return null;
+	}
+
+	private findMostRecentAssistantMessage(): UiMessage | null {
+		for (let i = this.messages.length - 1; i >= 0; i--) {
+			const message = this.messages[i];
+			if (message.role === "assistant") return message;
+		}
+		return null;
+	}
+
+	private attachOrphanToolResult(toolName: string, output: string, isError: boolean): void {
+		const assistantMessage = this.findMostRecentAssistantMessage();
+		if (!assistantMessage) {
+			this.messages.push({
+				id: uid("toolResult"),
+				role: "system",
+				text: `Tool result${isError ? " (error)" : ""}:\n${output || "(no output)"}`,
+				label: "tool-result",
+				toolCalls: [],
+			});
+			return;
+		}
+		assistantMessage.toolCalls.push({
+			id: uid("tc"),
+			name: toolName || "tool",
+			args: {},
+			result: output || "(no output)",
+			isError,
+			isRunning: false,
+			isExpanded: false,
+			startedAt: Date.now(),
+			endedAt: Date.now(),
+		});
 	}
 
 	private pushNotice(text: string, kind: Notice["kind"]): void {
@@ -3037,6 +3175,12 @@ export class ChatView {
 			}
 		}
 		this.retryStatus = "";
+		if (this.compactionCycle?.status === "running") {
+			this.compactionCycle.status = "aborted";
+			this.compactionCycle.summary = "Compaction interrupted";
+			this.compactionCycle.endedAt = Date.now();
+			this.compactionCycle.details.push("Compaction was interrupted before completion.");
+		}
 		this.pendingDeliveryMode = "prompt";
 		this.runHasAssistantText = false;
 		this.onRunStateChange?.(false);
@@ -3320,6 +3464,38 @@ export class ChatView {
 		});
 	}
 
+	private updateComposerOffset(): void {
+		const chatRoot = this.container.querySelector<HTMLElement>(".chat-root");
+		if (!chatRoot) return;
+		const composer = this.container.querySelector<HTMLElement>(".composer-shell");
+		if (!this.projectPath || !composer) {
+			chatRoot.style.setProperty("--composer-offset", "196px");
+			this.composerOffsetPx = 196;
+			this.composerResizeObserver?.disconnect();
+			this.composerResizeObserver = null;
+			this.observedComposerElement = null;
+			return;
+		}
+
+		const apply = () => {
+			const measured = Math.max(140, Math.ceil(composer.getBoundingClientRect().height) + 18);
+			if (Math.abs(measured - this.composerOffsetPx) < 2) return;
+			this.composerOffsetPx = measured;
+			chatRoot.style.setProperty("--composer-offset", `${measured}px`);
+			if (this.autoFollowChat) this.scrollToBottom();
+		};
+
+		apply();
+		if (!this.composerResizeObserver) {
+			this.composerResizeObserver = new ResizeObserver(() => apply());
+		}
+		if (this.observedComposerElement !== composer) {
+			this.composerResizeObserver.disconnect();
+			this.composerResizeObserver.observe(composer);
+			this.observedComposerElement = composer;
+		}
+	}
+
 	private renderNotices(): TemplateResult | typeof nothing {
 		if (this.notices.length === 0) return nothing;
 		return html`
@@ -3509,32 +3685,136 @@ export class ChatView {
 		`;
 	}
 
-	private renderToolCall(tc: ToolCallBlock): TemplateResult {
-		const statusClass = tc.isRunning ? "status-running" : tc.isError ? "status-error" : "status-ok";
-		const titleHint = tc.name === "bash" && typeof tc.args.command === "string" ? (tc.args.command as string) : "";
-		const output = (tc.streamingOutput ?? tc.result ?? "").trimEnd();
-		const hasOutput = output.length > 0;
-		const placeholder = tc.isRunning ? "Waiting for tool output…" : "No output reported.";
+	private pickToolArg(args: Record<string, unknown>, keys: string[]): string {
+		for (const key of keys) {
+			const value = args[key];
+			if (typeof value === "string" && value.trim().length > 0) return value.trim();
+		}
+		return "";
+	}
+
+	private summarizeToolCall(tc: ToolCallBlock): string {
+		const name = tc.name.trim().toLowerCase();
+		const command = this.pickToolArg(tc.args, ["command", "cmd", "shell", "script"]);
+		const path = this.pickToolArg(tc.args, ["path", "filePath", "targetPath", "from", "to"]);
+		const query = this.pickToolArg(tc.args, ["query", "pattern", "glob", "name"]);
+		if (name === "bash" && command) return `Ran ${truncate(command, 140)}`;
+		if ((name === "read" || name === "readfile") && path) return `Read ${truncate(path, 120)}`;
+		if ((name === "write" || name === "writefile") && path) return `Wrote ${truncate(path, 120)}`;
+		if (name === "edit" && path) return `Edited ${truncate(path, 120)}`;
+		if (name.includes("search") && query) return `Explored ${truncate(query, 120)}`;
+		if ((name === "list" || name.includes("ls")) && path) return `Explored ${truncate(path, 120)}`;
+		if (path) return `${tc.name} ${truncate(path, 120)}`;
+		return `Ran ${tc.name}`;
+	}
+
+	private buildToolCallGroups(toolCalls: ToolCallBlock[]): ToolCallGroup[] {
+		const groups: ToolCallGroup[] = [];
+		for (const tc of toolCalls) {
+			const preview = this.summarizeToolCall(tc);
+			const previous = groups[groups.length - 1];
+			if (previous && previous.toolName === tc.name && previous.preview === preview) {
+				previous.calls.push(tc);
+				continue;
+			}
+			groups.push({
+				id: `${tc.id}-group`,
+				toolName: tc.name,
+				preview,
+				calls: [tc],
+			});
+		}
+		return groups;
+	}
+
+	private isToolWorkflowExpanded(msg: UiMessage): boolean {
+		if (this.expandedToolWorkflowMessageIds.has(msg.id)) return true;
+		return msg.toolCalls.some((tc) => tc.isRunning);
+	}
+
+	private toggleToolWorkflowExpanded(msg: UiMessage): void {
+		if (this.isToolWorkflowExpanded(msg)) {
+			this.expandedToolWorkflowMessageIds.delete(msg.id);
+			for (const tc of msg.toolCalls) tc.isExpanded = false;
+		} else {
+			this.expandedToolWorkflowMessageIds.add(msg.id);
+		}
+		this.render();
+	}
+
+	private toggleToolCallGroupExpanded(group: ToolCallGroup): void {
+		const expanded = group.calls.some((tc) => tc.isExpanded);
+		for (const tc of group.calls) tc.isExpanded = !expanded;
+		this.render();
+	}
+
+	private renderToolWorkflow(msg: UiMessage): TemplateResult | typeof nothing {
+		if (msg.toolCalls.length === 0) return nothing;
+		const total = msg.toolCalls.length;
+		const running = msg.toolCalls.filter((tc) => tc.isRunning).length;
+		const failed = msg.toolCalls.filter((tc) => tc.isError).length;
+		const expanded = this.isToolWorkflowExpanded(msg);
+		const groups = this.buildToolCallGroups(msg.toolCalls);
+		const startedAt = msg.toolCalls.reduce((min, tc) => {
+			if (!tc.startedAt) return min;
+			return min === 0 ? tc.startedAt : Math.min(min, tc.startedAt);
+		}, 0);
+		const endedAt = msg.toolCalls.reduce((max, tc) => {
+			if (!tc.endedAt) return max;
+			return Math.max(max, tc.endedAt);
+		}, 0);
+		const duration = startedAt > 0 ? formatDuration((running > 0 ? Date.now() : Math.max(endedAt, startedAt)) - startedAt) : null;
+		const primaryLabel = running > 0 ? `Working with ${total} tool call${total === 1 ? "" : "s"}` : duration ? `Worked for ${duration}` : `Worked with ${total} tool call${total === 1 ? "" : "s"}`;
+		const secondaryLabel = running > 0 ? "in progress" : failed > 0 ? `${failed} failed` : `${total} complete`;
 
 		return html`
-			<div class="tool-card">
-				<button
-					class="tool-header"
-					@click=${() => {
-						tc.isExpanded = !tc.isExpanded;
-						this.render();
-					}}
-				>
-					<span class="status-dot ${statusClass}"></span>
-					<span class="tool-name">${tc.name}</span>
-					${titleHint ? html`<span class="tool-hint" title=${titleHint}>${truncate(titleHint, 56)}</span>` : nothing}
-					<span class="tool-chevron">${tc.isExpanded ? "▾" : "▸"}</span>
+			<div class="tool-workflow ${expanded ? "expanded" : ""}">
+				<button class="tool-workflow-summary" @click=${() => this.toggleToolWorkflowExpanded(msg)}>
+					<span class="workflow-divider" aria-hidden="true"></span>
+					<span class="workflow-summary-label">${primaryLabel}</span>
+					<span class="workflow-summary-meta">${secondaryLabel}</span>
+					<span class="workflow-summary-caret">${expanded ? "▾" : "▸"}</span>
+					<span class="workflow-divider" aria-hidden="true"></span>
 				</button>
-				${tc.isExpanded
+				${expanded
 					? html`
-						<pre class="tool-output ${hasOutput ? "" : "tool-output-empty"}">${hasOutput ? output : placeholder}${tc.isRunning
-							? html`<span class="streaming-inline"></span>`
-							: nothing}</pre>
+						<div class="tool-workflow-list">
+							${groups.map((group) => {
+								const count = group.calls.length;
+								const groupExpanded = group.calls.some((tc) => tc.isExpanded);
+								const groupRunning = group.calls.some((tc) => tc.isRunning);
+								const groupFailed = group.calls.some((tc) => tc.isError);
+								return html`
+									<div class="tool-workflow-item ${groupExpanded ? "expanded" : ""}">
+										<button class="tool-workflow-line" @click=${() => this.toggleToolCallGroupExpanded(group)}>
+											<span class="tool-workflow-line-text">${group.preview}</span>
+											${count > 1 ? html`<span class="tool-workflow-count">×${count}</span>` : nothing}
+											<span class="tool-workflow-state ${groupRunning ? "running" : groupFailed ? "error" : "done"}">${groupRunning ? "running" : groupFailed ? "failed" : "done"}</span>
+											<span class="tool-workflow-caret">${groupExpanded ? "▾" : "▸"}</span>
+										</button>
+										${groupExpanded
+											? html`
+												<div class="tool-workflow-details">
+													${group.calls.map((call, index) => {
+														const output = (call.streamingOutput ?? call.result ?? "").trimEnd();
+														const hasOutput = output.length > 0;
+														const placeholder = call.isRunning ? "Waiting for tool output…" : "No output reported.";
+														return html`
+															<div class="tool-workflow-detail-run">
+																${group.calls.length > 1 ? html`<div class="tool-workflow-detail-label">Run ${index + 1}</div>` : nothing}
+																<pre class="tool-workflow-output ${hasOutput ? "" : "tool-output-empty"}">${hasOutput ? output : placeholder}${call.isRunning
+																	? html`<span class="streaming-inline"></span>`
+																	: nothing}</pre>
+															</div>
+														`;
+													})}
+												</div>
+											`
+											: nothing}
+									</div>
+								`;
+							})}
+						</div>
 					`
 					: nothing}
 			</div>
@@ -3552,11 +3832,16 @@ export class ChatView {
 		const formattedErrorLine = errorLine
 			? (/^error\b[:\s-]*/i.test(errorLine) ? errorLine : `Error: ${errorLine}`)
 			: "";
+		const hasToolWorkflow = msg.toolCalls.length > 0;
 		return html`
 			<div class="chat-row assistant-row" data-message-id=${msg.id}>
 				<div class="message-shell assistant-message-shell">
 					<div class="assistant-block">
+						${hasToolWorkflow ? this.renderToolWorkflow(msg) : nothing}
 						${this.renderThinking(msg)}
+						${msg.text && hasToolWorkflow
+							? html`<div class="assistant-final-divider"><span>Final message</span></div>`
+							: nothing}
 						${msg.text
 							? html`
 								<div class="assistant-content ${msg.isStreaming ? "streaming-cursor" : ""}">
@@ -3565,7 +3850,6 @@ export class ChatView {
 							`
 							: nothing}
 						${formattedErrorLine ? html`<div class="assistant-error-line">${formattedErrorLine}</div>` : nothing}
-						${msg.toolCalls.map((tc) => this.renderToolCall(tc))}
 					</div>
 					<div class="message-actions">
 						${canCopy
@@ -3583,6 +3867,47 @@ export class ChatView {
 				<div class="system-message">
 					${msg.label ? html`<div class="system-label">${msg.label}</div>` : nothing}
 					<div class="system-text">${msg.text}</div>
+				</div>
+			</div>
+		`;
+	}
+
+	private renderCompactionCycle(): TemplateResult | typeof nothing {
+		if (!this.compactionCycle) return nothing;
+		const cycle = this.compactionCycle;
+		const completed = cycle.endedAt ?? Date.now();
+		const elapsed = formatDuration(completed - cycle.startedAt);
+		const statusText =
+			cycle.status === "running"
+				? "running"
+				: cycle.status === "error"
+					? "failed"
+					: cycle.status === "aborted"
+						? "aborted"
+						: "done";
+		return html`
+			<div class="chat-row system-row compaction-row" data-message-id=${cycle.id}>
+				<div class="compaction-card ${cycle.status}">
+					<button
+						class="compaction-header"
+						@click=${() => {
+							cycle.expanded = !cycle.expanded;
+							this.render();
+						}}
+					>
+						<span class="compaction-title">Context compaction</span>
+						<span class="compaction-meta">${elapsed} · ${statusText}</span>
+						<span class="compaction-caret">${cycle.expanded ? "▾" : "▸"}</span>
+					</button>
+					${cycle.expanded
+						? html`
+							<div class="compaction-details">
+								<div class="compaction-summary">${cycle.summary}</div>
+								${cycle.errorMessage ? html`<div class="compaction-error">${cycle.errorMessage}</div>` : nothing}
+								${cycle.details.map((line) => html`<div class="compaction-line">${line}</div>`)}
+							</div>
+						`
+						: nothing}
 				</div>
 			</div>
 		`;
@@ -4170,7 +4495,8 @@ export class ChatView {
 			this.slashPaletteIndex = slashItems.length - 1;
 		}
 		const connectivityStatus = this.bindingStatusText || (!this.isConnected && this.projectPath ? "RPC disconnected" : "");
-		const statusText = [connectivityStatus, this.compactionStatus, this.retryStatus].filter(Boolean).join(" · ");
+		const liveCompactionStatus = this.compactionCycle?.status === "running" ? "Compacting context…" : "";
+		const statusText = [connectivityStatus, liveCompactionStatus, this.retryStatus].filter(Boolean).join(" · ");
 		const ratio = Math.min(1, Math.max(0, this.sessionStats.usageRatio ?? 0));
 		const ratioPercent = `${Math.round(ratio * 100)}%`;
 		const ringRadius = 9;
@@ -4692,6 +5018,7 @@ export class ChatView {
 							: this.bindingStatusText
 								? this.renderBindingState()
 								: this.renderEmptyState()}
+					${hasProject ? this.renderCompactionCycle() : nothing}
 					${showWorkingIndicator ? this.renderWorkingIndicatorRow() : nothing}
 				</div>
 				${hasProject ? this.renderComposer() : nothing}
@@ -4704,6 +5031,7 @@ export class ChatView {
 
 		render(template, this.container);
 		this.scrollContainer = this.container.querySelector("#chat-scroll");
+		this.updateComposerOffset();
 	}
 
 	render(): void {

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -447,6 +447,7 @@ export class ChatView {
 	private slashSkillsLoading = false;
 	private slashSkillsUpdatedAt = 0;
 	private runHasAssistantText = false;
+	private keepWorkflowExpandedUntilAssistantText = false;
 	private readonly workingStatusPhrases = [
 		"starting",
 		"warming up",
@@ -584,6 +585,7 @@ export class ChatView {
 		this.expandedToolWorkflowIds.clear();
 		this.expandedToolGroupByWorkflowId.clear();
 		this.compactionCycle = null;
+		this.keepWorkflowExpandedUntilAssistantText = false;
 		if (!path) {
 			this.bindingStatusText = null;
 			this.welcomeHeadlineIndex = (this.welcomeHeadlineIndex + 1) % this.welcomeHeadlines.length;
@@ -616,6 +618,7 @@ export class ChatView {
 		this.expandedToolGroupByWorkflowId.clear();
 		this.compactionCycle = null;
 		this.runHasAssistantText = false;
+		this.keepWorkflowExpandedUntilAssistantText = false;
 		this.clearWorkingStatusTimer(true);
 		this.bindingStatusText = projectPath ? (statusText ?? "Loading session…") : null;
 		this.render();
@@ -1036,8 +1039,10 @@ export class ChatView {
 					if ((entry.role as string) !== "assistant") return false;
 					return this.extractText((entry as Record<string, unknown>).content).trim().length > 0;
 				});
+				this.keepWorkflowExpandedUntilAssistantText = !this.runHasAssistantText;
 			} else {
 				this.runHasAssistantText = false;
+				this.keepWorkflowExpandedUntilAssistantText = false;
 			}
 			this.pendingDeliveryMode = state.isStreaming ? "steer" : "prompt";
 			this.bindingStatusText = null;
@@ -2244,6 +2249,7 @@ export class ChatView {
 			case "agent_start":
 				this.pendingDeliveryMode = "steer";
 				this.runHasAssistantText = false;
+				this.keepWorkflowExpandedUntilAssistantText = true;
 				if (this.state) {
 					this.state = { ...this.state, isStreaming: true };
 					this.onStateChange?.(this.state);
@@ -2271,6 +2277,7 @@ export class ChatView {
 					this.pushRuntimeNotice(`Run failed: ${truncate(runError, 180)}`, "error", 2600);
 				}
 				this.runHasAssistantText = false;
+				this.keepWorkflowExpandedUntilAssistantText = false;
 				this.onRunStateChange?.(false);
 				rpcBridge
 					.getState()
@@ -2308,7 +2315,10 @@ export class ChatView {
 						isStreaming: true,
 						thinkingExpanded: this.allThinkingExpanded,
 					});
-					if (initialText.trim().length > 0) this.runHasAssistantText = true;
+					if (initialText.trim().length > 0) {
+						this.runHasAssistantText = true;
+						this.keepWorkflowExpandedUntilAssistantText = false;
+					}
 					this.render();
 					this.scrollToBottom();
 					break;
@@ -2363,7 +2373,10 @@ export class ChatView {
 				if (subtype === "text_delta") {
 					const partialText = this.extractAssistantPartialContent(assistantEvent, "text");
 					last.text = this.mergeStreamingText(last.text, partialText, assistantEvent.delta);
-					if (last.text.trim().length > 0) this.runHasAssistantText = true;
+					if (last.text.trim().length > 0) {
+						this.runHasAssistantText = true;
+						this.keepWorkflowExpandedUntilAssistantText = false;
+					}
 					this.scheduleStreamingUiReconcile(1800);
 					this.render();
 					this.scrollToBottom();
@@ -3187,6 +3200,7 @@ export class ChatView {
 		}
 		this.pendingDeliveryMode = "prompt";
 		this.runHasAssistantText = false;
+		this.keepWorkflowExpandedUntilAssistantText = false;
 		this.onRunStateChange?.(false);
 	}
 
@@ -3906,7 +3920,7 @@ export class ChatView {
 		const summarySecondary = running > 0 ? `${total} running` : failed > 0 ? `${failed} failed` : `${total} complete`;
 		const hasFinalContent = Boolean(workflow.finalText || workflow.errorText);
 		const manualExpanded = this.isToolWorkflowExpanded(workflow.id);
-		const autoExpanded = running > 0 || (workflow.isTerminal && this.currentIsStreaming() && !hasFinalContent);
+		const autoExpanded = this.keepWorkflowExpandedUntilAssistantText && workflow.isTerminal && !hasFinalContent;
 		const expanded = autoExpanded || manualExpanded;
 		if (!expanded) {
 			this.expandedToolGroupByWorkflowId.delete(workflow.id);
@@ -3951,9 +3965,9 @@ export class ChatView {
 													class="tool-workflow-line ${groupRunning ? "running" : ""}"
 													@click=${() => this.toggleToolGroupExpanded(workflow.id, group.id)}
 												>
-													${groupRunning ? html`<span class="tool-workflow-running-indicator" aria-hidden="true">•••</span>` : nothing}
 													<span class="tool-workflow-line-text ${groupRunning ? "running" : ""}">${this.renderToolPreview(group.preview)}</span>
 													${count > 1 ? html`<span class="tool-workflow-count">×${count}</span>` : nothing}
+													${groupRunning ? html`<span class="tool-workflow-running-indicator" aria-hidden="true">•••</span>` : nothing}
 												</button>
 												${groupExpanded
 													? html`

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -3774,13 +3774,13 @@ export class ChatView {
 		const command = this.pickToolArg(tc.args, ["command", "cmd", "shell", "script"]);
 		const path = this.pickToolArg(tc.args, ["path", "filePath", "targetPath", "from", "to"]);
 		const query = this.pickToolArg(tc.args, ["query", "pattern", "glob", "name"]);
-		if (name === "bash" && command) return `Ran ${truncate(command, 96)}`;
-		if ((name === "read" || name === "readfile") && path) return `Read ${truncate(path, 88)}`;
-		if ((name === "write" || name === "writefile") && path) return `Wrote ${truncate(path, 88)}`;
-		if (name === "edit" && path) return `Edited ${truncate(path, 88)}`;
-		if (name.includes("search") && query) return `Explored ${truncate(query, 88)}`;
-		if ((name === "list" || name.includes("ls")) && path) return `Explored ${truncate(path, 88)}`;
-		if (path) return `${tc.name} ${truncate(path, 88)}`;
+		if (name === "bash" && command) return `Ran ${truncate(command, 84)}`;
+		if ((name === "read" || name === "readfile") && path) return `Read ${truncate(path, 74)}`;
+		if ((name === "write" || name === "writefile") && path) return `Wrote ${truncate(path, 74)}`;
+		if (name === "edit" && path) return `Edited ${truncate(path, 74)}`;
+		if (name.includes("search") && query) return `Explored ${truncate(query, 74)}`;
+		if ((name === "list" || name.includes("ls")) && path) return `Explored ${truncate(path, 74)}`;
+		if (path) return `${tc.name} ${truncate(path, 74)}`;
 		return `Ran ${tc.name}`;
 	}
 
@@ -3843,6 +3843,7 @@ export class ChatView {
 			messages: UiMessage[];
 			toolCalls: ToolCallBlock[];
 			toolGroups: ToolCallGroup[];
+			thinkingText: string;
 			finalText: string;
 			errorText: string;
 			isStreaming: boolean;
@@ -3904,7 +3905,13 @@ export class ChatView {
 			if (!tc.endedAt) return max;
 			return Math.max(max, tc.endedAt);
 		}, 0);
+		const thinkingParts = grouped
+			.map((entry) => this.normalizeThinkingText((entry.thinking ?? "").replace(/^\s+/, "")))
+			.filter(Boolean);
+		const dedupedThinkingParts = thinkingParts.filter((part, index) => index === 0 || part !== thinkingParts[index - 1]);
+		const thinkingText = dedupedThinkingParts.join("\n\n").trim();
 		const finalText = grouped
+			.filter((entry) => entry.toolCalls.length === 0)
 			.map((entry) => entry.text.trim())
 			.filter(Boolean)
 			.join("\n\n");
@@ -3922,6 +3929,7 @@ export class ChatView {
 				messages: grouped,
 				toolCalls,
 				toolGroups: this.buildToolCallGroups(toolCalls),
+				thinkingText,
 				finalText,
 				errorText,
 				isStreaming: grouped.some((entry) => entry.isStreaming),
@@ -3938,6 +3946,7 @@ export class ChatView {
 		messages: UiMessage[];
 		toolCalls: ToolCallBlock[];
 		toolGroups: ToolCallGroup[];
+		thinkingText: string;
 		finalText: string;
 		errorText: string;
 		isStreaming: boolean;
@@ -3957,7 +3966,7 @@ export class ChatView {
 		const summarySecondary = running > 0 ? `${total} running` : failed > 0 ? `${failed} failed` : `${total} complete`;
 		const hasFinalContent = Boolean(workflow.finalText || workflow.errorText);
 		const manualExpanded = this.isToolWorkflowExpanded(workflow.id);
-		const autoExpanded = !hasFinalContent && (this.keepWorkflowExpandedUntilAssistantText || workflow.isStreaming || running > 0);
+		const autoExpanded = workflow.isTerminal && this.keepWorkflowExpandedUntilAssistantText && (running > 0 || this.runSawToolActivity);
 		const expanded = autoExpanded || manualExpanded;
 		if (!expanded) {
 			this.expandedToolGroupByWorkflowId.delete(workflow.id);
@@ -3984,6 +3993,16 @@ export class ChatView {
 						</button>
 						${expanded
 							? html`
+								${workflow.thinkingText
+									? html`
+										<div class="tool-workflow-thinking">
+											<div class="tool-workflow-thinking-label ${autoExpanded ? "animating" : "done"}">
+												${"thinking…".split("").map((char, index) => html`<span class="thinking-char" style=${`--thinking-char-index:${index};`}>${char}</span>`)}
+											</div>
+											<div class="tool-workflow-thinking-content">${workflow.thinkingText}</div>
+										</div>
+									`
+									: nothing}
 								<div class="tool-workflow-list">
 									${workflow.toolGroups.map((group) => {
 										const count = group.calls.length;
@@ -4004,7 +4023,6 @@ export class ChatView {
 												>
 													<span class="tool-workflow-line-text ${groupRunning ? "running" : ""}">${this.renderToolPreview(group.preview)}</span>
 													${count > 1 ? html`<span class="tool-workflow-count">×${count}</span>` : nothing}
-													${groupRunning ? html`<span class="tool-workflow-running-indicator" aria-hidden="true">•••</span>` : nothing}
 												</button>
 												${groupExpanded
 													? html`

--- a/src/components/file-viewer.ts
+++ b/src/components/file-viewer.ts
@@ -2,6 +2,7 @@
  * FileViewer - lightweight file surface (view + basic edit + draft create)
  */
 
+import "@mariozechner/mini-lit/dist/CodeBlock.js";
 import "@mariozechner/mini-lit/dist/MarkdownBlock.js";
 import { invoke } from "@tauri-apps/api/core";
 import { html, nothing, render } from "lit";

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5100,23 +5100,18 @@ body.sidebar-resizing {
 	padding: 5px 8px;
 	display: flex;
 	align-items: center;
-	gap: 6px;
+	gap: 0;
 	cursor: pointer;
 	text-align: left;
 	--thinking-idle: color-mix(in srgb, var(--muted) 88%, var(--text));
 	--thinking-active: color-mix(in srgb, var(--text) 80%, var(--muted));
 }
 
-.tool-workflow-thinking-caret {
-	font-size: 11px;
-	color: color-mix(in srgb, var(--muted) 86%, var(--text));
-	flex-shrink: 0;
-}
-
 .tool-workflow-thinking-text {
 	font-size: 11px;
 	line-height: 1.3;
 	color: var(--thinking-idle);
+	font-style: italic;
 }
 
 .tool-workflow-thinking-toggle.animating .tool-workflow-thinking-text {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4285,13 +4285,15 @@ body.sidebar-resizing {
 	height: 100%;
 	width: 100%;
 	background: var(--bg);
+	--composer-offset: 196px;
 }
 
 .chat-scroll {
 	flex: 1;
 	min-height: 0;
 	overflow-y: auto;
-	padding: 24px 0 192px;
+	overflow-x: hidden;
+	padding: 24px 0 calc(var(--composer-offset, 196px) + 10px);
 	scrollbar-gutter: stable;
 }
 
@@ -4299,7 +4301,7 @@ body.sidebar-resizing {
 	position: absolute;
 	left: 50%;
 	transform: translateX(-50%);
-	bottom: 194px;
+	bottom: calc(var(--composer-offset, 196px) + 2px);
 	width: 32px;
 	height: 32px;
 	padding: 0;
@@ -4457,6 +4459,8 @@ body.sidebar-resizing {
 	font-size: 13px;
 	line-height: 1.5;
 	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+	word-break: break-word;
 }
 
 .attachment-grid {
@@ -4489,6 +4493,8 @@ body.sidebar-resizing {
 	font-size: 14px;
 	line-height: 1.62;
 	color: color-mix(in srgb, var(--text) 92%, var(--muted));
+	overflow-wrap: anywhere;
+	word-break: break-word;
 }
 
 :root.light .assistant-content {
@@ -4946,109 +4952,238 @@ body.sidebar-resizing {
 	}
 }
 
-.tool-card {
-	margin-top: 10px;
-	background: color-mix(in srgb, var(--bg-soft) 34%, transparent);
-	border: none;
-	border-radius: 10px;
-	overflow: hidden;
+.tool-workflow {
+	margin: 6px 0 10px;
 }
 
-:root.light .tool-card {
-	background: color-mix(in srgb, var(--bg-soft) 82%, #fff 18%);
-}
-
-.tool-header {
+.tool-workflow-summary {
 	width: 100%;
-	height: 30px;
-	padding: 0 10px;
-	display: flex;
-	align-items: center;
-	gap: 8px;
 	border: none;
 	background: transparent;
-	color: color-mix(in srgb, var(--text) 90%, var(--muted));
-	font-size: 12px;
+	padding: 0;
+	display: grid;
+	grid-template-columns: 1fr auto auto auto 1fr;
+	align-items: center;
+	gap: 10px;
 	cursor: pointer;
+	color: color-mix(in srgb, var(--text) 76%, var(--muted));
 }
 
-.tool-header:hover {
-	background: color-mix(in srgb, var(--bg-soft) 70%, transparent);
+.workflow-divider {
+	height: 1px;
+	background: color-mix(in srgb, var(--border) 66%, transparent);
 }
 
-.status-dot {
-	width: 8px;
-	height: 8px;
-	border-radius: 999px;
-	flex-shrink: 0;
-}
-
-.status-dot.status-running {
-	background: var(--accent);
-	animation: pulseDot 1.2s ease-in-out infinite;
-}
-
-.status-dot.status-error {
-	background: var(--danger);
-}
-
-.status-dot.status-ok {
-	background: var(--success);
-}
-
-@keyframes pulseDot {
-	0%,
-	100% {
-		opacity: 1;
-	}
-	50% {
-		opacity: 0.3;
-	}
-}
-
-.tool-name {
-	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+.workflow-summary-label {
 	font-size: 11px;
-	font-weight: 600;
-	color: color-mix(in srgb, var(--text) 94%, var(--muted));
-}
-
-.tool-hint {
-	color: color-mix(in srgb, var(--muted) 86%, var(--text));
+	font-weight: 560;
+	color: color-mix(in srgb, var(--text) 82%, var(--muted));
 	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	flex: 1;
-	text-align: left;
-	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-	font-size: 10px;
 }
 
-.tool-chevron {
+.workflow-summary-meta {
+	font-size: 11px;
+	color: color-mix(in srgb, var(--muted) 90%, var(--text));
+	white-space: nowrap;
+}
+
+.workflow-summary-caret {
+	font-size: 11px;
 	color: color-mix(in srgb, var(--muted) 88%, var(--text));
 }
 
-.tool-output {
-	margin: 0;
-	padding: 8px 12px 10px;
-	background: color-mix(in srgb, var(--bg-elev) 28%, transparent);
-	border-top: none;
+.tool-workflow-summary:hover .workflow-summary-label,
+.tool-workflow-summary:hover .workflow-summary-meta {
+	color: color-mix(in srgb, var(--text) 90%, var(--muted));
+}
+
+.tool-workflow-list {
+	margin-top: 8px;
+	display: grid;
+	gap: 2px;
+}
+
+.tool-workflow-item {
+	border-radius: 8px;
+}
+
+.tool-workflow-line {
+	width: 100%;
+	border: none;
+	background: transparent;
+	padding: 5px 0;
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto auto auto;
+	align-items: center;
+	gap: 8px;
+	cursor: pointer;
+	text-align: left;
+}
+
+.tool-workflow-line:hover {
+	color: var(--text);
+}
+
+.tool-workflow-line-text {
+	font-size: 12px;
+	color: color-mix(in srgb, var(--text) 74%, var(--muted));
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.tool-workflow-count {
 	font-size: 11px;
-	line-height: 1.45;
+	color: color-mix(in srgb, var(--muted) 88%, var(--text));
+	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.tool-workflow-state {
+	font-size: 10px;
+	text-transform: lowercase;
+	letter-spacing: 0.01em;
+}
+
+.tool-workflow-state.running {
+	color: var(--accent);
+}
+
+.tool-workflow-state.error {
+	color: var(--danger);
+}
+
+.tool-workflow-state.done {
+	color: color-mix(in srgb, var(--success) 78%, var(--text));
+}
+
+.tool-workflow-caret {
+	font-size: 11px;
+	color: color-mix(in srgb, var(--muted) 86%, var(--text));
+}
+
+.tool-workflow-details {
+	margin: 4px 0 6px;
+	padding: 0 0 0 8px;
+	display: grid;
+	gap: 8px;
+	border-left: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
+}
+
+.tool-workflow-detail-label {
+	font-size: 10px;
+	color: var(--muted);
+	text-transform: uppercase;
+	letter-spacing: 0.07em;
+	margin-bottom: 4px;
+}
+
+.tool-workflow-output {
+	margin: 0;
+	padding: 8px 10px;
+	background: color-mix(in srgb, var(--bg-muted) 56%, transparent);
+	border-radius: 8px;
+	font-size: 11px;
+	line-height: 1.42;
 	white-space: pre-wrap;
 	color: color-mix(in srgb, var(--text) 78%, var(--muted));
-	max-height: 360px;
+	max-height: 260px;
 	overflow: auto;
 }
 
-.tool-output.tool-output-empty {
+.tool-output-empty {
 	font-style: italic;
 	color: color-mix(in srgb, var(--muted) 90%, var(--text));
 }
 
-:root.light .tool-output {
-	background: color-mix(in srgb, var(--bg-elev) 70%, transparent);
-	color: color-mix(in srgb, var(--text) 74%, var(--muted));
+.assistant-final-divider {
+	margin: 8px 0 10px;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	color: color-mix(in srgb, var(--text) 72%, var(--muted));
+	font-size: 12px;
+}
+
+.assistant-final-divider::before,
+.assistant-final-divider::after {
+	content: "";
+	height: 1px;
+	background: color-mix(in srgb, var(--border) 64%, transparent);
+	flex: 1;
+}
+
+.compaction-row {
+	margin-top: 8px;
+}
+
+.compaction-card {
+	width: min(720px, 100%);
+	border-radius: 10px;
+	background: color-mix(in srgb, var(--bg-elev) 82%, transparent);
+	border: 1px solid color-mix(in srgb, var(--border) 54%, transparent);
+	overflow: hidden;
+}
+
+.compaction-card.running {
+	border-color: color-mix(in srgb, var(--accent) 46%, var(--border));
+}
+
+.compaction-card.error {
+	border-color: color-mix(in srgb, var(--danger) 48%, var(--border));
+}
+
+.compaction-card.done {
+	border-color: color-mix(in srgb, var(--success) 38%, var(--border));
+}
+
+.compaction-header {
+	width: 100%;
+	border: none;
+	background: transparent;
+	padding: 8px 10px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	cursor: pointer;
+	text-align: left;
+}
+
+.compaction-title {
+	font-size: 12px;
+	font-weight: 600;
+	color: color-mix(in srgb, var(--text) 84%, var(--muted));
+}
+
+.compaction-meta {
+	font-size: 11px;
+	color: var(--muted);
+	margin-left: auto;
+}
+
+.compaction-caret {
+	font-size: 11px;
+	color: color-mix(in srgb, var(--muted) 84%, var(--text));
+}
+
+.compaction-details {
+	padding: 0 10px 10px;
+	display: grid;
+	gap: 5px;
+}
+
+.compaction-summary {
+	font-size: 12px;
+	color: color-mix(in srgb, var(--text) 78%, var(--muted));
+}
+
+.compaction-error {
+	font-size: 12px;
+	color: color-mix(in srgb, var(--danger) 84%, var(--text));
+}
+
+.compaction-line {
+	font-size: 11px;
+	color: color-mix(in srgb, var(--muted) 86%, var(--text));
 }
 
 .system-row {
@@ -7252,6 +7387,13 @@ body.sidebar-resizing {
 markdown-block {
 	line-height: 1.62;
 	color: inherit;
+	overflow-wrap: anywhere;
+	word-break: break-word;
+}
+
+markdown-block :not(pre):not(code):not(code *) {
+	overflow-wrap: anywhere;
+	word-break: break-word;
 }
 
 markdown-block p {
@@ -7304,6 +7446,23 @@ markdown-block pre {
 markdown-block code-block > div {
 	background: color-mix(in srgb, var(--bg-soft) 34%, transparent);
 	border: none !important;
+}
+
+.assistant-content markdown-block code-block copy-button,
+markdown-block code-block copy-button {
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 0.14s ease;
+}
+
+.assistant-content markdown-block code-block:hover copy-button,
+.assistant-content markdown-block code-block:focus-within copy-button,
+.assistant-content markdown-block code-block copy-button:focus-within,
+markdown-block code-block:hover copy-button,
+markdown-block code-block:focus-within copy-button,
+markdown-block code-block copy-button:focus-within {
+	opacity: 1;
+	pointer-events: auto;
 }
 
 :root.light .assistant-content markdown-block code-block > div,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4956,6 +4956,10 @@ body.sidebar-resizing {
 	margin: 6px 0 10px;
 }
 
+.tool-workflow.tool-workflow-flat {
+	margin-top: 2px;
+}
+
 .tool-workflow-summary {
 	width: 100%;
 	border: none;
@@ -5001,6 +5005,10 @@ body.sidebar-resizing {
 	margin-top: 8px;
 	display: grid;
 	gap: 2px;
+}
+
+.tool-workflow-flat .tool-workflow-list {
+	margin-top: 0;
 }
 
 .tool-workflow-item {
@@ -5102,6 +5110,17 @@ body.sidebar-resizing {
 	gap: 10px;
 	color: color-mix(in srgb, var(--text) 72%, var(--muted));
 	font-size: 12px;
+}
+
+.assistant-wrapup-missing {
+	margin: 6px 0 10px;
+	font-size: 12px;
+	color: color-mix(in srgb, var(--muted) 92%, var(--text));
+	font-style: italic;
+}
+
+.assistant-tool-only-row {
+	margin-bottom: 10px;
 }
 
 .assistant-final-divider::before,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4998,7 +4998,7 @@ body.sidebar-resizing {
 	color: color-mix(in srgb, var(--text) 82%, var(--muted));
 	white-space: nowrap;
 	font-variant-numeric: tabular-nums;
-	min-width: 7ch;
+	width: 7ch;
 	text-align: center;
 }
 
@@ -5032,11 +5032,12 @@ body.sidebar-resizing {
 
 .tool-workflow-item {
 	border-radius: 8px;
+	max-width: min(100%, 760px);
 }
 
 .tool-workflow-line {
-	width: fit-content;
-	max-width: 100%;
+	width: min(100%, 760px);
+	max-width: min(100%, 760px);
 	border: none;
 	background: transparent;
 	padding: 5px 8px;
@@ -5053,16 +5054,14 @@ body.sidebar-resizing {
 	background: color-mix(in srgb, var(--bg-soft) 72%, transparent);
 }
 
-.tool-workflow-line.running {
-	background: color-mix(in srgb, var(--bg-soft) 62%, transparent);
-}
-
 .tool-workflow-line-text {
 	font-size: 12px;
 	color: color-mix(in srgb, var(--text) 74%, var(--muted));
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	flex: 1;
+	min-width: 0;
 }
 
 .tool-workflow-line-text.running {
@@ -5077,6 +5076,7 @@ body.sidebar-resizing {
 	letter-spacing: 0.02em;
 	color: color-mix(in srgb, var(--accent) 76%, var(--text));
 	animation: toolRunDots 1.2s ease-in-out infinite;
+	margin-left: auto;
 }
 
 @keyframes toolRunDots {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4966,11 +4966,19 @@ body.sidebar-resizing {
 	background: transparent;
 	padding: 0;
 	display: grid;
-	grid-template-columns: 1fr auto auto 1fr;
+	grid-template-columns: 1fr auto 1fr;
 	align-items: center;
 	gap: 10px;
 	cursor: pointer;
 	color: color-mix(in srgb, var(--text) 76%, var(--muted));
+}
+
+.workflow-summary-center {
+	display: inline-flex;
+	align-items: baseline;
+	justify-content: center;
+	gap: 12px;
+	min-width: max-content;
 }
 
 .workflow-divider {
@@ -5021,6 +5029,7 @@ body.sidebar-resizing {
 	gap: 8px;
 	text-align: left;
 	border-radius: 8px;
+	cursor: pointer;
 }
 
 .tool-workflow-line:hover {
@@ -5068,32 +5077,47 @@ body.sidebar-resizing {
 }
 
 .tool-workflow-details {
-	margin: 4px 0 6px;
-	padding: 0 0 0 8px;
+	margin: 2px 0 8px;
+	padding: 0 0 0 10px;
 	display: grid;
-	gap: 8px;
-	border-left: 1px solid color-mix(in srgb, var(--border) 50%, transparent);
-}
-
-.tool-workflow-detail-label {
-	font-size: 10px;
-	color: var(--muted);
-	text-transform: uppercase;
-	letter-spacing: 0.07em;
-	margin-bottom: 4px;
+	gap: 4px;
+	border-left: 1px solid color-mix(in srgb, var(--border) 54%, transparent);
 }
 
 .tool-workflow-output {
 	margin: 0;
-	padding: 8px 10px;
-	background: color-mix(in srgb, var(--bg-muted) 56%, transparent);
-	border-radius: 8px;
+	padding: 0;
+	background: transparent;
+	border-radius: 0;
 	font-size: 11px;
-	line-height: 1.42;
+	line-height: 1.45;
 	white-space: pre-wrap;
-	color: color-mix(in srgb, var(--text) 78%, var(--muted));
-	max-height: 260px;
+	color: color-mix(in srgb, var(--text) 74%, var(--muted));
+	max-height: 220px;
 	overflow: auto;
+}
+
+.tool-workflow-detail-meta {
+	display: flex;
+	justify-content: flex-end;
+}
+
+.tool-workflow-detail-status {
+	font-size: 10px;
+	text-transform: lowercase;
+	letter-spacing: 0.02em;
+}
+
+.tool-workflow-detail-status.done {
+	color: color-mix(in srgb, var(--success) 82%, var(--text));
+}
+
+.tool-workflow-detail-status.error {
+	color: var(--danger);
+}
+
+.tool-workflow-detail-status.running {
+	color: var(--accent);
 }
 
 .tool-output-empty {
@@ -5115,6 +5139,10 @@ body.sidebar-resizing {
 	font-size: 12px;
 	color: color-mix(in srgb, var(--muted) 92%, var(--text));
 	font-style: italic;
+}
+
+.workflow-final-collapsed {
+	margin-top: 6px;
 }
 
 .assistant-tool-only-row {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5125,11 +5125,15 @@ body.sidebar-resizing {
 }
 
 .tool-workflow-thinking-content {
-	margin: 4px 8px 0;
+	margin: 2px 0 8px;
+	padding: 0 0 0 10px;
 	font-size: 12px;
 	line-height: 1.45;
 	color: color-mix(in srgb, var(--muted) 92%, var(--text));
 	white-space: pre-wrap;
+	max-height: 220px;
+	overflow: auto;
+	border-left: 1px solid color-mix(in srgb, var(--border) 54%, transparent);
 }
 
 .tool-workflow-state {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5054,6 +5054,23 @@ body.sidebar-resizing {
 	text-overflow: ellipsis;
 }
 
+.tool-workflow-line-text.running {
+	--tool-run-idle: color-mix(in srgb, var(--text) 70%, var(--muted));
+	--tool-run-active: color-mix(in srgb, var(--text) 92%, var(--accent));
+	color: var(--tool-run-idle);
+	animation: toolRunSweep 1.7s ease-in-out infinite;
+}
+
+@keyframes toolRunSweep {
+	0%,
+	100% {
+		color: var(--tool-run-idle);
+	}
+	50% {
+		color: var(--tool-run-active);
+	}
+}
+
 .tool-workflow-count {
 	font-size: 11px;
 	color: color-mix(in srgb, var(--muted) 88%, var(--text));

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5032,16 +5032,17 @@ body.sidebar-resizing {
 
 .tool-workflow-item {
 	border-radius: 8px;
-	max-width: min(100%, 760px);
+	max-width: 100%;
 }
 
 .tool-workflow-line {
-	width: min(100%, 760px);
-	max-width: min(100%, 760px);
+	width: min(100%, 72ch);
+	max-width: 100%;
+	min-width: 0;
 	border: none;
 	background: transparent;
 	padding: 5px 8px;
-	display: inline-flex;
+	display: flex;
 	align-items: center;
 	gap: 8px;
 	text-align: left;
@@ -5062,6 +5063,7 @@ body.sidebar-resizing {
 	text-overflow: ellipsis;
 	flex: 1;
 	min-width: 0;
+	display: block;
 }
 
 .tool-workflow-line-text.running {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4565,6 +4565,7 @@ body.sidebar-resizing {
 	align-items: baseline;
 	white-space: nowrap;
 	min-height: 14px;
+	animation: pi-running-breath 5.4s ease-in-out infinite;
 }
 
 .chat-working-label,
@@ -5073,10 +5074,8 @@ body.sidebar-resizing {
 }
 
 .tool-workflow-line-text.running {
-	--thinking-idle: color-mix(in srgb, var(--muted) 88%, var(--text));
-	--thinking-active: color-mix(in srgb, var(--text) 80%, var(--muted));
-	color: var(--thinking-idle);
-	animation: thinkingCharSweep 1.8s ease-in-out infinite;
+	color: color-mix(in srgb, var(--text) 72%, var(--muted));
+	animation: pi-running-breath 5.4s ease-in-out infinite;
 }
 
 .tool-workflow-inline-pi {
@@ -5137,7 +5136,7 @@ body.sidebar-resizing {
 }
 
 .tool-workflow-thinking-toggle.animating .tool-workflow-thinking-text {
-	animation: thinkingCharSweep 1.8s ease-in-out infinite;
+	animation: pi-running-breath 5.4s ease-in-out infinite;
 }
 
 .tool-workflow-thinking-toggle.done .tool-workflow-thinking-text,
@@ -7586,7 +7585,37 @@ markdown-block pre {
 .assistant-content markdown-block code-block > div,
 markdown-block code-block > div {
 	background: color-mix(in srgb, var(--bg-soft) 34%, transparent);
+	border: 1px solid color-mix(in srgb, var(--border) 58%, transparent) !important;
+	border-radius: 10px;
+	overflow: hidden;
+}
+
+.assistant-content markdown-block code-block > div > div:first-child,
+markdown-block code-block > div > div:first-child {
+	background: transparent;
+	padding: 6px 10px;
+	min-height: 30px;
+}
+
+.assistant-content markdown-block code-block > div > div:first-child > span,
+markdown-block code-block > div > div:first-child > span {
+	font-size: 11px;
+	color: color-mix(in srgb, var(--text) 66%, var(--muted));
+}
+
+.assistant-content markdown-block code-block > div > div:last-child,
+markdown-block code-block > div > div:last-child {
+	background: transparent;
+	border-top: 1px solid color-mix(in srgb, var(--border) 54%, transparent);
+}
+
+.assistant-content markdown-block code-block > div > div:last-child > pre,
+markdown-block code-block > div > div:last-child > pre {
+	margin: 0 !important;
+	padding: 10px 12px 12px !important;
+	background: transparent !important;
 	border: none !important;
+	border-radius: 0 !important;
 }
 
 .assistant-content markdown-block code-block copy-button,
@@ -7594,6 +7623,37 @@ markdown-block code-block copy-button {
 	opacity: 0;
 	pointer-events: none;
 	transition: opacity 0.14s ease;
+}
+
+.assistant-content markdown-block code-block copy-button button,
+markdown-block code-block copy-button button {
+	width: 24px;
+	height: 24px;
+	min-width: 24px;
+	min-height: 24px;
+	padding: 0 !important;
+	border-radius: 7px;
+	background: transparent !important;
+	color: color-mix(in srgb, var(--text) 70%, var(--muted));
+}
+
+.assistant-content markdown-block code-block copy-button button:hover,
+.assistant-content markdown-block code-block copy-button button:focus-visible,
+markdown-block code-block copy-button button:hover,
+markdown-block code-block copy-button button:focus-visible {
+	background: color-mix(in srgb, var(--bg-soft) 66%, transparent) !important;
+	color: color-mix(in srgb, var(--text) 92%, var(--muted));
+}
+
+.assistant-content markdown-block code-block copy-button button svg,
+markdown-block code-block copy-button button svg {
+	width: 14px;
+	height: 14px;
+}
+
+.assistant-content markdown-block code-block copy-button button > span,
+markdown-block code-block copy-button button > span {
+	display: none;
 }
 
 .assistant-content markdown-block code-block:hover copy-button,
@@ -7609,7 +7669,7 @@ markdown-block code-block copy-button:focus-within {
 :root.light .assistant-content markdown-block code-block > div,
 :root.light markdown-block code-block > div {
 	background: color-mix(in srgb, var(--bg-soft) 80%, #fff 20%);
-	border: none !important;
+	border: 1px solid color-mix(in srgb, var(--border) 56%, transparent) !important;
 }
 
 .assistant-content markdown-block code-block .hljs,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5089,27 +5089,49 @@ body.sidebar-resizing {
 .tool-workflow-thinking {
 	margin-top: 4px;
 	margin-bottom: 8px;
+	width: min(100%, 64ch);
+	max-width: 100%;
 }
 
-.tool-workflow-thinking-label {
-	font-size: 11px;
-	line-height: 1.3;
-	user-select: none;
+.tool-workflow-thinking-toggle {
+	width: 100%;
+	border: none;
+	background: transparent;
+	padding: 5px 8px;
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	cursor: pointer;
+	text-align: left;
 	--thinking-idle: color-mix(in srgb, var(--muted) 88%, var(--text));
 	--thinking-active: color-mix(in srgb, var(--text) 80%, var(--muted));
 }
 
-.tool-workflow-thinking-label.animating .thinking-char {
+.tool-workflow-thinking-caret {
+	font-size: 11px;
+	color: color-mix(in srgb, var(--muted) 86%, var(--text));
+	flex-shrink: 0;
+}
+
+.tool-workflow-thinking-toggle .thinking-char {
+	font-size: 11px;
+	line-height: 1.3;
+	color: var(--thinking-idle);
+}
+
+.tool-workflow-thinking-toggle.animating .thinking-char {
 	animation: thinkingCharSweep 1.8s ease-in-out infinite;
 	animation-delay: calc(var(--thinking-char-index, 0) * 0.12s);
 }
 
-.tool-workflow-thinking-label.done .thinking-char {
+.tool-workflow-thinking-toggle.done .thinking-char,
+.tool-workflow-thinking-toggle:hover .thinking-char,
+.tool-workflow-thinking-toggle:focus-visible .thinking-char {
 	color: var(--thinking-active);
 }
 
 .tool-workflow-thinking-content {
-	margin-top: 4px;
+	margin: 4px 8px 0;
 	font-size: 12px;
 	line-height: 1.45;
 	color: color-mix(in srgb, var(--muted) 92%, var(--text));

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4966,7 +4966,7 @@ body.sidebar-resizing {
 	background: transparent;
 	padding: 0;
 	display: grid;
-	grid-template-columns: 1fr auto auto auto 1fr;
+	grid-template-columns: 1fr auto auto 1fr;
 	align-items: center;
 	gap: 10px;
 	cursor: pointer;
@@ -4991,11 +4991,6 @@ body.sidebar-resizing {
 	white-space: nowrap;
 }
 
-.workflow-summary-caret {
-	font-size: 11px;
-	color: color-mix(in srgb, var(--muted) 88%, var(--text));
-}
-
 .tool-workflow-summary:hover .workflow-summary-label,
 .tool-workflow-summary:hover .workflow-summary-meta {
 	color: color-mix(in srgb, var(--text) 90%, var(--muted));
@@ -5016,20 +5011,21 @@ body.sidebar-resizing {
 }
 
 .tool-workflow-line {
-	width: 100%;
+	width: fit-content;
+	max-width: 100%;
 	border: none;
 	background: transparent;
-	padding: 5px 0;
-	display: grid;
-	grid-template-columns: minmax(0, 1fr) auto auto auto;
+	padding: 5px 8px;
+	display: inline-flex;
 	align-items: center;
 	gap: 8px;
-	cursor: pointer;
 	text-align: left;
+	border-radius: 8px;
 }
 
 .tool-workflow-line:hover {
 	color: var(--text);
+	background: color-mix(in srgb, var(--bg-soft) 72%, transparent);
 }
 
 .tool-workflow-line-text {
@@ -5064,9 +5060,11 @@ body.sidebar-resizing {
 	color: color-mix(in srgb, var(--success) 78%, var(--text));
 }
 
-.tool-workflow-caret {
-	font-size: 11px;
-	color: color-mix(in srgb, var(--muted) 86%, var(--text));
+.tool-file-target {
+	color: color-mix(in srgb, var(--accent) 78%, #4f95ff);
+	background: color-mix(in srgb, var(--accent) 14%, transparent);
+	border-radius: 6px;
+	padding: 1px 5px;
 }
 
 .tool-workflow-details {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4965,10 +4965,9 @@ body.sidebar-resizing {
 	border: none;
 	background: transparent;
 	padding: 0;
-	display: grid;
-	grid-template-columns: 1fr auto 1fr;
+	display: flex;
 	align-items: center;
-	gap: 10px;
+	gap: 12px;
 	cursor: pointer;
 	color: color-mix(in srgb, var(--text) 76%, var(--muted));
 }
@@ -4979,11 +4978,13 @@ body.sidebar-resizing {
 	justify-content: center;
 	gap: 12px;
 	min-width: max-content;
+	margin: 0 auto;
 }
 
 .workflow-divider {
 	height: 1px;
 	background: color-mix(in srgb, var(--border) 66%, transparent);
+	flex: 1;
 }
 
 .workflow-summary-label {
@@ -4991,16 +4992,24 @@ body.sidebar-resizing {
 	font-weight: 560;
 	color: color-mix(in srgb, var(--text) 82%, var(--muted));
 	white-space: nowrap;
+	font-variant-numeric: tabular-nums;
 }
 
 .workflow-summary-meta {
 	font-size: 11px;
 	color: color-mix(in srgb, var(--muted) 90%, var(--text));
 	white-space: nowrap;
+	font-variant-numeric: tabular-nums;
+}
+
+.workflow-summary-caret {
+	font-size: 12px;
+	color: color-mix(in srgb, var(--muted) 86%, var(--text));
 }
 
 .tool-workflow-summary:hover .workflow-summary-label,
-.tool-workflow-summary:hover .workflow-summary-meta {
+.tool-workflow-summary:hover .workflow-summary-meta,
+.tool-workflow-summary:hover .workflow-summary-caret {
 	color: color-mix(in srgb, var(--text) 90%, var(--muted));
 }
 
@@ -5134,19 +5143,8 @@ body.sidebar-resizing {
 	font-size: 12px;
 }
 
-.assistant-wrapup-missing {
-	margin: 6px 0 10px;
-	font-size: 12px;
-	color: color-mix(in srgb, var(--muted) 92%, var(--text));
-	font-style: italic;
-}
-
 .workflow-final-collapsed {
 	margin-top: 6px;
-}
-
-.assistant-tool-only-row {
-	margin-bottom: 10px;
 }
 
 .assistant-final-divider::before,

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5036,7 +5036,7 @@ body.sidebar-resizing {
 }
 
 .tool-workflow-line {
-	width: min(100%, 72ch);
+	width: min(100%, 64ch);
 	max-width: 100%;
 	min-width: 0;
 	border: none;
@@ -5050,9 +5050,10 @@ body.sidebar-resizing {
 	cursor: pointer;
 }
 
-.tool-workflow-line:hover {
-	color: var(--text);
-	background: color-mix(in srgb, var(--bg-soft) 72%, transparent);
+.tool-workflow-line:hover,
+.tool-workflow-line:focus-visible {
+	color: inherit;
+	background: transparent;
 }
 
 .tool-workflow-line-text {
@@ -5066,45 +5067,53 @@ body.sidebar-resizing {
 	display: block;
 }
 
+.tool-workflow-line:hover .tool-workflow-line-text,
+.tool-workflow-line:focus-visible .tool-workflow-line-text {
+	color: color-mix(in srgb, var(--text) 88%, var(--muted));
+}
+
 .tool-workflow-line-text.running {
-	--tool-run-idle: color-mix(in srgb, var(--text) 70%, var(--muted));
-	--tool-run-active: color-mix(in srgb, var(--text) 92%, var(--accent));
-	color: var(--tool-run-idle);
-	animation: toolRunSweep 1.6s ease-in-out infinite;
-}
-
-.tool-workflow-running-indicator {
-	font-size: 10px;
-	letter-spacing: 0.02em;
-	color: color-mix(in srgb, var(--accent) 76%, var(--text));
-	animation: toolRunDots 1.2s ease-in-out infinite;
-	margin-left: auto;
-}
-
-@keyframes toolRunDots {
-	0%,
-	100% {
-		opacity: 0.32;
-	}
-	50% {
-		opacity: 1;
-	}
-}
-
-@keyframes toolRunSweep {
-	0%,
-	100% {
-		color: var(--tool-run-idle);
-	}
-	50% {
-		color: var(--tool-run-active);
-	}
+	--thinking-idle: color-mix(in srgb, var(--muted) 88%, var(--text));
+	--thinking-active: color-mix(in srgb, var(--text) 80%, var(--muted));
+	color: var(--thinking-idle);
+	animation: thinkingCharSweep 1.8s ease-in-out infinite;
 }
 
 .tool-workflow-count {
 	font-size: 11px;
 	color: color-mix(in srgb, var(--muted) 88%, var(--text));
 	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	flex-shrink: 0;
+}
+
+.tool-workflow-thinking {
+	margin-top: 4px;
+	margin-bottom: 8px;
+}
+
+.tool-workflow-thinking-label {
+	font-size: 11px;
+	line-height: 1.3;
+	user-select: none;
+	--thinking-idle: color-mix(in srgb, var(--muted) 88%, var(--text));
+	--thinking-active: color-mix(in srgb, var(--text) 80%, var(--muted));
+}
+
+.tool-workflow-thinking-label.animating .thinking-char {
+	animation: thinkingCharSweep 1.8s ease-in-out infinite;
+	animation-delay: calc(var(--thinking-char-index, 0) * 0.12s);
+}
+
+.tool-workflow-thinking-label.done .thinking-char {
+	color: var(--thinking-active);
+}
+
+.tool-workflow-thinking-content {
+	margin-top: 4px;
+	font-size: 12px;
+	line-height: 1.45;
+	color: color-mix(in srgb, var(--muted) 92%, var(--text));
+	white-space: pre-wrap;
 }
 
 .tool-workflow-state {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4358,6 +4358,11 @@ body.sidebar-resizing {
 	align-items: flex-start;
 }
 
+.assistant-workflow-row .message-shell,
+.assistant-workflow-row .assistant-block {
+	width: 100%;
+}
+
 .message-actions {
 	display: flex;
 	gap: 6px;
@@ -4993,6 +4998,8 @@ body.sidebar-resizing {
 	color: color-mix(in srgb, var(--text) 82%, var(--muted));
 	white-space: nowrap;
 	font-variant-numeric: tabular-nums;
+	min-width: 7ch;
+	text-align: center;
 }
 
 .workflow-summary-meta {
@@ -5046,6 +5053,10 @@ body.sidebar-resizing {
 	background: color-mix(in srgb, var(--bg-soft) 72%, transparent);
 }
 
+.tool-workflow-line.running {
+	background: color-mix(in srgb, var(--bg-soft) 62%, transparent);
+}
+
 .tool-workflow-line-text {
 	font-size: 12px;
 	color: color-mix(in srgb, var(--text) 74%, var(--muted));
@@ -5058,7 +5069,24 @@ body.sidebar-resizing {
 	--tool-run-idle: color-mix(in srgb, var(--text) 70%, var(--muted));
 	--tool-run-active: color-mix(in srgb, var(--text) 92%, var(--accent));
 	color: var(--tool-run-idle);
-	animation: toolRunSweep 1.7s ease-in-out infinite;
+	animation: toolRunSweep 1.6s ease-in-out infinite;
+}
+
+.tool-workflow-running-indicator {
+	font-size: 10px;
+	letter-spacing: 0.02em;
+	color: color-mix(in srgb, var(--accent) 76%, var(--text));
+	animation: toolRunDots 1.2s ease-in-out infinite;
+}
+
+@keyframes toolRunDots {
+	0%,
+	100% {
+		opacity: 0.32;
+	}
+	50% {
+		opacity: 1;
+	}
 }
 
 @keyframes toolRunSweep {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5113,20 +5113,19 @@ body.sidebar-resizing {
 	flex-shrink: 0;
 }
 
-.tool-workflow-thinking-toggle .thinking-char {
+.tool-workflow-thinking-text {
 	font-size: 11px;
 	line-height: 1.3;
 	color: var(--thinking-idle);
 }
 
-.tool-workflow-thinking-toggle.animating .thinking-char {
+.tool-workflow-thinking-toggle.animating .tool-workflow-thinking-text {
 	animation: thinkingCharSweep 1.8s ease-in-out infinite;
-	animation-delay: calc(var(--thinking-char-index, 0) * 0.12s);
 }
 
-.tool-workflow-thinking-toggle.done .thinking-char,
-.tool-workflow-thinking-toggle:hover .thinking-char,
-.tool-workflow-thinking-toggle:focus-visible .thinking-char {
+.tool-workflow-thinking-toggle.done .tool-workflow-thinking-text,
+.tool-workflow-thinking-toggle:hover .tool-workflow-thinking-text,
+.tool-workflow-thinking-toggle:focus-visible .tool-workflow-thinking-text {
 	color: var(--thinking-active);
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5127,9 +5127,9 @@ body.sidebar-resizing {
 .tool-workflow-thinking-content {
 	margin: 2px 0 8px;
 	padding: 0 0 0 10px;
-	font-size: 12px;
+	font-size: 11px;
 	line-height: 1.45;
-	color: color-mix(in srgb, var(--muted) 92%, var(--text));
+	color: color-mix(in srgb, var(--text) 74%, var(--muted));
 	white-space: pre-wrap;
 	max-height: 220px;
 	overflow: auto;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -4530,29 +4530,29 @@ body.sidebar-resizing {
 .chat-working-indicator {
 	display: inline-flex;
 	align-items: center;
-	gap: 7px;
+	gap: 6px;
 	padding: 0;
 	border: none;
 	background: transparent;
-	color: color-mix(in srgb, var(--text) 88%, var(--muted));
+	color: color-mix(in srgb, var(--text) 74%, var(--muted));
 	width: fit-content;
 	min-height: 20px;
 }
 
 .chat-working-pi {
-	width: 12px;
-	height: 12px;
+	width: 11px;
+	height: 11px;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	color: color-mix(in srgb, var(--text) 86%, var(--muted) 14%);
-	opacity: 1;
+	color: color-mix(in srgb, var(--text) 72%, var(--muted));
+	opacity: 0.9;
 	animation: pi-running-breath 5.4s ease-in-out infinite;
 }
 
 .chat-working-pi svg {
-	width: 11px;
-	height: 11px;
+	width: 10px;
+	height: 10px;
 	display: block;
 }
 
@@ -4571,8 +4571,8 @@ body.sidebar-resizing {
 .chat-working-dots {
 	font-family: inherit;
 	font-size: 11px;
-	font-weight: 500;
-	color: color-mix(in srgb, var(--text) 88%, var(--muted));
+	font-weight: 460;
+	color: color-mix(in srgb, var(--text) 74%, var(--muted));
 	line-height: 1;
 	text-transform: none;
 }
@@ -5079,6 +5079,28 @@ body.sidebar-resizing {
 	animation: thinkingCharSweep 1.8s ease-in-out infinite;
 }
 
+.tool-workflow-inline-pi {
+	width: 11px;
+	height: 11px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	color: color-mix(in srgb, var(--text) 72%, var(--muted));
+	opacity: 0.9;
+	animation: pi-running-breath 5.4s ease-in-out infinite;
+	flex-shrink: 0;
+}
+
+.tool-workflow-inline-pi svg {
+	width: 10px;
+	height: 10px;
+	display: block;
+}
+
+.tool-workflow-inline-pi path {
+	fill: currentColor;
+}
+
 .tool-workflow-count {
 	font-size: 11px;
 	color: color-mix(in srgb, var(--muted) 88%, var(--text));
@@ -5100,7 +5122,7 @@ body.sidebar-resizing {
 	padding: 5px 8px;
 	display: flex;
 	align-items: center;
-	gap: 0;
+	gap: 6px;
 	cursor: pointer;
 	text-align: left;
 	--thinking-idle: color-mix(in srgb, var(--muted) 88%, var(--text));


### PR DESCRIPTION
## Summary
This PR completes the chat-interface sweep on `feat/chat-interface-issue-sweep`, focusing on Codex-style workflow clarity, streaming-state stability, markdown/codeblock polish, and robust tool/thinking timeline behavior.

### Implemented
- Compact assistant workflow timeline with centered duration header and grouped repeated tool calls.
- Stable workflow expansion/collapse behavior:
  - open by default while active,
  - collapse only on assistant handoff,
  - manual user collapse override is respected during active runs.
- Robust thinking/tool interleaving in workflow details (thinking can appear before/between/after tools).
- Streaming-state hardening:
  - no transient empty assistant placeholder rows,
  - reduced spacing jumps before workflow materialization,
  - stronger dedupe/merge of repeated streamed thinking content.
- Running affordances:
  - synchronized text/Pi animation cadence,
  - inline Pi indicators on active workflow rows,
  - calmer bottom running indicator styling.
- Markdown/codeblock UX polish:
  - improved code-block visual hierarchy (single-surface treatment),
  - reduced copy-button chrome,
  - message-level copy suppressed for assistant replies that are only a single fenced code block.
- Overflow and wrapping safeguards for chat prose vs code scrolling.

### Documentation updates
- Updated `CHANGELOG.md` (Unreleased chat sweep additions/fixes).
- Updated `TODO.md` chat-sweep recap and issue status notes.
- Updated `docs/ISSUE_IMPLEMENTATION_LOG_2026-03-31.md` with per-issue implementation status and follow-ups.

## Validation
- `npm run check`
- `npm run build:frontend`

## Issue mapping
Closes #49
Closes #50
Closes #52
Closes #53
Closes #54
Closes #55
Closes #72

Refs #63
Refs #70
