### PR TITLE
feat: finalize slash/settings reliability and codex-style settings shell polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,23 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 
 ### Changed
 - Reworked the no-project / new-thread welcome view into a cleaner Codex-inspired centered layout with Pi Desktop branding, a project-focused dropdown, and reduced UI chrome.
+- Settings navigation now lives in the main left sidebar while Settings is open, and the right pane uses simplified section-first headers with reduced chrome.
+- Composer now supports terminal-style full input history traversal (`ArrowUp` / `ArrowDown`) across previously sent prompts and slash commands.
+- Slash palette keyboard navigation now previews the active command directly in the composer input and keeps the active row visible while traversing.
+- Command palette (`Cmd/Ctrl+K`) keyboard navigation now auto-scrolls the selected row into view for long lists.
 - Welcome project dropdown now lists all projects in the current workspace and supports direct project switching (plus quick actions for add project, packages, and settings).
 - Welcome heading copy now rotates between Pi-style idle phrases for a calmer ambient experience.
 - Reworked assistant tool-heavy runs into a compact workflow timeline with centered duration summary, grouped repeated tool calls, and progressive disclosure for details.
 - Workflow detail timeline now preserves natural interleaving of thinking and tool entries (including mid-run thinking blocks), instead of forcing thinking to the top.
 - Running-state affordances now use synchronized Pi/text animation cadence, including inline Pi indicators on active workflow rows and toned-down bottom-status typography.
 - Polished markdown code blocks toward a cleaner Codex-like appearance (single surface, tightened header/content spacing, smaller copy affordance, less chrome).
+- Composer slash palette now shows CLI-first command groups with runtime-discovered extension/prompt/skill commands, while keeping visual chrome minimal.
+- Compaction status rendering was reduced to a minimal workflow-style row with collapsed-by-default details instead of a heavy status card.
 
 ### Fixed
 - Bundled default Pi Desktop themes now emit full Pi CLI-compatible theme schema (all required color tokens) instead of a partial Desktop-only color set.
+- Fixed `/scoped-models` settings-open race causing Lit `ChildPart has no parentNode` errors by removing unsupported `innerHTML` mutation paths in `SettingsPanel` render/fallback lifecycle.
+- Fixed user message bubble width/wrapping regression that could squeeze short text into broken wrapping (`he j`) by correcting user-shell width constraints and wrap behavior.
 - Added bundled-theme auto-repair for legacy invalid `~/.pi/agent/themes/pi-desktop-*.json` files so existing installs stop producing CLI theme validation errors.
 - Theme files created from Settings (“Create theme”) now use the full Pi theme schema, so custom exports are valid in both Desktop and CLI.
 - Hardened Settings pane mounting/open flow to recover from race conditions and stale container rebinding during workspace/project transitions.
@@ -27,6 +35,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Removed transient blank spacing before workflow materialization by avoiding empty assistant placeholder rows during stream startup.
 - Fixed repeated streamed thinking duplication by tightening partial-update merge/dedupe behavior in workflow rendering.
 - Assistant message-level copy action is now suppressed for messages that are only a single fenced code block (copy remains on the code block itself).
+- Fixed slash command execution regressions where `/` input could fall through to plain prompt sends; built-in commands now execute deterministically from the composer.
+- Fixed workflow summary counters to report mixed outcomes correctly (complete + failed + running) instead of over-reporting failures.
+- Removed blinking assistant-body streaming cursor artifact and removed noisy composer status text beneath model controls.
+- Fixed compaction timeline behavior so compaction rows stay anchored at the correct chronological position instead of drifting to the newest row.
 
 ## [0.1.8] - 2026-03-23
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,42 @@
 # TODO — V1/V1.1 release cleanup plan
 
+## Session update (2026-04-04) — Issue #70
+
+Status: **In progress, near completion**
+
+Done in this session:
+- [x] Replaced hardcoded slash “Actions” with CLI-aligned command handling + runtime command discovery (`extension`/`prompt`/`skill`).
+- [x] Fixed slash execution reliability (`/compact`, `/settings`, `/model`, etc.) so slash input no longer falls back to sending plain `/` prompts.
+- [x] Added deterministic slash selection behavior (exact match / active menu item) and unknown-command handling.
+- [x] Removed command echo noise in chat canvas for desktop-mapped slash actions.
+- [x] Reworked compaction UX to minimal workflow-style row (no heavy card), with collapsed-by-default details and timeline-stable insertion.
+- [x] Fixed workflow summary counts to report combined outcomes (e.g. complete + failed + running).
+- [x] Removed blinking streaming cursor from assistant message body.
+- [x] Removed composer status line noise beneath model picker.
+
+Remaining before closing #70:
+- [ ] Final command-by-command QA matrix pass and polish (especially less-used built-ins and extension-config command mappings).
+  - [x] Composer history polish complete (`ArrowUp`/`ArrowDown` traverses full message/command history terminal-style).
+  - [x] Slash palette keyboard UX polish complete (active row visibility + live composer command preview while navigating).
+  - [x] Command palette keyboard visibility polish complete (selected command row auto-scrolls into view).
+  - [x] User message bubble width/render regression fixed (no more squeezed `he j` wrapping artifacts on short messages).
+  - [x] `/name` parity pass complete (inline sidebar rename when no arg, shared rename pipeline when arg provided).
+  - [x] `/new` parity pass complete (reuses sidebar fresh-session flow via `startFreshSessionTab()`).
+  - [x] `/import` parity pass complete (supports native file picker when no path arg is provided).
+  - [x] `/export` parity pass complete (supports native save picker when no path arg is provided).
+  - [x] `/reload` parity pass complete (restarts active runtime bridge, then refreshes state/models/commands).
+  - [x] `/session` parity pass complete (renders detailed session info block in timeline, not just a toast).
+  - [x] `/share` parity pass complete (CLI-aligned secret gist flow via `gh`, exported as `session.html`, minimal clickable output).
+  - [x] `/tree` UX polish pass complete (supports prefilled `/tree <query>`, full JSONL-backed session-tree browse across branches, terminal-like inline tree connectors, active-path markers, and quick fork actions).
+  - [x] `/scoped-models` native Settings implementation complete (searchable model scope editor with provider toggles + persisted `enabledModels` save path).
+  - [x] `/login` + `/logout` polish pass complete (terminal-only guidance with compact auth row; no misleading settings mapping).
+  - [x] `/changelog` parity pass complete (loads Pi Coding Agent changelog from CLI package; shows latest sections in collapsible/scrollable row with `/changelog all` option).
+  - [x] `/fork` parity pass updated (`/fork <query>` pre-fills user-message fork selector, aligned with CLI user-only fork model).
+  - [x] `/resume` UX polish pass complete (`/resume <query>` pre-fills session-browser search).
+  - [x] `/model` UX polish pass complete (non-exact args open picker with provider-aware hinting; no noisy mismatch toast).
+- [ ] Update issue comments/changelog with final verified behavior and close #70 only after smoke checks.
+- [ ] Keep `/tree` + `/fork` minor UI polish out of #70 close criteria and track in dedicated follow-up issue (`issues/tree-fork-polish-followup.md`).
+
 ## Chat interface sweep plan (new branch)
 
 Branch: `feat/chat-interface-issue-sweep` (based on `origin/dev`)
@@ -260,6 +297,7 @@ The app should feel native while still reflecting Pi’s actual resource model.
 - [x] Add first-run onboarding card when Pi CLI is missing (install + copy command + retry)
 - [x] Add in-app Pi CLI update signaling (startup + daily reminder + sidebar hint + settings update path)
 - [x] Harden settings pane open/render lifecycle across no-project + project-switch states (#69)
+- [x] Rework Settings IA: move section navigation into the main app sidebar while Settings content becomes cleaner/simpler in the right pane (no-project-safe section fallback retained).
 - [x] Refine no-project/new-thread welcome dashboard toward clean Codex-inspired centered flow (#63, partial)
 - [ ] Final new-file draft UX polish pass
 - [ ] Final session delete/select stability polish pass

--- a/commandsdevelopment.md
+++ b/commandsdevelopment.md
@@ -1,0 +1,57 @@
+# Commands development log (#70)
+
+Last updated: 2026-04-06 (post-UX polish)
+
+## Goal
+Bring all composer slash commands to a stable, desktop-native behavior model where commands reuse existing UI/flows instead of ad-hoc implementations.
+
+## Status summary
+- ✅ Implemented: **17 / 20**
+- 🟡 Partial / placeholder: **3 / 20** (`/tree`, `/login`, `/logout`)
+- 🔴 Not implemented: **0 / 20**
+- 📝 Deferred follow-up polish: `/tree` + `/fork` visual/interaction cleanup tracked separately (`issues/tree-fork-polish-followup.md`).
+
+## Current implementation snapshot
+
+| Command | Current behavior | Reuse quality | Notes |
+|---|---|---:|---|
+| `/settings` | Opens Desktop Settings pane | ✅ | Reuses same path as settings gear / app settings entry (`requestOpenSettingsPanel`). |
+| `/model` | No arg opens picker. Exact arg sets model; non-exact arg opens picker with provider-aware hinting. | ✅ | Reuses existing model picker + `setModel`, avoids noisy no-match toasts while staying deterministic. |
+| `/scoped-models` | Opens native Settings scoped-models editor (model enable/disable for Ctrl+P cycle) with search, provider toggles, save, and refresh. | ✅ | Persists to Pi global settings (`enabledModels`) and keeps Desktop behavior aligned with CLI model scope semantics. |
+| `/export` | With arg: exports to provided path. Without arg: opens native save dialog and exports to chosen location. | ✅ | Reuses existing RPC `exportHtml`; adds desktop-native save picker for no-arg flow. |
+| `/import` | With arg: imports from path. Without arg: opens native file picker, then imports selected session. | ✅ | Reuses existing RPC `switchSession` flow; adds desktop-native picker UX when no path is provided. |
+| `/share` | Exports to `session.html`, creates a secret GitHub gist, then shows minimal clickable links (pi.dev + gist). | ✅ | CLI-aligned `gh gist create --public=false` flow via desktop host command (avoids chat bash-noise and keeps share output minimal). |
+| `/copy` | Copies last assistant message | ✅ | Reuses existing copy path. |
+| `/name` | With arg: renames through shared sidebar/main rename pipeline. Without arg: attempts inline sidebar rename editor, then falls back to prompt. | ✅ | Reuses same workspace/session rename path as sidebar context rename. |
+| `/session` | Appends a detailed session info block to timeline (name/file/id/model, message + token stats). | ✅ | Mirrors CLI intent with richer in-chat output instead of a short toast. |
+| `/changelog` | Shows latest changelog sections in a collapsed, scrollable chat row (`/changelog all` for full file, `/changelog refresh` to reload). | ✅ | Uses CLI discovery + package changelog resolution, then presents minimal in-canvas output (no browser URL dependency). |
+| `/hotkeys` | Opens shortcuts panel | ✅ | Reuses shortcuts overlay. |
+| `/fork` | Opens user-message fork selector (CLI-style); `/fork <query>` pre-fills user-message search. | ✅ | Uses RPC `get_fork_messages` directly, matching CLI behavior (select user turn to fork from). |
+| `/tree` | Opens full session-tree viewer from JSONL with terminal-like inline connectors (`│ ├─ └─`), role-prefixed lines (`user:`/`assistant:`/`[tool:]`), active-path markers, query prefill, and quick Fork on user nodes. | 🟡 | Stronger CLI-style tree UX/readability, but still not full branch-switch navigation (`navigateTree`) parity in Desktop. |
+| `/login` | Shows terminal guidance (`pi` then `/login [provider]`) with compact in-chat auth row. | 🟡 | Deterministic non-misleading placeholder until native Desktop OAuth flow exists. |
+| `/logout` | Shows terminal guidance (`pi` then `/logout [provider]`) with compact in-chat auth row. | 🟡 | Deterministic non-misleading placeholder until native Desktop OAuth flow exists. |
+| `/new` | Starts a fresh session tab using the same workspace flow as sidebar “New session”. | ✅ | Reuses `startFreshSessionTab()` path via chat callback; falls back to runtime `newSession()` only if callback is unavailable. |
+| `/compact` | Runs compact with minimal compaction timeline row | ✅ | Implemented + polished in this session. |
+| `/resume` | Opens session browser; `/resume <query>` pre-fills session search. | ✅ | Reuses existing session browser and filtering state (no new backend behavior). |
+| `/reload` | Performs a runtime reload pass for active workspace/session (bridge restart + state/models/commands refresh). | ✅ | Reuses existing runtime orchestration (`ensureRuntimeForSessionTab`) instead of ad-hoc reload logic. |
+| `/quit` | Closes app window | ✅ | Native app behavior. |
+
+## Recent UX polish (2026-04-06)
+
+- Composer now supports terminal-style full input history traversal with `ArrowUp` / `ArrowDown` (not only the last message).
+- Slash palette keyboard navigation now keeps the highlighted row reliably visible when traversing long command lists.
+- Slash palette keyboard highlight now previews the selected slash command directly in the composer input (`/mod` -> `Arrow` to `/model` updates the input live).
+- Command Palette (`Cmd/Ctrl+K`) now auto-scrolls selected rows into view during keyboard navigation.
+
+## Runtime commands
+Runtime-discovered commands (`extension` / `prompt` / `skill`) come from `get_commands`.
+
+- Extension `*-config` commands can be mapped to Desktop config UI.
+- Current mapping implemented: `name-ai-config` -> opens package config modal for `pi-session-auto-rename`.
+
+## Plan (step-by-step)
+1. Validate `/name` parity smoke checks (with arg + no arg inline edit path).
+2. Validate command-by-command smoke checks (project and runtime states).
+3. Keep `/tree` + `/fork` behavior parity locked and ship minor UI polish via follow-up issue (post-#70).
+4. Decide login/logout desktop OAuth scope vs explicit “terminal required” behavior.
+5. Final #70 QA and closure notes.

--- a/docs/ISSUE_IMPLEMENTATION_LOG_2026-03-31.md
+++ b/docs/ISSUE_IMPLEMENTATION_LOG_2026-03-31.md
@@ -18,7 +18,7 @@ This log now covers both implementation tracks completed/advanced on 2026-03-31:
 - **#63** Codex parity umbrella — **Partially implemented** (welcome slice merged; chat slice implemented on sweep branch)
 - **#66** Theme schema / CLI compatibility — **Merged to dev (PR #73)**
 - **#69** Settings pane render hardening — **Merged to dev (PR #73)**
-- **#70** Slash action audit/cleanup — **In progress**
+- **#70** Slash action audit/cleanup — **In progress (major implementation complete, final QA/polish pending)**
 - **#72** Tool-result/steer timeline anomalies — **Implemented (chat sweep branch)**
 
 ---
@@ -42,6 +42,8 @@ Implemented:
 - Deterministic pane open/mount handling with race/rebind guards.
 - Safe fallback settings shell when runtime-dependent sections fail.
 - No-project settings flow decoupled from runtime-dependent rendering.
+- Codex-style Settings information architecture: section navigation now lives in the main Desktop left sidebar (replacing project/session list while Settings is open), with right-side contextual panel rendering per section.
+- Runtime-gated sections (`General`, `Account`) now gracefully disable/fallback in no-project or disconnected runtime states while `Appearance` and update visibility remain usable.
 
 ---
 
@@ -92,13 +94,29 @@ Implemented:
 
 ### #70 — Slash actions
 
-Status: **Not complete**
+Status: **In progress, near completion**
 
-Progress:
-- Redundant slash actions already covered by clearer UI entry points were reduced.
+Progress (2026-04-04 follow-up):
+- Replaced hardcoded slash action list with CLI-aligned built-in command handling plus runtime-discovered commands (`extension` / `prompt` / `skill`).
+- Fixed slash reliability so composer `/` input executes commands deterministically instead of falling back to plain prompt sends.
+- Desktop-mapped commands now execute host actions directly (e.g. settings/model/session browser flows) without chat-canvas command spam.
+- Added extension config bridge hook for `name-ai-config` to open the Desktop Packages extension-config modal.
+- Reworked compaction UX into a minimal workflow-style row with collapsed-by-default details and stable timeline placement.
+- Removed assistant streaming cursor artifact and cleaned workflow status aggregation (`complete` + `failed` + `running`).
+
+Additional UX hardening (2026-04-06 follow-up):
+- Settings open flow hardened for `/scoped-models`: removed unsupported `innerHTML` mutation paths in `SettingsPanel` to avoid Lit `ChildPart has no parentNode` render failures during async section refreshes.
+- Settings visual cleanup completed: sidebar-hosted settings navigation, workspace header hidden in settings shell, and simplified settings top chrome.
+- Composer now supports terminal-style full history navigation via `ArrowUp`/`ArrowDown` for prior user prompts and slash commands.
+- Slash keyboard navigation now previews selected command text directly in composer and keeps highlighted rows visible.
+- Command palette keyboard navigation now auto-scrolls selected rows into view.
+- User message bubble width/wrapping regression fixed (`he j` squeeze artifact removed).
 
 Remaining:
-- Final curated slash list audit and `/compact`-path validation before closing #70.
+- Final command-by-command QA matrix pass for lower-frequency built-ins and extension command mappings.
+  - Completed in follow-up pass: `/name` (sidebar-inline parity), `/new` (fresh-session sidebar parity), `/import` (native picker fallback when no arg), `/export` (native save picker when no arg), `/reload` (runtime restart + full desktop refresh pass), `/session` (detailed timeline info block parity), `/share` (CLI-aligned secret gist flow via `gh`, `session.html` export, minimal clickable output + compact left-aligned row), `/tree` (query-aware full session-tree viewer from JSONL across branches with terminal-like inline connectors and active-path markers, plus quick fork actions), `/fork` (query-aware user-message selector aligned with CLI fork behavior), `/resume` (query-aware session browser open via `/resume <query>`), `/model` (provider-aware picker hinting when arg is non-exact), `/scoped-models` (native Settings scoped-models editor with search/provider toggles and persisted `enabledModels` saves), `/login` + `/logout` (terminal-only guidance rows, no misleading settings routing), `/changelog` (Pi Coding Agent changelog from CLI package, latest sections by default in collapsed scrollable row, `all/refresh` options).
+- Close #70 only after targeted smoke validation across project/no-project and streaming/non-streaming contexts.
+- Minor tree/fork UI polish (spacing/readability/keybind-level UX) is intentionally tracked as post-#70 follow-up (`issues/tree-fork-polish-followup.md`).
 
 ---
 

--- a/issues/tree-fork-polish-followup.md
+++ b/issues/tree-fork-polish-followup.md
@@ -1,0 +1,33 @@
+# Follow-up: tree/fork UI polish after #70
+
+Status: Deferred intentionally (not a #70 blocker)
+Created: 2026-04-06
+
+## Context
+`/tree` and `/fork` are now behaviorally separated:
+- `/tree` = full session tree overview across branches
+- `/fork` = user-message selector (CLI-style)
+
+Parity behavior is in place, but we still want focused visual/interaction polish.
+
+## Polish scope
+
+### `/tree`
+- Improve deep-tree readability without introducing horizontal scroll.
+- Reduce visual density in long sessions (row rhythm/contrast).
+- Tune connector/path marker clarity in dark/light themes.
+- Optional: add keyboard navigation affordances closer to CLI tree selector semantics.
+
+### `/fork`
+- Keep user-only list compact and scannable in long sessions.
+- Improve selected/hover state hierarchy for fast message picking.
+- Optional: richer message snippet formatting (without timeline/tool noise).
+
+## Non-goals
+- Do not re-merge `/fork` into full history timeline UI.
+- Do not add desktop-only behavior that diverges from CLI fork semantics.
+
+## Acceptance criteria
+- `/tree` remains readable in very deep sessions and never exposes blank horizontal scroll area.
+- `/fork` shows only user messages and supports quick fork selection with minimal noise.
+- No regressions in slash reliability or fork/tree command determinism.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
@@ -312,6 +312,114 @@ fn discover_npm_path(pi: Option<&PiProcess>) -> Option<PathBuf> {
     candidates.push(PathBuf::from("/usr/bin").join(npm));
 
     candidates.into_iter().find(|candidate| candidate.is_file())
+}
+
+fn discover_npm_global_root(pi: Option<&PiProcess>) -> Option<PathBuf> {
+    let npm_path = discover_npm_path(pi)?;
+
+    let mut cmd = Command::new(&npm_path);
+    cmd.arg("root")
+        .arg("-g")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    if let Some(parent) = npm_path.parent() {
+        prepend_bin_dir_to_path(&mut cmd, parent);
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+
+    let output = cmd.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let root = stdout
+        .lines()
+        .next()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())?;
+
+    let path = PathBuf::from(root);
+    if path.is_dir() {
+        Some(path)
+    } else {
+        None
+    }
+}
+
+fn resolve_pi_changelog_candidates(pi: &PiProcess) -> Vec<PathBuf> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    if let Ok(pkg_dir) = std::env::var("PI_PACKAGE_DIR") {
+        let trimmed = pkg_dir.trim();
+        if !trimmed.is_empty() {
+            candidates.push(PathBuf::from(trimmed).join("CHANGELOG.md"));
+        }
+    }
+
+    match pi {
+        PiProcess::DevNode { script } => {
+            let script_path = PathBuf::from(script);
+            if let Some(dist_dir) = script_path.parent() {
+                candidates.push(dist_dir.join("..").join("CHANGELOG.md"));
+            }
+        }
+        PiProcess::PathBinary { path } | PiProcess::SidecarBinary { path } => {
+            let mut binaries = vec![path.clone()];
+            if let Ok(canonical) = fs::canonicalize(path) {
+                binaries.push(canonical);
+            }
+            for binary in binaries {
+                if let Some(parent) = binary.parent() {
+                    candidates.push(
+                        parent
+                            .join("..")
+                            .join("lib")
+                            .join("node_modules")
+                            .join("@mariozechner")
+                            .join("pi-coding-agent")
+                            .join("CHANGELOG.md"),
+                    );
+                    candidates.push(
+                        parent
+                            .join("..")
+                            .join("node_modules")
+                            .join("@mariozechner")
+                            .join("pi-coding-agent")
+                            .join("CHANGELOG.md"),
+                    );
+                    candidates.push(
+                        parent
+                            .join("..")
+                            .join("..")
+                            .join("lib")
+                            .join("node_modules")
+                            .join("@mariozechner")
+                            .join("pi-coding-agent")
+                            .join("CHANGELOG.md"),
+                    );
+                }
+            }
+        }
+    }
+
+    if let Some(global_root) = discover_npm_global_root(Some(pi)) {
+        candidates.push(
+            global_root
+                .join("@mariozechner")
+                .join("pi-coding-agent")
+                .join("CHANGELOG.md"),
+        );
+    }
+
+    candidates
 }
 
 fn discover_pi_from_env_override() -> Option<PathBuf> {
@@ -1086,6 +1194,12 @@ struct CliUpdateStatus {
 }
 
 #[derive(Debug, Serialize)]
+struct PiChangelogResult {
+    path: String,
+    content: String,
+}
+
+#[derive(Debug, Serialize)]
 struct NpmCommandResult {
     stdout: String,
     stderr: String,
@@ -1105,6 +1219,20 @@ struct GitCommandResult {
     exit_code: i32,
 }
 
+#[derive(Debug, Deserialize)]
+struct ShareGistOptions {
+    html_path: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ShareGistResult {
+    gist_url: String,
+    gist_id: String,
+    preview_url: String,
+    stdout: String,
+    stderr: String,
+}
+
 #[derive(Debug, Serialize)]
 struct DesktopRuntimeInfo {
     platform: String,
@@ -1118,6 +1246,78 @@ fn npm_executable() -> &'static str {
     } else {
         "npm"
     }
+}
+
+fn discover_gh_path() -> Option<PathBuf> {
+    if let Ok(path) = which::which("gh") {
+        return Some(path);
+    }
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(app_data) = std::env::var("APPDATA") {
+            candidates.push(PathBuf::from(app_data).join("GitHub CLI").join("gh.exe"));
+            candidates.push(PathBuf::from(app_data).join("npm").join("gh.cmd"));
+        }
+        if let Ok(program_files) = std::env::var("ProgramFiles") {
+            candidates.push(PathBuf::from(program_files).join("GitHub CLI").join("gh.exe"));
+        }
+        if let Ok(program_files_x86) = std::env::var("ProgramFiles(x86)") {
+            candidates.push(PathBuf::from(program_files_x86).join("GitHub CLI").join("gh.exe"));
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        candidates.push(PathBuf::from("/opt/homebrew/bin/gh"));
+        candidates.push(PathBuf::from("/usr/local/bin/gh"));
+        candidates.push(PathBuf::from("/usr/bin/gh"));
+        if let Some(home_dir) = resolve_home_dir() {
+            candidates.push(home_dir.join(".local/bin/gh"));
+            candidates.push(home_dir.join(".nvm/versions/node/current/bin/gh"));
+        }
+    }
+
+    candidates.into_iter().find(|candidate| candidate.is_file())
+}
+
+fn parse_gist_url_from_output(output: &str) -> Option<String> {
+    for token in output.split_whitespace() {
+        let Some(start) = token.find("https://gist.github.com/") else {
+            continue;
+        };
+        let mut url = token[start..]
+            .trim_matches(|c: char| c == '"' || c == '\'' || c == '`' || c == '(' || c == '[' || c == '{')
+            .to_string();
+
+        while let Some(last) = url.chars().last() {
+            if matches!(last, ')' | ']' | '}' | ',' | ';' | '.') {
+                url.pop();
+                continue;
+            }
+            break;
+        }
+
+        if !url.is_empty() {
+            return Some(url);
+        }
+    }
+    None
+}
+
+fn parse_gist_id_from_url(url: &str) -> Option<String> {
+    let clean = url.trim().trim_end_matches('/');
+    let parts: Vec<&str> = clean.split('/').filter(|entry| !entry.trim().is_empty()).collect();
+    let gist_id = parts.last()?.trim();
+    if gist_id.len() < 20 {
+        return None;
+    }
+    if !gist_id.chars().all(|c| c.is_ascii_hexdigit()) {
+        return None;
+    }
+    Some(gist_id.to_string())
 }
 
 fn sanitize_version_token(raw: &str) -> String {
@@ -1393,6 +1593,57 @@ async fn get_cli_update_status(
     })
 }
 
+#[tauri::command]
+async fn get_pi_changelog(
+    app: AppHandle,
+    options: Option<CliStatusOptions>,
+) -> Result<PiChangelogResult, String> {
+    let opts = options.unwrap_or(CliStatusOptions {
+        cli_path: None,
+        cwd: Some(".".to_string()),
+        env: None,
+    });
+
+    let discovery_opts = RpcStartOptions {
+        cli_path: opts.cli_path.clone(),
+        cwd: opts.cwd.clone().unwrap_or_else(|| ".".to_string()),
+        provider: None,
+        model: None,
+        env: opts.env.clone(),
+    };
+
+    let pi = discover_pi(&app, &discovery_opts)?;
+    let candidates = resolve_pi_changelog_candidates(&pi);
+    let mut seen = HashSet::new();
+
+    for candidate in candidates {
+        let raw = candidate.to_string_lossy().to_string();
+        if raw.trim().is_empty() || !seen.insert(raw.clone()) {
+            continue;
+        }
+        if !candidate.is_file() {
+            continue;
+        }
+
+        match fs::read_to_string(&candidate) {
+            Ok(content) => {
+                return Ok(PiChangelogResult {
+                    path: raw,
+                    content,
+                });
+            }
+            Err(_) => {
+                continue;
+            }
+        }
+    }
+
+    Err(format!(
+        "Could not locate Pi Coding Agent changelog for discovery: {:?}",
+        pi
+    ))
+}
+
 /// Update globally installed pi CLI via npm.
 #[tauri::command]
 async fn update_cli_via_npm() -> Result<NpmCommandResult, String> {
@@ -1460,6 +1711,98 @@ async fn run_git_command(options: GitCommandOptions) -> Result<GitCommandResult,
         stdout: String::from_utf8_lossy(&output.stdout).to_string(),
         stderr: String::from_utf8_lossy(&output.stderr).to_string(),
         exit_code: output.status.code().unwrap_or(-1),
+    })
+}
+
+#[tauri::command]
+async fn create_share_gist(options: ShareGistOptions) -> Result<ShareGistResult, String> {
+    let html_path_raw = options.html_path.trim();
+    if html_path_raw.is_empty() {
+        return Err("No export file path provided".to_string());
+    }
+
+    let html_path = PathBuf::from(html_path_raw);
+    if !html_path.is_file() {
+        return Err(format!("Exported session file not found: {}", html_path_raw));
+    }
+
+    let gh_path = discover_gh_path().ok_or_else(|| {
+        "GitHub CLI (gh) is not installed. Install it from https://cli.github.com/".to_string()
+    })?;
+
+    let mut auth_cmd = Command::new(&gh_path);
+    auth_cmd
+        .arg("auth")
+        .arg("status")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        auth_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+
+    let auth_output = auth_cmd
+        .output()
+        .map_err(|e| format!("Failed to run gh auth status: {}", e))?;
+
+    if !auth_output.status.success() {
+        return Err("GitHub CLI is not logged in. Run 'gh auth login' first.".to_string());
+    }
+
+    let mut gist_cmd = Command::new(&gh_path);
+    gist_cmd
+        .arg("gist")
+        .arg("create")
+        .arg("--public=false")
+        .arg(&html_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    if let Some(parent) = html_path.parent() {
+        gist_cmd.current_dir(parent);
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        gist_cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+
+    let gist_output = gist_cmd
+        .output()
+        .map_err(|e| format!("Failed to run gh gist create: {}", e))?;
+
+    let stdout = String::from_utf8_lossy(&gist_output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&gist_output.stderr).to_string();
+
+    if !gist_output.status.success() {
+        let message = if !stderr.trim().is_empty() {
+            stderr.trim().to_string()
+        } else if !stdout.trim().is_empty() {
+            stdout.trim().to_string()
+        } else {
+            format!("gh gist create failed with exit code {}", gist_output.status.code().unwrap_or(-1))
+        };
+        return Err(format!("Failed to create gist: {}", message));
+    }
+
+    let combined = format!("{}\n{}", stdout, stderr);
+    let gist_url = parse_gist_url_from_output(&combined)
+        .ok_or_else(|| "Failed to parse gist URL from gh output".to_string())?;
+    let gist_id = parse_gist_id_from_url(&gist_url)
+        .ok_or_else(|| "Failed to parse gist ID from gh output".to_string())?;
+    let preview_url = format!("https://pi.dev/session/#{}", gist_id);
+
+    Ok(ShareGistResult {
+        gist_url,
+        gist_id,
+        preview_url,
+        stdout,
+        stderr,
     })
 }
 
@@ -1602,8 +1945,10 @@ pub fn run() {
             open_file_dialog,
             run_pi_cli_command,
             get_cli_update_status,
+            get_pi_changelog,
             update_cli_via_npm,
             run_git_command,
+            create_share_gist,
             get_desktop_runtime_info,
             open_path_in_default_app,
         ])

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -53,6 +53,9 @@ interface UiMessage {
 	errorText?: string;
 	deliveryMode?: DeliveryMode;
 	label?: string;
+	renderAsMarkdown?: boolean;
+	collapsibleTitle?: string;
+	collapsibleExpanded?: boolean;
 }
 
 interface Notice {
@@ -79,6 +82,30 @@ interface ForkTimelineRow {
 	sourceIndex: number;
 	thinkingSnippets: string[];
 	tools: ToolCallBlock[];
+}
+
+interface SessionTreeEntryRecord {
+	id: string;
+	parentId: string | null;
+	type: string;
+	index: number;
+	role: UiRole;
+	entryLabel: string;
+	preview: string;
+	displayText: string;
+	canFork: boolean;
+}
+
+interface HistoryTreeRow {
+	entryId: string;
+	depth: number;
+	role: UiRole;
+	entryLabel: string;
+	preview: string;
+	displayText: string;
+	linePrefix: string;
+	onActivePath: boolean;
+	canFork: boolean;
 }
 
 interface SessionStatsSummary {
@@ -126,12 +153,22 @@ interface ComposerSkillDraft {
 	scope: string | null;
 }
 
+type SlashPaletteSection = "CLI" | "Extensions" | "Prompts" | "Skills";
+type SlashCommandSource = "builtin" | "extension" | "prompt" | "skill";
+
+interface RuntimeSlashCommand {
+	name: string;
+	description: string;
+	source: "extension" | "prompt" | "skill";
+}
+
 interface SlashPaletteItem {
 	id: string;
-	section: "Actions" | "Skills";
+	section: SlashPaletteSection;
 	label: string;
 	hint: string;
-	skillName?: string;
+	commandName: string;
+	source: SlashCommandSource;
 }
 
 interface ToolCallGroup {
@@ -151,6 +188,29 @@ interface CompactionCycleState {
 	details: string[];
 	expanded: boolean;
 }
+
+const BUILTIN_SLASH_COMMANDS: Array<{ name: string; description: string }> = [
+	{ name: "settings", description: "Open Desktop settings" },
+	{ name: "model", description: "No arg opens picker; exact arg sets model, otherwise opens picker near matches" },
+	{ name: "scoped-models", description: "Open Settings scoped-models editor (Ctrl+P model cycle scope)" },
+	{ name: "export", description: "No arg opens save dialog, /export <path> writes HTML directly" },
+	{ name: "import", description: "No arg opens file picker, /import <path> imports a session file" },
+	{ name: "share", description: "Create secret gist and post minimal links to pi.dev + GitHub gist" },
+	{ name: "copy", description: "Copy last assistant message" },
+	{ name: "name", description: "No arg opens inline rename, /name <text> sets name directly" },
+	{ name: "session", description: "Append detailed session info + token stats" },
+	{ name: "changelog", description: "Show latest changelog in collapsible row (/changelog all, /changelog refresh)" },
+	{ name: "hotkeys", description: "Open keyboard shortcuts" },
+	{ name: "fork", description: "Open fork flow, /fork <query> pre-fills message search" },
+	{ name: "tree", description: "Open full session tree across branches, /tree <query> pre-fills search" },
+	{ name: "login", description: "Terminal-only today: /login [provider] guidance" },
+	{ name: "logout", description: "Terminal-only today: /logout [provider] guidance" },
+	{ name: "new", description: "Start fresh session tab" },
+	{ name: "compact", description: "Manually compact context, /compact <instructions> optional" },
+	{ name: "resume", description: "Open session browser, /resume <query> pre-fills search" },
+	{ name: "reload", description: "Reload runtime (bridge restart + state/models/commands refresh)" },
+	{ name: "quit", description: "Quit Desktop app" },
+];
 
 function uid(prefix = "id"): string {
 	return `${prefix}_${Math.random().toString(36).slice(2, 8)}_${Date.now().toString(36)}`;
@@ -398,8 +458,16 @@ export class ChatView {
 	private onStateChange: ((state: RpcSessionState) => void) | null = null;
 	private onOpenTerminal: (() => void) | null = null;
 	private onAddProject: (() => void) | null = null;
-	private onOpenSettings: (() => void) | null = null;
+	private onOpenSettings: ((sectionId?: string) => void) | null = null;
 	private onOpenPackages: (() => void) | null = null;
+	private onOpenExtensionConfig: ((commandName: string) => boolean | Promise<boolean>) | null = null;
+	private onBeginRenameCurrentSession: (() => boolean | Promise<boolean>) | null = null;
+	private onRenameCurrentSession: ((nextName: string) => boolean | Promise<boolean>) | null = null;
+	private onCreateFreshSession: (() => boolean | Promise<boolean>) | null = null;
+	private onReloadRuntime: (() => boolean | Promise<boolean>) | null = null;
+	private onOpenSessionBrowser: ((query?: string) => void) | null = null;
+	private onOpenShortcuts: (() => void) | null = null;
+	private onQuitApp: (() => void) | null = null;
 	private onSelectWelcomeProject: ((projectId: string) => void) | null = null;
 	private onPromptSubmitted: (() => void) | null = null;
 	private onRunStateChange: ((running: boolean) => void) | null = null;
@@ -417,9 +485,13 @@ export class ChatView {
 	private sendingPrompt = false;
 	private pendingImages: PendingImage[] = [];
 	private notices: Notice[] = [];
+	private changelogCacheMarkdown: string | null = null;
+	private changelogCacheAt = 0;
+	private loadingChangelog = false;
 	private allThinkingExpanded = false;
 	private retryStatus = "";
 	private compactionCycle: CompactionCycleState | null = null;
+	private compactionInsertIndex: number | null = null;
 	private lastRuntimeNoticeSignature = "";
 	private lastRuntimeNoticeAt = 0;
 	private pendingDeliveryMode: DeliveryMode = "prompt";
@@ -430,6 +502,8 @@ export class ChatView {
 	private historyViewerMode: "browse" | "fork" = "browse";
 	private historyViewerLoading = false;
 	private historyViewerSessionLabel = "";
+	private historyTreeRows: HistoryTreeRow[] = [];
+	private historyTreeRequestSeq = 0;
 	private forkEntryIdByMessageId = new Map<string, string>();
 	private forkTargetsRequestSeq = 0;
 	private forkExpandedMessageRows = new Set<string>();
@@ -446,9 +520,12 @@ export class ChatView {
 	private slashPaletteQuery = "";
 	private slashPaletteIndex = 0;
 	private slashPaletteNavigationMode: "pointer" | "keyboard" = "pointer";
-	private slashSkills: string[] = [];
-	private slashSkillsLoading = false;
-	private slashSkillsUpdatedAt = 0;
+	private slashRuntimeCommands: RuntimeSlashCommand[] = [];
+	private slashCommandsLoading = false;
+	private slashCommandsUpdatedAt = 0;
+	private composerInputHistory: string[] = [];
+	private composerHistoryIndex = -1;
+	private composerHistoryDraft = "";
 	private runHasAssistantText = false;
 	private runSawToolActivity = false;
 	private keepWorkflowExpandedUntilAssistantText = false;
@@ -542,12 +619,44 @@ export class ChatView {
 		this.onAddProject = cb;
 	}
 
-	setOnOpenSettings(cb: () => void): void {
+	setOnOpenSettings(cb: (sectionId?: string) => void): void {
 		this.onOpenSettings = cb;
 	}
 
 	setOnOpenPackages(cb: () => void): void {
 		this.onOpenPackages = cb;
+	}
+
+	setOnOpenExtensionConfig(cb: (commandName: string) => boolean | Promise<boolean>): void {
+		this.onOpenExtensionConfig = cb;
+	}
+
+	setOnBeginRenameCurrentSession(cb: () => boolean | Promise<boolean>): void {
+		this.onBeginRenameCurrentSession = cb;
+	}
+
+	setOnRenameCurrentSession(cb: (nextName: string) => boolean | Promise<boolean>): void {
+		this.onRenameCurrentSession = cb;
+	}
+
+	setOnCreateFreshSession(cb: () => boolean | Promise<boolean>): void {
+		this.onCreateFreshSession = cb;
+	}
+
+	setOnReloadRuntime(cb: () => boolean | Promise<boolean>): void {
+		this.onReloadRuntime = cb;
+	}
+
+	setOnOpenSessionBrowser(cb: (query?: string) => void): void {
+		this.onOpenSessionBrowser = cb;
+	}
+
+	setOnOpenShortcuts(cb: () => void): void {
+		this.onOpenShortcuts = cb;
+	}
+
+	setOnQuitApp(cb: () => void): void {
+		this.onQuitApp = cb;
 	}
 
 	setOnSelectWelcomeProject(cb: (projectId: string) => void): void {
@@ -585,12 +694,14 @@ export class ChatView {
 		this.slashPaletteOpen = false;
 		this.slashPaletteQuery = "";
 		this.slashPaletteIndex = 0;
-		this.slashSkillsUpdatedAt = 0;
+		this.slashCommandsUpdatedAt = 0;
+		this.slashRuntimeCommands = [];
 		this.expandedToolWorkflowIds.clear();
 		this.expandedToolGroupByWorkflowId.clear();
 		this.expandedWorkflowThinkingIds.clear();
 		this.collapsedAutoWorkflowIds.clear();
 		this.compactionCycle = null;
+		this.compactionInsertIndex = null;
 		this.keepWorkflowExpandedUntilAssistantText = false;
 		if (!path) {
 			this.bindingStatusText = null;
@@ -621,11 +732,14 @@ export class ChatView {
 		this.slashPaletteOpen = false;
 		this.slashPaletteQuery = "";
 		this.slashPaletteIndex = 0;
+		this.slashCommandsUpdatedAt = 0;
+		this.slashRuntimeCommands = [];
 		this.expandedToolWorkflowIds.clear();
 		this.expandedToolGroupByWorkflowId.clear();
 		this.expandedWorkflowThinkingIds.clear();
 		this.collapsedAutoWorkflowIds.clear();
 		this.compactionCycle = null;
+		this.compactionInsertIndex = null;
 		this.runHasAssistantText = false;
 		this.runSawToolActivity = false;
 		this.keepWorkflowExpandedUntilAssistantText = false;
@@ -640,6 +754,7 @@ export class ChatView {
 
 	setInputText(text: string): void {
 		this.inputText = text;
+		this.resetComposerHistoryNavigation();
 		this.updateSlashPaletteStateFromInput();
 		this.render();
 		requestAnimationFrame(() => {
@@ -657,6 +772,7 @@ export class ChatView {
 		if (draft) {
 			this.selectedSkillDraft = draft;
 			this.inputText = "";
+			this.resetComposerHistoryNavigation();
 			this.updateSlashPaletteStateFromInput();
 			this.render();
 			requestAnimationFrame(() => {
@@ -667,6 +783,7 @@ export class ChatView {
 		}
 		this.selectedSkillDraft = null;
 		this.inputText = commandText;
+		this.resetComposerHistoryNavigation();
 		this.closeSlashPalette();
 		this.render();
 		requestAnimationFrame(() => {
@@ -728,14 +845,15 @@ export class ChatView {
 			this.slashPaletteNavigationMode = "pointer";
 			return;
 		}
+		const wasOpen = this.slashPaletteOpen;
 		const normalized = query.toLowerCase();
-		if (!this.slashPaletteOpen || normalized !== this.slashPaletteQuery) {
+		if (!wasOpen || normalized !== this.slashPaletteQuery) {
 			this.slashPaletteIndex = 0;
 			this.slashPaletteNavigationMode = "pointer";
 		}
 		this.slashPaletteOpen = true;
 		this.slashPaletteQuery = normalized;
-		void this.ensureSlashSkillsLoaded();
+		void this.ensureSlashCommandsLoaded(!wasOpen);
 	}
 
 	private closeSlashPalette(clearInput = false): void {
@@ -746,52 +864,125 @@ export class ChatView {
 		if (clearInput) this.inputText = "";
 	}
 
-	private normalizeSkillNameFromCommand(rawName: string): string | null {
-		const trimmed = rawName.trim();
-		if (!trimmed) return null;
-		const fromPrefixed = trimmed.match(/^\/?skill:([a-zA-Z0-9._-]+)\b/i);
-		if (fromPrefixed) return fromPrefixed[1] ?? null;
-		if (/^[a-zA-Z0-9._-]+$/.test(trimmed)) return trimmed;
-		return null;
-	}
-
-	private collectRuntimeSkillNames(commands: Array<Record<string, unknown>>): string[] {
-		const names = new Set<string>();
-		for (const raw of commands) {
-			const source = normalizeText((raw as Record<string, unknown>).source).toLowerCase();
-			if (source !== "skill") continue;
-			const name = this.normalizeSkillNameFromCommand(normalizeText((raw as Record<string, unknown>).name));
-			if (name) names.add(name);
+	private parseSlashInput(value: string): { commandText: string; commandName: string; args: string } | null {
+		const raw = value.trim();
+		if (!raw.startsWith("/")) return null;
+		if (raw.includes("\n")) return null;
+		const body = raw.slice(1).trim();
+		if (!body) return null;
+		const splitIndex = body.search(/\s/);
+		if (splitIndex < 0) {
+			const commandToken = body.trim();
+			const commandName = commandToken.toLowerCase();
+			return {
+				commandName,
+				args: "",
+				commandText: `/${commandToken}`,
+			};
 		}
-		return [...names].sort((a, b) => a.localeCompare(b));
+		const commandToken = body.slice(0, splitIndex).trim();
+		const commandName = commandToken.toLowerCase();
+		const args = body.slice(splitIndex + 1).trim();
+		return {
+			commandName,
+			args,
+			commandText: `/${commandToken}${args ? ` ${args}` : ""}`,
+		};
 	}
 
-	private async ensureSlashSkillsLoaded(force = false): Promise<void> {
-		if (this.slashSkillsLoading) return;
-		if (!force && this.slashSkills.length > 0 && Date.now() - this.slashSkillsUpdatedAt < 120_000) return;
-		this.slashSkillsLoading = true;
+	private normalizeRuntimeSlashCommand(raw: Record<string, unknown>): RuntimeSlashCommand | null {
+		const source = normalizeText(raw.source).toLowerCase();
+		if (source !== "extension" && source !== "prompt" && source !== "skill") return null;
+		const name = normalizeText(raw.name).replace(/^\/+/, "").trim().toLowerCase();
+		if (!name) return null;
+		const description = normalizeText(raw.description) || `Run /${name}`;
+		return {
+			name,
+			description,
+			source,
+		};
+	}
+
+	private async ensureSlashCommandsLoaded(force = false): Promise<void> {
+		if (this.slashCommandsLoading) return;
+		if (!force && this.slashRuntimeCommands.length > 0 && Date.now() - this.slashCommandsUpdatedAt < 15_000) return;
+		this.slashCommandsLoading = true;
 		if (this.slashPaletteOpen) this.render();
 		try {
 			const runtimeCommands = await rpcBridge.getCommands().catch(() => []);
-			const runtimeSkills = this.collectRuntimeSkillNames(runtimeCommands as Array<Record<string, unknown>>);
-
-			const { homeDir } = await import("@tauri-apps/api/path");
-			const home = await homeDir();
-			const roots = [joinFsPath(joinFsPath(joinFsPath(home, ".pi"), "agent"), "skills")];
-			const sets = await Promise.all(roots.map((root) => this.collectSkillNames(root)));
-			const merged = new Set<string>(runtimeSkills);
-			for (const list of sets) {
-				for (const name of list) merged.add(name);
+			const normalized: RuntimeSlashCommand[] = [];
+			const seen = new Set<string>();
+			for (const raw of runtimeCommands as Array<Record<string, unknown>>) {
+				const parsed = this.normalizeRuntimeSlashCommand(raw);
+				if (!parsed) continue;
+				const key = `${parsed.source}:${parsed.name}`;
+				if (seen.has(key)) continue;
+				seen.add(key);
+				normalized.push(parsed);
 			}
-			this.slashSkills = [...merged].sort((a, b) => a.localeCompare(b));
-			this.slashSkillsUpdatedAt = Date.now();
+			const sourceOrder: Record<RuntimeSlashCommand["source"], number> = {
+				extension: 0,
+				prompt: 1,
+				skill: 2,
+			};
+			normalized.sort((a, b) => {
+				const sourceDiff = sourceOrder[a.source] - sourceOrder[b.source];
+				if (sourceDiff !== 0) return sourceDiff;
+				return a.name.localeCompare(b.name);
+			});
+			this.slashRuntimeCommands = normalized;
+			this.slashCommandsUpdatedAt = Date.now();
 		} catch {
-			this.slashSkills = this.slashSkills.slice();
-			this.slashSkillsUpdatedAt = Date.now();
+			this.slashRuntimeCommands = this.slashRuntimeCommands.slice();
+			this.slashCommandsUpdatedAt = Date.now();
 		} finally {
-			this.slashSkillsLoading = false;
+			this.slashCommandsLoading = false;
 			if (this.slashPaletteOpen) this.render();
 		}
+	}
+
+	private slashSectionForSource(source: SlashCommandSource): SlashPaletteSection {
+		switch (source) {
+			case "builtin":
+				return "CLI";
+			case "extension":
+				return "Extensions";
+			case "prompt":
+				return "Prompts";
+			case "skill":
+			default:
+				return "Skills";
+		}
+	}
+
+	private buildAllSlashPaletteItems(): SlashPaletteItem[] {
+		const builtinItems: SlashPaletteItem[] = BUILTIN_SLASH_COMMANDS.map((command) => ({
+			id: `builtin:${command.name}`,
+			section: "CLI",
+			label: `/${command.name}`,
+			hint: command.description,
+			commandName: command.name,
+			source: "builtin",
+		}));
+		const builtinNames = new Set(builtinItems.map((item) => item.commandName));
+		const runtimeItems: SlashPaletteItem[] = this.slashRuntimeCommands
+			.filter((command) => !builtinNames.has(command.name))
+			.map((command) => ({
+				id: `${command.source}:${command.name}`,
+				section: this.slashSectionForSource(command.source),
+				label: `/${command.name}`,
+				hint: command.description,
+				commandName: command.name,
+				source: command.source,
+			}));
+		return [...builtinItems, ...runtimeItems];
+	}
+
+	private slashQueryToken(): string {
+		const raw = this.slashPaletteQuery.trim();
+		if (!raw) return "";
+		const [token] = raw.split(/\s+/, 1);
+		return (token || "").toLowerCase();
 	}
 
 	private matchesSlashQuery(query: string, ...values: string[]): boolean {
@@ -802,89 +993,515 @@ export class ChatView {
 
 	private getSlashPaletteItems(): SlashPaletteItem[] {
 		if (!this.slashPaletteOpen) return [];
-		const query = this.slashPaletteQuery;
-		const actions: SlashPaletteItem[] = [
-			{ id: "action:new-session", section: "Actions" as const, label: "New session", hint: "Create a fresh session tab" },
-			{ id: "action:rename-session", section: "Actions" as const, label: "Rename session", hint: "Rename current session" },
-			{ id: "action:open-terminal", section: "Actions" as const, label: "Open terminal", hint: "Switch to terminal pane" },
-			{ id: "action:compact", section: "Actions" as const, label: "Compact context", hint: "Run session compaction now" },
-			{ id: "action:history", section: "Actions" as const, label: "Open history", hint: "Browse current session history" },
-			{ id: "action:copy-last", section: "Actions" as const, label: "Copy last answer", hint: "Copy latest assistant response" },
-			{ id: "action:export-html", section: "Actions" as const, label: "Export HTML", hint: "Export conversation to HTML" },
-		].filter((item) => this.matchesSlashQuery(query, item.label, item.hint, item.id));
-
-		const skills = this.slashSkills
-			.filter((name) => this.matchesSlashQuery(query, name, "skill"))
-			.slice(0, 24)
-			.map((name) => ({
-				id: `skill:${name}`,
-				section: "Skills" as const,
-				label: name,
-				hint: "Use skill in composer",
-				skillName: name,
-			}));
-
-		if (query && query.startsWith("skill:") && skills.length === 0) {
-			const raw = query.slice("skill:".length).trim();
-			if (raw) {
-				skills.push({
-					id: `skill:${raw}`,
-					section: "Skills" as const,
-					label: raw,
-					hint: "Use typed skill name",
-					skillName: raw,
-				});
+		const query = this.slashQueryToken();
+		const allItems = this.buildAllSlashPaletteItems();
+		if (!query) return allItems;
+		const startsWith: SlashPaletteItem[] = [];
+		const contains: SlashPaletteItem[] = [];
+		for (const item of allItems) {
+			if (!this.matchesSlashQuery(query, item.commandName, item.label, item.hint, item.section)) continue;
+			if (item.commandName.startsWith(query) || item.label.toLowerCase().startsWith(`/${query}`)) {
+				startsWith.push(item);
+			} else {
+				contains.push(item);
 			}
 		}
+		return [...startsWith, ...contains];
+	}
 
-		return [...actions, ...skills];
+	private findSlashPaletteItemByName(commandName: string): SlashPaletteItem | null {
+		const normalized = commandName.trim().toLowerCase();
+		if (!normalized) return null;
+		return this.buildAllSlashPaletteItems().find((item) => item.commandName === normalized) ?? null;
+	}
+
+	private unwrapQuotedArg(value: string): string {
+		const trimmed = value.trim();
+		if (!trimmed) return "";
+		if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+			return trimmed.slice(1, -1).trim();
+		}
+		return trimmed;
+	}
+
+	private normalizedAuthProviderArg(rawArgs: string): string {
+		const provider = this.unwrapQuotedArg(rawArgs).toLowerCase();
+		if (!provider) return "";
+		if (!/^[a-z0-9._-]+$/.test(provider)) return "";
+		return provider;
+	}
+
+	private showTerminalOnlyAuthGuidance(action: "login" | "logout", rawArgs: string): void {
+		const provider = this.normalizedAuthProviderArg(rawArgs);
+		const command = `/${action}${provider ? ` ${provider}` : ""}`;
+		this.appendSystemMessage(`Run in terminal: \`pi\` then \`${command}\``, {
+			label: "auth",
+			markdown: true,
+		});
+		this.pushNotice("OAuth commands are terminal-only in Desktop for now", "info");
+	}
+
+	private async pickSessionImportPathFromDialog(): Promise<string | null> {
+		try {
+			const { open } = await import("@tauri-apps/plugin-dialog");
+			const selected = await open({
+				multiple: false,
+				directory: false,
+				filters: [{ name: "Session JSONL", extensions: ["jsonl", "json"] }],
+				defaultPath: this.projectPath || undefined,
+			});
+			if (Array.isArray(selected)) {
+				const first = selected.find((entry) => typeof entry === "string" && entry.trim().length > 0);
+				return typeof first === "string" ? first : null;
+			}
+			if (typeof selected === "string" && selected.trim().length > 0) {
+				return selected;
+			}
+			return null;
+		} catch (err) {
+			console.error("Failed to open session import picker:", err);
+			this.pushNotice("Failed to open import picker", "error");
+			return null;
+		}
+	}
+
+	private async pickSessionExportPathFromDialog(): Promise<string | null> {
+		try {
+			const { save } = await import("@tauri-apps/plugin-dialog");
+			const basePath = this.projectPath ? `${this.projectPath.replace(/\\/g, "/")}/session.html` : "session.html";
+			const selected = await save({
+				title: "Export session",
+				defaultPath: basePath,
+				filters: [{ name: "HTML", extensions: ["html"] }],
+			});
+			if (typeof selected === "string" && selected.trim().length > 0) {
+				return selected;
+			}
+			return null;
+		} catch (err) {
+			console.error("Failed to open export picker:", err);
+			this.pushNotice("Failed to open export picker", "error");
+			return null;
+		}
+	}
+
+	private async executeSlashCommandFromComposer(): Promise<void> {
+		const slashQuery = this.slashQueryFromInput();
+		const parsed = this.parseSlashInput(this.inputText);
+		if (!parsed && slashQuery === null) return;
+		if (this.pendingImages.length > 0) {
+			this.pushNotice("Slash commands cannot be sent with image attachments", "info");
+			return;
+		}
+		await this.ensureSlashCommandsLoaded();
+		const liveItems = this.getSlashPaletteItems();
+		if (parsed) {
+			const exact = this.findSlashPaletteItemByName(parsed.commandName);
+			if (exact) {
+				await this.runSlashCommand(parsed.commandText, exact, parsed.args);
+				return;
+			}
+		}
+		if (this.slashPaletteOpen && liveItems.length > 0) {
+			const picked = liveItems[Math.max(0, Math.min(this.slashPaletteIndex, liveItems.length - 1))];
+			const pickedArgs = parsed && parsed.commandName === picked.commandName ? parsed.args : "";
+			const commandText = `/${picked.commandName}${pickedArgs ? ` ${pickedArgs}` : ""}`;
+			await this.runSlashCommand(commandText, picked, pickedArgs);
+			return;
+		}
+		if (parsed) {
+			this.pushNotice(`Unknown slash command: /${parsed.commandName}`, "error");
+			return;
+		}
+		this.pushNotice("Select a slash command from the menu", "info");
+	}
+
+	private async runSlashCommand(commandText: string, item: SlashPaletteItem, args: string): Promise<void> {
+		const trimmedCommandText = commandText.trim();
+		if (!trimmedCommandText) return;
+		this.rememberComposerHistoryEntry(trimmedCommandText);
+		this.clearComposer();
+		this.sendingPrompt = true;
+		this.render();
+		try {
+			if (item.source === "builtin") {
+				await this.executeBuiltinSlashCommand(item.commandName, args);
+			} else {
+				await this.executeRuntimeSlashCommand(trimmedCommandText, item.source, item.commandName);
+			}
+		} catch (err) {
+			console.error(`Slash command failed (${item.commandName}):`, err);
+			const message = err instanceof Error ? err.message : String(err);
+			this.pushNotice(message || `Failed to run /${item.commandName}`, "error");
+		} finally {
+			this.sendingPrompt = false;
+			this.render();
+		}
+	}
+
+	private async executeRuntimeSlashCommand(commandText: string, source: SlashCommandSource, commandName: string): Promise<void> {
+		if (source === "builtin") return;
+		if (source === "extension" && this.onOpenExtensionConfig && commandName.toLowerCase().endsWith("config")) {
+			const handled = await this.onOpenExtensionConfig(commandName.toLowerCase());
+			if (handled) return;
+		}
+		const options = this.currentIsStreaming() ? { streamingBehavior: "steer" as const } : {};
+		await rpcBridge.prompt(commandText, options);
+		this.onPromptSubmitted?.();
+	}
+
+	private openModelPicker(options: { preferredProvider?: string } = {}): void {
+		if (!this.loadingModels && this.availableModels.length === 0) {
+			void this.loadAvailableModels();
+		}
+		const preferred = normalizeText(options.preferredProvider).toLowerCase();
+		if (preferred) {
+			const exact = this.availableModels.find((model) => model.provider.toLowerCase() === preferred)?.provider;
+			if (exact) {
+				this.modelPickerActiveProvider = exact;
+			} else {
+				const partial = this.availableModels.find((model) => model.provider.toLowerCase().includes(preferred))?.provider;
+				if (partial) this.modelPickerActiveProvider = partial;
+			}
+		}
+		if (!this.modelPickerActiveProvider) {
+			const currentProvider = normalizeText(this.state?.model?.provider);
+			if (currentProvider) {
+				this.modelPickerActiveProvider = currentProvider;
+			}
+		}
+		this.modelPickerOpen = true;
+		this.render();
+	}
+
+	private resolveProviderHintFromModelArg(rawArg: string): string | null {
+		const arg = rawArg.trim().replace(/^\/+/, "");
+		if (!arg) return null;
+
+		const byDelim = arg.includes("/") ? arg.split("/")[0] : arg.includes("::") ? arg.split("::")[0] : arg;
+		const token = byDelim.trim().toLowerCase();
+		if (!token) return null;
+
+		const providers = [...new Set(this.availableModels.map((model) => model.provider))];
+		const exact = providers.find((provider) => provider.toLowerCase() === token);
+		if (exact) return exact;
+		const partial = providers.find((provider) => provider.toLowerCase().includes(token));
+		if (partial) return partial;
+
+		const fuzzy = this.availableModels.filter((model) => `${model.provider}/${model.id}`.toLowerCase().includes(token));
+		if (fuzzy.length > 0) {
+			const uniqueProviders = [...new Set(fuzzy.map((model) => model.provider))];
+			if (uniqueProviders.length === 1) return uniqueProviders[0];
+		}
+
+		return null;
+	}
+
+	private resolveModelCandidateFromArg(rawArg: string): ModelOption | null {
+		const arg = rawArg.trim();
+		if (!arg) return null;
+		const normalizedArg = arg.replace(/^\/+/, "").trim();
+		const viaDoubleColon = normalizedArg.split("::");
+		if (viaDoubleColon.length === 2) {
+			const provider = viaDoubleColon[0]?.trim().toLowerCase();
+			const id = viaDoubleColon[1]?.trim().toLowerCase();
+			if (provider && id) {
+				return this.availableModels.find((model) => model.provider.toLowerCase() === provider && model.id.toLowerCase() === id) ?? null;
+			}
+		}
+		const slashIndex = normalizedArg.indexOf("/");
+		if (slashIndex > 0) {
+			const provider = normalizedArg.slice(0, slashIndex).trim().toLowerCase();
+			const id = normalizedArg.slice(slashIndex + 1).trim().toLowerCase();
+			if (provider && id) {
+				const exact = this.availableModels.find((model) => model.provider.toLowerCase() === provider && model.id.toLowerCase() === id);
+				if (exact) return exact;
+			}
+		}
+		const lower = normalizedArg.toLowerCase();
+		const exactById = this.availableModels.find((model) => model.id.toLowerCase() === lower);
+		if (exactById) return exactById;
+		const fuzzy = this.availableModels.filter((model) => `${model.provider}/${model.id}`.toLowerCase().includes(lower));
+		if (fuzzy.length === 1) return fuzzy[0];
+		return null;
+	}
+
+	private getSessionMessageBreakdown(): {
+		user: number;
+		assistant: number;
+		toolCalls: number;
+		toolResults: number;
+	} {
+		let user = 0;
+		let assistant = 0;
+		let toolCalls = 0;
+		let toolResults = 0;
+		for (const message of this.messages) {
+			if (message.role === "user") {
+				user += 1;
+				continue;
+			}
+			if (message.role !== "assistant") continue;
+			assistant += 1;
+			toolCalls += message.toolCalls.length;
+			toolResults += message.toolCalls.filter((call) => typeof call.result === "string" && call.result.trim().length > 0).length;
+		}
+		return { user, assistant, toolCalls, toolResults };
+	}
+
+	private formatSessionInfoBlock(): string {
+		const lines: string[] = [];
+		const sessionName = normalizeText(this.state?.sessionName);
+		const sessionFile = normalizeText(this.state?.sessionFile);
+		const sessionId = normalizeText(this.state?.sessionId);
+		const modelProvider = normalizeText(this.state?.model?.provider);
+		const modelId = normalizeText(this.state?.model?.id);
+		const modelLabel = modelProvider && modelId ? `${modelProvider}/${modelId}` : "—";
+		const { user, assistant, toolCalls, toolResults } = this.getSessionMessageBreakdown();
+		const totalMessages = this.state?.messageCount ?? this.sessionStats.messageCount;
+		const pendingMessages = this.state?.pendingMessageCount ?? this.sessionStats.pendingCount;
+
+		lines.push("Session info");
+		lines.push("");
+		lines.push(`Name: ${sessionName || "(unnamed)"}`);
+		lines.push(`File: ${sessionFile || "In-memory"}`);
+		lines.push(`ID: ${sessionId || "—"}`);
+		lines.push(`Model: ${modelLabel}`);
+		lines.push(`Thinking: ${this.state?.thinkingLevel ?? "—"}`);
+		lines.push("");
+		lines.push("Messages");
+		lines.push(`User: ${user}`);
+		lines.push(`Assistant: ${assistant}`);
+		lines.push(`Tool calls: ${toolCalls}`);
+		lines.push(`Tool results: ${toolResults}`);
+		lines.push(`Total: ${Math.max(0, totalMessages)}`);
+		lines.push(`Pending: ${Math.max(0, pendingMessages)}`);
+		lines.push("");
+		lines.push("Tokens");
+		lines.push(
+			`Context: ${this.sessionStats.tokens !== null ? Math.round(this.sessionStats.tokens).toLocaleString() : "—"}`,
+		);
+		lines.push(
+			`Context window: ${this.sessionStats.contextWindow !== null ? Math.round(this.sessionStats.contextWindow).toLocaleString() : "—"}`,
+		);
+		lines.push(`Usage: ${this.sessionStats.usageRatio !== null ? `${(this.sessionStats.usageRatio * 100).toFixed(1)}%` : "—"}`);
+		lines.push(
+			`Session tokens total: ${this.sessionStats.lifetimeTokens !== null ? Math.round(this.sessionStats.lifetimeTokens).toLocaleString() : "—"}`,
+		);
+		lines.push(`Cost: ${this.sessionStats.costUsd !== null ? formatUsd(this.sessionStats.costUsd) : "—"}`);
+		return lines.join("\n");
+	}
+
+	private async executeBuiltinSlashCommand(commandName: string, args: string): Promise<void> {
+		switch (commandName) {
+			case "settings": {
+				if (!this.onOpenSettings) {
+					this.pushNotice("Settings panel is unavailable", "error");
+					return;
+				}
+				this.onOpenSettings();
+				return;
+			}
+			case "model": {
+				const rawArg = args.trim();
+				if (!rawArg) {
+					this.openModelPicker();
+					return;
+				}
+				if (this.availableModels.length === 0) {
+					await this.loadAvailableModels();
+				}
+				const candidate = this.resolveModelCandidateFromArg(rawArg);
+				if (!candidate) {
+					const providerHint = this.resolveProviderHintFromModelArg(rawArg) ?? undefined;
+					this.openModelPicker({ preferredProvider: providerHint });
+					return;
+				}
+				await this.setModel(candidate.provider, candidate.id);
+				return;
+			}
+			case "scoped-models": {
+				if (this.onOpenSettings) {
+					this.onOpenSettings("general");
+				} else {
+					this.pushNotice("Settings panel is unavailable", "error");
+				}
+				return;
+			}
+			case "export": {
+				let outputPath = this.unwrapQuotedArg(args);
+				if (!outputPath) {
+					outputPath = (await this.pickSessionExportPathFromDialog()) || "";
+				}
+				if (!outputPath) {
+					this.pushNotice("Export cancelled", "info");
+					return;
+				}
+				const result = await rpcBridge.exportHtml(outputPath);
+				this.pushNotice(`Exported session to ${truncate(result.path, 70)}`, "success");
+				return;
+			}
+			case "import": {
+				let target = this.unwrapQuotedArg(args);
+				if (!target) {
+					target = (await this.pickSessionImportPathFromDialog()) || "";
+				}
+				if (!target) {
+					this.pushNotice("Import cancelled", "info");
+					return;
+				}
+				const result = await rpcBridge.switchSession(target);
+				if (!result.cancelled) {
+					await this.refreshFromBackend();
+					this.pushNotice(`Session imported from ${truncate(target, 56)}`, "success");
+				} else {
+					this.pushNotice("Import cancelled", "info");
+				}
+				return;
+			}
+			case "share": {
+				await this.shareAsGist();
+				return;
+			}
+			case "copy": {
+				await this.copyLastMessage();
+				return;
+			}
+			case "name": {
+				const nextName = args.trim();
+				if (!nextName) {
+					if (this.onBeginRenameCurrentSession) {
+						const handled = await this.onBeginRenameCurrentSession();
+						if (handled) return;
+					}
+					await this.renameSession();
+					return;
+				}
+				await this.renameSessionTo(nextName);
+				return;
+			}
+			case "session": {
+				await this.refreshSessionStats(true);
+				this.appendSystemMessage(this.formatSessionInfoBlock(), { label: "session" });
+				return;
+			}
+			case "changelog": {
+				const tokens = args
+					.split(/\s+/)
+					.map((token) => token.trim().toLowerCase())
+					.filter(Boolean);
+				const forceRefresh = tokens.includes("refresh");
+				const showAll = tokens.includes("all") || tokens.includes("full");
+				const markdownFull = await this.loadPiAgentChangelogMarkdown(forceRefresh);
+				const markdown = showAll ? markdownFull : this.extractLatestChangelogSections(markdownFull, 2);
+				this.appendSystemMessage(markdown, {
+					label: "changelog",
+					markdown: true,
+					collapsibleTitle: showAll ? "Changelog · all" : "Changelog · latest",
+					collapsedByDefault: true,
+				});
+				return;
+			}
+			case "hotkeys": {
+				if (this.onOpenShortcuts) {
+					this.onOpenShortcuts();
+				} else {
+					this.pushNotice("Keyboard shortcuts panel is unavailable", "info");
+				}
+				return;
+			}
+			case "fork": {
+				this.openHistoryViewerForFork({
+					loading: false,
+					sessionName: this.state?.sessionName ?? null,
+					query: args.trim() || undefined,
+				});
+				return;
+			}
+			case "tree": {
+				this.openHistoryViewer({ query: args.trim() || undefined });
+				return;
+			}
+			case "login": {
+				this.showTerminalOnlyAuthGuidance("login", args);
+				return;
+			}
+			case "logout": {
+				this.showTerminalOnlyAuthGuidance("logout", args);
+				return;
+			}
+			case "new": {
+				if (this.onCreateFreshSession) {
+					const handled = await this.onCreateFreshSession();
+					if (handled) return;
+				}
+				await this.newSession();
+				return;
+			}
+			case "compact": {
+				await this.compactNow(args.trim() || undefined);
+				return;
+			}
+			case "resume": {
+				if (this.onOpenSessionBrowser) {
+					this.onOpenSessionBrowser(args.trim() || undefined);
+				} else {
+					this.pushNotice("Session browser is unavailable", "info");
+				}
+				return;
+			}
+			case "reload": {
+				if (this.onReloadRuntime) {
+					const handled = await this.onReloadRuntime();
+					if (handled) {
+						await this.ensureSlashCommandsLoaded(true);
+						this.pushNotice("Reloaded runtime state", "success");
+						return;
+					}
+				}
+				await this.ensureSlashCommandsLoaded(true);
+				await this.refreshFromBackend();
+				await this.loadAvailableModels();
+				this.pushNotice("Reloaded runtime state", "success");
+				return;
+			}
+			case "quit": {
+				if (this.onQuitApp) {
+					this.onQuitApp();
+				} else {
+					this.pushNotice("Quit is unavailable in this context", "info");
+				}
+				return;
+			}
+			default: {
+				this.pushNotice(`Unknown slash command: /${commandName}`, "error");
+				return;
+			}
+		}
+	}
+
+	private previewSlashPaletteItem(item: SlashPaletteItem): void {
+		const parsed = this.parseSlashInput(this.inputText);
+		const args = parsed && parsed.commandName === item.commandName ? parsed.args : "";
+		const commandText = `/${item.commandName}${args ? ` ${args}` : ""}`;
+		if (this.inputText === commandText) return;
+		this.inputText = commandText;
+		requestAnimationFrame(() => {
+			const textarea = this.container.querySelector("#chat-input") as HTMLTextAreaElement | null;
+			if (!textarea) return;
+			textarea.value = commandText;
+			textarea.style.height = "auto";
+			textarea.style.height = `${Math.min(textarea.scrollHeight, 220)}px`;
+			const end = commandText.length;
+			textarea.setSelectionRange(end, end);
+		});
 	}
 
 	private selectSlashPaletteItem(item: SlashPaletteItem): void {
-		if (item.section === "Skills" && item.skillName) {
-			this.selectedSkillDraft = {
-				name: item.skillName,
-				commandText: `/skill:${item.skillName}`,
-				scope: null,
-			};
-			this.inputText = "";
-			this.closeSlashPalette();
-			this.render();
-			requestAnimationFrame(() => {
-				const textarea = this.container.querySelector("#chat-input") as HTMLTextAreaElement | null;
-				textarea?.focus();
-			});
-			return;
-		}
-
-		this.inputText = "";
-		this.closeSlashPalette();
-		this.render();
-		switch (item.id) {
-			case "action:new-session":
-				void this.newSession();
-				return;
-			case "action:rename-session":
-				void this.renameSession();
-				return;
-			case "action:open-terminal":
-				this.onOpenTerminal?.();
-				return;
-			case "action:compact":
-				void this.compactNow();
-				return;
-			case "action:history":
-				this.openHistoryViewer();
-				return;
-			case "action:copy-last":
-				void this.copyLastMessage();
-				return;
-			case "action:export-html":
-				void this.exportToHtml();
-				return;
-			default:
-				return;
-		}
+		const parsed = this.parseSlashInput(this.inputText);
+		const args = parsed && parsed.commandName === item.commandName ? parsed.args : "";
+		const commandText = `/${item.commandName}${args ? ` ${args}` : ""}`;
+		void this.runSlashCommand(commandText, item, args);
 	}
 
 	private async bindNativeFileDropListener(): Promise<void> {
@@ -1030,10 +1647,18 @@ export class ChatView {
 					usageRatio: null,
 					updatedAt: 0,
 				};
+				if (this.historyViewerOpen && this.historyViewerMode === "browse") {
+					this.historyTreeRows = [];
+					this.historyViewerLoading = true;
+					void this.loadSessionTreeForHistory();
+				}
 			}
 			this.lastBackendRefreshError = null;
 			this.onStateChange?.(state);
 			this.messages = this.mapBackendMessages(backendMessages);
+			if (this.compactionInsertIndex !== null) {
+				this.compactionInsertIndex = Math.max(0, Math.min(this.compactionInsertIndex, this.messages.length));
+			}
 			this.expandedToolWorkflowIds.clear();
 			this.expandedToolGroupByWorkflowId.clear();
 			this.expandedWorkflowThinkingIds.clear();
@@ -1486,8 +2111,8 @@ export class ChatView {
 		}
 	}
 
-	private async setModel(provider: string, modelId: string): Promise<void> {
-		if (this.settingModel) return;
+	private async setModel(provider: string, modelId: string): Promise<boolean> {
+		if (this.settingModel) return false;
 		this.modelPickerOpen = false;
 		this.settingModel = true;
 		this.render();
@@ -1497,9 +2122,11 @@ export class ChatView {
 			if (this.state) this.onStateChange?.(this.state);
 			void this.refreshSessionStats(true);
 			this.pushNotice(`Switched to ${provider}/${modelId}`, "success");
+			return true;
 		} catch (err) {
 			console.error("Failed to set model:", err);
 			this.pushNotice("Failed to switch model", "error");
+			return false;
 		} finally {
 			this.settingModel = false;
 			this.render();
@@ -1772,7 +2399,8 @@ export class ChatView {
 
 	private parseBashResult(raw: unknown): { stdout: string; stderr: string; exitCode: number } {
 		const source = raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
-		const stdout = typeof source.stdout === "string" ? source.stdout : "";
+		const output = typeof source.output === "string" ? source.output : "";
+		const stdout = typeof source.stdout === "string" ? source.stdout : output;
 		const stderr = typeof source.stderr === "string" ? source.stderr : "";
 		const exit = source.exitCode ?? source.exit_code;
 		if (typeof exit === "number" && Number.isFinite(exit)) {
@@ -1783,6 +2411,53 @@ export class ChatView {
 			if (Number.isFinite(parsed)) return { stdout, stderr, exitCode: parsed };
 		}
 		return { stdout, stderr, exitCode: 0 };
+	}
+
+	private extractLatestChangelogSections(markdown: string, maxSections = 2): string {
+		const lines = markdown.split(/\r?\n/);
+		const firstSectionIndex = lines.findIndex((line) => line.startsWith("## "));
+		if (firstSectionIndex < 0) return markdown;
+
+		const header = lines.slice(0, firstSectionIndex).join("\n").trim();
+		const sections: string[] = [];
+		let index = firstSectionIndex;
+		while (index < lines.length && sections.length < maxSections) {
+			if (!lines[index].startsWith("## ")) {
+				index += 1;
+				continue;
+			}
+			let end = index + 1;
+			while (end < lines.length && !lines[end].startsWith("## ")) {
+				end += 1;
+			}
+			sections.push(lines.slice(index, end).join("\n").trimEnd());
+			index = end;
+		}
+
+		const body = sections.join("\n\n").trim();
+		return `${header ? `${header}\n\n` : ""}${body}`.trim();
+	}
+
+	private async loadPiAgentChangelogMarkdown(force = false): Promise<string> {
+		if (this.loadingChangelog) {
+			return this.changelogCacheMarkdown ?? "";
+		}
+		if (!force && this.changelogCacheMarkdown && Date.now() - this.changelogCacheAt < 45_000) {
+			return this.changelogCacheMarkdown;
+		}
+		this.loadingChangelog = true;
+		try {
+			const result = await rpcBridge.getPiChangelog();
+			const markdown = (result.content || "").trim();
+			if (!markdown) {
+				throw new Error("Pi Coding Agent changelog is empty");
+			}
+			this.changelogCacheMarkdown = markdown;
+			this.changelogCacheAt = Date.now();
+			return markdown;
+		} finally {
+			this.loadingChangelog = false;
+		}
 	}
 
 	private parseNumstat(output: string): { additions: number; deletions: number } {
@@ -2250,13 +2925,21 @@ export class ChatView {
 		return `Error: ${stripped || raw}`;
 	}
 
-	private appendRuntimeSystemLine(text: string): void {
+	private appendSystemMessage(
+		text: string,
+		options: { label?: string; idPrefix?: string; markdown?: boolean; collapsibleTitle?: string; collapsedByDefault?: boolean } = {},
+	): void {
 		const line = text.trim();
 		if (!line) return;
+		const isCollapsible = Boolean(options.collapsibleTitle && options.collapsibleTitle.trim().length > 0);
 		this.messages.push({
-			id: uid("runtimeError"),
+			id: uid(options.idPrefix ?? "system"),
 			role: "system",
 			text: line,
+			label: options.label,
+			renderAsMarkdown: options.markdown,
+			collapsibleTitle: isCollapsible ? options.collapsibleTitle : undefined,
+			collapsibleExpanded: isCollapsible ? !(options.collapsedByDefault ?? true) : undefined,
 			toolCalls: [],
 		});
 		this.render();
@@ -2274,7 +2957,7 @@ export class ChatView {
 		this.lastRuntimeNoticeAt = now;
 		const inlineLine = this.toRuntimeInlineLine(text);
 		if (inlineLine) {
-			this.appendRuntimeSystemLine(inlineLine);
+			this.appendSystemMessage(inlineLine, { idPrefix: "runtimeError" });
 		}
 		this.pushNotice(text, kind);
 	}
@@ -2557,6 +3240,7 @@ export class ChatView {
 			}
 
 			case "auto_compaction_start": {
+				this.compactionInsertIndex = this.messages.length;
 				this.compactionCycle = {
 					id: uid("compaction"),
 					status: "running",
@@ -2565,7 +3249,7 @@ export class ChatView {
 					summary: "Compacting context…",
 					errorMessage: null,
 					details: ["Compaction started"],
-					expanded: true,
+					expanded: false,
 				};
 				this.render();
 				break;
@@ -2591,6 +3275,7 @@ export class ChatView {
 				const aborted = Boolean(event.aborted);
 				const errorMessage = this.extractRuntimeErrorMessage(event);
 				if (!this.compactionCycle) {
+					this.compactionInsertIndex = this.messages.length;
 					this.compactionCycle = {
 						id: uid("compaction"),
 						status: "running",
@@ -2599,7 +3284,7 @@ export class ChatView {
 						summary: "Compacting context…",
 						errorMessage: null,
 						details: [],
-						expanded: true,
+						expanded: false,
 					};
 				}
 				this.compactionCycle.endedAt = Date.now();
@@ -2617,6 +3302,10 @@ export class ChatView {
 				} else {
 					this.compactionCycle.status = "done";
 					this.compactionCycle.summary = "Compaction complete";
+					const tokensBefore = pickNumber(event, ["result.tokensBefore", "tokensBefore", "tokens_before"]);
+					if (typeof tokensBefore === "number" && Number.isFinite(tokensBefore)) {
+						this.compactionCycle.details.push(`Context before compaction: ${Math.round(tokensBefore).toLocaleString()} tokens`);
+					}
 					this.compactionCycle.details.push("Compaction completed successfully.");
 					this.pushNotice("Auto-compaction complete", "success");
 				}
@@ -2633,7 +3322,7 @@ export class ChatView {
 				const retryLine = errorMessage
 					? `Retry ${attempt}/${maxAttempts} in ${(delayMs / 1000).toFixed(1)}s · ${truncate(errorMessage, 150)}`
 					: `Retry ${attempt}/${maxAttempts} in ${(delayMs / 1000).toFixed(1)}s`;
-				this.appendRuntimeSystemLine(retryLine);
+				this.appendSystemMessage(retryLine, { idPrefix: "runtime" });
 				this.render();
 				break;
 			}
@@ -2646,7 +3335,7 @@ export class ChatView {
 					const finalError = this.extractRuntimeErrorMessage(event) || "Unknown retry failure";
 					this.pushRuntimeNotice(`Retry failed: ${truncate(finalError, 180)}`, "error", 2600);
 				} else {
-					this.appendRuntimeSystemLine(attempt ? `Retry succeeded on attempt ${attempt}` : "Retry succeeded");
+					this.appendSystemMessage(attempt ? `Retry succeeded on attempt ${attempt}` : "Retry succeeded", { idPrefix: "runtime" });
 				}
 				this.render();
 				break;
@@ -3092,10 +3781,81 @@ export class ChatView {
 		this.scrollToBottom(true);
 	}
 
+	private resetComposerHistoryNavigation(): void {
+		this.composerHistoryIndex = -1;
+		this.composerHistoryDraft = "";
+	}
+
+	private rememberComposerHistoryEntry(rawText: string): void {
+		const text = rawText.trim();
+		if (!text) return;
+		const last = this.composerInputHistory[this.composerInputHistory.length - 1] ?? "";
+		if (last !== text) {
+			this.composerInputHistory.push(text);
+			if (this.composerInputHistory.length > 120) {
+				this.composerInputHistory.splice(0, this.composerInputHistory.length - 120);
+			}
+		}
+		this.resetComposerHistoryNavigation();
+	}
+
+	private shouldHandleComposerHistoryKey(event: KeyboardEvent, textarea: HTMLTextAreaElement, direction: "up" | "down"): boolean {
+		if (event.altKey || event.ctrlKey || event.metaKey) return false;
+		if (textarea.selectionStart !== textarea.selectionEnd) return false;
+		const caret = textarea.selectionStart;
+		if (direction === "up") {
+			return textarea.value.slice(0, caret).indexOf("\n") === -1;
+		}
+		if (this.composerHistoryIndex < 0) return false;
+		return textarea.value.indexOf("\n", caret) === -1;
+	}
+
+	private applyComposerText(text: string): void {
+		this.inputText = text;
+		this.updateSlashPaletteStateFromInput();
+		this.render();
+		requestAnimationFrame(() => {
+			const textarea = this.container.querySelector("#chat-input") as HTMLTextAreaElement | null;
+			if (!textarea) return;
+			textarea.value = text;
+			textarea.style.height = "auto";
+			textarea.style.height = `${Math.min(textarea.scrollHeight, 220)}px`;
+			const end = text.length;
+			textarea.setSelectionRange(end, end);
+			textarea.focus();
+		});
+	}
+
+	private navigateComposerHistory(direction: "up" | "down"): void {
+		if (this.composerInputHistory.length === 0) return;
+		if (direction === "up") {
+			if (this.composerHistoryIndex < 0) {
+				this.composerHistoryDraft = this.inputText;
+				this.composerHistoryIndex = this.composerInputHistory.length - 1;
+			} else if (this.composerHistoryIndex > 0) {
+				this.composerHistoryIndex -= 1;
+			}
+			const entry = this.composerInputHistory[this.composerHistoryIndex] ?? "";
+			this.applyComposerText(entry);
+			return;
+		}
+		if (this.composerHistoryIndex < 0) return;
+		if (this.composerHistoryIndex < this.composerInputHistory.length - 1) {
+			this.composerHistoryIndex += 1;
+			const entry = this.composerInputHistory[this.composerHistoryIndex] ?? "";
+			this.applyComposerText(entry);
+			return;
+		}
+		const draft = this.composerHistoryDraft;
+		this.resetComposerHistoryNavigation();
+		this.applyComposerText(draft);
+	}
+
 	private clearComposer(): void {
 		this.inputText = "";
 		this.pendingImages = [];
 		this.selectedSkillDraft = null;
+		this.resetComposerHistoryNavigation();
 		this.closeSlashPalette();
 		this.render();
 		const textarea = this.container.querySelector("#chat-input") as HTMLTextAreaElement | null;
@@ -3116,7 +3876,12 @@ export class ChatView {
 			? (promptText ? `${selectedSkillCommand}\n\n${promptText}` : selectedSkillCommand)
 			: promptText;
 		const images = [...this.pendingImages];
+		if (!selectedSkillCommand && images.length === 0 && this.slashQueryFromInput() !== null) {
+			await this.executeSlashCommandFromComposer();
+			return;
+		}
 		if (!text && images.length === 0) return;
+		if (text) this.rememberComposerHistoryEntry(text);
 
 		let streaming = this.currentIsStreaming();
 		if (streaming) {
@@ -3198,18 +3963,20 @@ export class ChatView {
 		this.pushNotice("Message loaded. Press send to resend", "info");
 	}
 
-	async copyLastMessage(): Promise<void> {
+	async copyLastMessage(): Promise<boolean> {
 		try {
 			const text = await rpcBridge.getLastAssistantText();
 			if (!text) {
 				this.pushNotice("No assistant message to copy", "info");
-				return;
+				return false;
 			}
 			await navigator.clipboard.writeText(text);
 			this.pushNotice("Copied last assistant message", "success");
+			return true;
 		} catch (err) {
 			console.error("Failed to copy:", err);
 			this.pushNotice("Failed to copy message", "error");
+			return false;
 		}
 	}
 
@@ -3252,16 +4019,24 @@ export class ChatView {
 		}
 	}
 
-	async shareAsGist(): Promise<void> {
+	async shareAsGist(): Promise<boolean> {
 		try {
-			const { path } = await rpcBridge.exportHtml();
-			const { readTextFile } = await import("@tauri-apps/plugin-fs");
-			const html = await readTextFile(path);
-			await navigator.clipboard.writeText(html);
-			this.pushNotice("Copied exported HTML to clipboard", "success");
+			const { tempDir } = await import("@tauri-apps/api/path");
+			const tempRoot = (await tempDir()).replace(/\\/g, "/").replace(/\/+$/, "");
+			const exportPath = `${tempRoot}/session.html`;
+			const { path } = await rpcBridge.exportHtml(exportPath);
+			const shared = await rpcBridge.createShareGist(path);
+			this.appendSystemMessage(`[Open shared session](${shared.preview_url}) · [Open gist](${shared.gist_url})`, {
+				label: "share",
+				markdown: true,
+			});
+			this.pushNotice("Session shared as secret gist", "success");
+			return true;
 		} catch (err) {
-			console.error("Failed to copy exported HTML:", err);
-			this.pushNotice("Failed to copy exported HTML", "error");
+			console.error("Failed to share as gist:", err);
+			const message = err instanceof Error ? err.message : String(err);
+			this.pushNotice(truncate(message || "Failed to share session", 180), "error");
+			return false;
 		}
 	}
 
@@ -3333,26 +4108,96 @@ export class ChatView {
 		}
 	}
 
-	async newSession(): Promise<void> {
+	async newSession(): Promise<boolean> {
 		try {
 			await rpcBridge.newSession();
 			this.messages = [];
 			await this.refreshFromBackend();
 			this.pushNotice("Started new session", "success");
+			return true;
 		} catch (err) {
 			console.error("Failed to create session:", err);
 			this.pushNotice("Failed to create session", "error");
+			return false;
 		}
 	}
 
-	async compactNow(): Promise<void> {
+	async compactNow(customInstructions?: string): Promise<boolean> {
+		if (this.compactionCycle?.status === "running") {
+			this.pushNotice("Compaction already in progress", "info");
+			return false;
+		}
+		const normalizedInstructions = customInstructions?.trim() || undefined;
+		this.compactionInsertIndex = this.messages.length;
+		this.compactionCycle = {
+			id: uid("compaction"),
+			status: "running",
+			startedAt: Date.now(),
+			endedAt: null,
+			summary: "Compacting context…",
+			errorMessage: null,
+			details: normalizedInstructions ? [`Custom instructions: ${truncate(normalizedInstructions, 180)}`] : ["Manual compaction started"],
+			expanded: false,
+		};
+		this.render();
+		this.scrollToBottom();
 		try {
-			await rpcBridge.compact();
+			const result = await rpcBridge.compact(normalizedInstructions);
+			const summary = pickString(result as Record<string, unknown>, ["summary"]) || "Compaction complete";
+			const tokensBefore = pickNumber(result as Record<string, unknown>, ["tokensBefore", "tokens_before"]);
+			const firstKeptEntry = pickString(result as Record<string, unknown>, ["firstKeptEntryId", "first_kept_entry_id"]);
+			if (this.compactionCycle) {
+				this.compactionCycle.status = "done";
+				this.compactionCycle.endedAt = Date.now();
+				this.compactionCycle.summary = summary;
+				if (typeof tokensBefore === "number" && Number.isFinite(tokensBefore)) {
+					this.compactionCycle.details.push(`Context before compaction: ${Math.round(tokensBefore).toLocaleString()} tokens`);
+				}
+				if (firstKeptEntry) {
+					this.compactionCycle.details.push(`First kept entry: ${truncate(firstKeptEntry, 48)}`);
+				}
+				this.compactionCycle.details.push("Compaction completed successfully.");
+			}
 			await this.refreshFromBackend();
+			await this.refreshSessionStats(true);
+			if (this.compactionCycle && typeof this.sessionStats.tokens === "number" && Number.isFinite(this.sessionStats.tokens)) {
+				this.compactionCycle.details.push(`Context after compaction: ${Math.round(this.sessionStats.tokens).toLocaleString()} tokens`);
+			}
 			this.pushNotice("Compaction complete", "success");
+			this.render();
+			return true;
 		} catch (err) {
 			console.error("Failed to compact:", err);
+			if (this.compactionCycle) {
+				this.compactionCycle.status = "error";
+				this.compactionCycle.endedAt = Date.now();
+				this.compactionCycle.summary = "Compaction failed";
+				this.compactionCycle.errorMessage = err instanceof Error ? truncate(err.message, 220) : "Unknown compaction error";
+			}
 			this.pushNotice("Compaction failed", "error");
+			this.render();
+			return false;
+		}
+	}
+
+	private async renameSessionTo(nextNameRaw: string): Promise<boolean> {
+		const nextName = nextNameRaw.trim();
+		if (!nextName) return false;
+		try {
+			if (this.onRenameCurrentSession) {
+				const handled = await this.onRenameCurrentSession(nextName);
+				if (handled) {
+					this.pushNotice("Session renamed", "success");
+					return true;
+				}
+			}
+			await rpcBridge.setSessionName(nextName);
+			await this.refreshFromBackend();
+			this.pushNotice("Session renamed", "success");
+			return true;
+		} catch (err) {
+			this.pushNotice("Failed to rename session", "error");
+			return false;
 		}
 	}
 
@@ -3360,13 +4205,7 @@ export class ChatView {
 		const current = this.state?.sessionName || "";
 		const next = window.prompt("Session name", current);
 		if (!next || !next.trim()) return;
-		try {
-			await rpcBridge.setSessionName(next.trim());
-			await this.refreshFromBackend();
-			this.pushNotice("Session renamed", "success");
-		} catch (err) {
-			this.pushNotice("Failed to rename session", "error");
-		}
+		await this.renameSessionTo(next.trim());
 	}
 
 	async openForkPicker(): Promise<void> {
@@ -3423,23 +4262,28 @@ export class ChatView {
 		}
 	}
 
-	openHistoryViewer(): void {
+	openHistoryViewer(options?: { query?: string }): void {
 		this.historyViewerOpen = true;
 		this.historyViewerMode = "browse";
-		this.historyViewerLoading = false;
+		this.historyViewerLoading = true;
 		this.historyViewerSessionLabel = "";
+		this.historyTreeRows = [];
+		this.historyQuery = options?.query?.trim() ?? "";
+		this.historyRoleFilter = "all";
 		this.forkExpandedMessageRows.clear();
 		this.forkExpandedToolRows.clear();
 		this.render();
+		void this.loadSessionTreeForHistory();
 	}
 
-	openHistoryViewerForFork(options?: { loading?: boolean; sessionName?: string | null }): void {
+	openHistoryViewerForFork(options?: { loading?: boolean; sessionName?: string | null; query?: string }): void {
 		this.historyViewerOpen = true;
 		this.historyViewerMode = "fork";
 		this.historyViewerLoading = options?.loading ?? false;
 		this.historyViewerSessionLabel = options?.sessionName?.trim() || this.state?.sessionName?.trim() || "";
-		this.historyQuery = "";
+		this.historyQuery = options?.query?.trim() ?? "";
 		this.historyRoleFilter = "all";
+		this.forkOptions = [];
 		this.forkExpandedMessageRows.clear();
 		this.forkExpandedToolRows.clear();
 		this.render();
@@ -3453,8 +4297,11 @@ export class ChatView {
 		this.historyViewerMode = "browse";
 		this.historyViewerLoading = false;
 		this.historyViewerSessionLabel = "";
+		this.historyTreeRows = [];
+		this.historyTreeRequestSeq += 1;
 		this.historyQuery = "";
 		this.historyRoleFilter = "all";
+		this.forkOptions = [];
 		this.forkEntryIdByMessageId.clear();
 		this.forkExpandedMessageRows.clear();
 		this.forkExpandedToolRows.clear();
@@ -3501,11 +4348,13 @@ export class ChatView {
 		try {
 			const options = await rpcBridge.getForkMessages();
 			if (requestId !== this.forkTargetsRequestSeq || this.historyViewerMode !== "fork") return;
+			this.forkOptions = options;
 			this.hydrateForkTargetsFromOptions(options);
 		} catch (err) {
 			if (requestId !== this.forkTargetsRequestSeq || this.historyViewerMode !== "fork") return;
 			console.error("Failed to load fork points:", err);
 			this.pushNotice("Failed to load fork points", "error");
+			this.forkOptions = [];
 			this.forkEntryIdByMessageId.clear();
 		} finally {
 			if (requestId !== this.forkTargetsRequestSeq || this.historyViewerMode !== "fork") return;
@@ -4118,7 +4967,13 @@ export class ChatView {
 				: 0;
 		const durationLabel = durationMs > 0 ? formatDuration(durationMs) : "0s";
 		const summaryPrimary = durationLabel;
-		const summarySecondary = running > 0 ? `${total} running` : failed > 0 ? `${failed} failed` : total > 0 ? `${total} complete` : "";
+		const completed = Math.max(0, total - running - failed);
+		const summaryParts: string[] = [];
+		if (completed > 0) summaryParts.push(`${completed} complete`);
+		if (failed > 0) summaryParts.push(`${failed} failed`);
+		if (running > 0) summaryParts.push(`${running} running`);
+		if (summaryParts.length === 0 && total > 0) summaryParts.push(`${total} complete`);
+		const summarySecondary = summaryParts.join(" · ");
 		const hasFinalContent = Boolean(workflow.finalText || workflow.errorText);
 		type WorkflowDetailEntry =
 			| {
@@ -4268,7 +5123,7 @@ export class ChatView {
 								</div>
 								${hasFinalContent ? html`<div class="assistant-final-divider"><span>Agent</span></div>` : nothing}
 								${workflow.finalText
-									? html`<div class="assistant-content ${workflow.isStreaming ? "streaming-cursor" : ""}"><markdown-block .content=${workflow.finalText}></markdown-block></div>`
+									? html`<div class="assistant-content"><markdown-block .content=${workflow.finalText}></markdown-block></div>`
 									: nothing}
 								${workflow.errorText ? html`<div class="assistant-error-line">${workflow.errorText}</div>` : nothing}
 							`
@@ -4286,7 +5141,23 @@ export class ChatView {
 
 	private renderMessageTimeline(): TemplateResult[] {
 		const rows: TemplateResult[] = [];
+		const compactionInsertAt = this.compactionCycle
+			? Math.max(0, Math.min(this.compactionInsertIndex ?? this.messages.length, this.messages.length))
+			: null;
+		let compactionInserted = false;
+		const maybeInsertCompaction = (position: number): void => {
+			if (compactionInserted) return;
+			if (compactionInsertAt === null) return;
+			if (position !== compactionInsertAt) return;
+			const row = this.renderCompactionCycle();
+			if (row !== nothing) {
+				rows.push(row as TemplateResult);
+			}
+			compactionInserted = true;
+		};
+
 		for (let index = 0; index < this.messages.length; index += 1) {
+			maybeInsertCompaction(index);
 			const msg = this.messages[index];
 			if (msg.role === "assistant") {
 				const workflowCandidate = this.collectAssistantWorkflow(index);
@@ -4307,8 +5178,13 @@ export class ChatView {
 				rows.push(this.renderAssistantMessage(msg));
 				continue;
 			}
+			if (msg.label === "changelog") {
+				rows.push(this.renderChangelogMessage(msg));
+				continue;
+			}
 			rows.push(this.renderSystemMessage(msg));
 		}
+		maybeInsertCompaction(this.messages.length);
 		return rows;
 	}
 
@@ -4328,7 +5204,7 @@ export class ChatView {
 						${this.renderThinking(msg)}
 						${msg.text
 							? html`
-								<div class="assistant-content ${msg.isStreaming ? "streaming-cursor" : ""}">
+								<div class="assistant-content">
 									<markdown-block .content=${msg.text}></markdown-block>
 								</div>
 							`
@@ -4346,11 +5222,48 @@ export class ChatView {
 	}
 
 	private renderSystemMessage(msg: UiMessage): TemplateResult {
+		const isInline = msg.label === "share" || msg.label === "auth" || msg.label === "models";
 		return html`
-			<div class="chat-row system-row" data-message-id=${msg.id}>
-				<div class="system-message">
-					${msg.label ? html`<div class="system-label">${msg.label}</div>` : nothing}
-					<div class="system-text">${msg.text}</div>
+			<div class="chat-row system-row ${isInline ? "system-row-inline" : ""}" data-message-id=${msg.id}>
+				<div class="system-message ${isInline ? "system-message-inline" : ""}">
+					${msg.label ? html`<div class="system-label ${isInline ? "system-label-inline" : ""}">${msg.label}</div>` : nothing}
+					<div class="system-text ${isInline ? "system-text-inline" : ""}">
+						${msg.renderAsMarkdown ? html`<markdown-block .content=${msg.text}></markdown-block>` : msg.text}
+					</div>
+				</div>
+			</div>
+		`;
+	}
+
+	private renderChangelogMessage(msg: UiMessage): TemplateResult {
+		const expanded = Boolean(msg.collapsibleExpanded);
+		const title = msg.collapsibleTitle?.trim() || "Changelog";
+		return html`
+			<div class="chat-row assistant-row assistant-workflow-row changelog-row" data-message-id=${msg.id}>
+				<div class="message-shell assistant-message-shell">
+					<div class="assistant-block">
+						<div class="changelog-inline">
+							<button
+								class="tool-workflow-line changelog-inline-toggle"
+								@click=${() => {
+									msg.collapsibleExpanded = !expanded;
+									this.render();
+								}}
+							>
+								<span class="tool-workflow-line-text">${title}</span>
+								<span class="tool-workflow-count">${expanded ? "hide" : "show"}</span>
+							</button>
+							${expanded
+								? html`
+									<div class="tool-workflow-details changelog-inline-details">
+										<div class="tool-workflow-output changelog-inline-output">
+											<markdown-block .content=${msg.text}></markdown-block>
+										</div>
+									</div>
+								`
+								: nothing}
+						</div>
+					</div>
 				</div>
 			</div>
 		`;
@@ -4360,38 +5273,48 @@ export class ChatView {
 		if (!this.compactionCycle) return nothing;
 		const cycle = this.compactionCycle;
 		const completed = cycle.endedAt ?? Date.now();
-		const elapsed = formatDuration(completed - cycle.startedAt);
-		const statusText =
+		const elapsedSeconds = Math.max(1, Math.round((completed - cycle.startedAt) / 1000));
+		const elapsed = `${elapsedSeconds}s`;
+		const title =
 			cycle.status === "running"
-				? "running"
-				: cycle.status === "error"
-					? "failed"
-					: cycle.status === "aborted"
-						? "aborted"
-						: "done";
+				? "Compacting context..."
+				: cycle.status === "done"
+					? "Compaction complete"
+					: cycle.status === "error"
+						? "Compaction failed"
+						: "Compaction aborted";
+		const normalizedSummary = cycle.summary.trim().toLowerCase();
+		const showSummaryLine =
+			cycle.status !== "running" &&
+			Boolean(cycle.summary.trim()) &&
+			!(["compaction complete", "compaction failed", "compaction aborted", "compacting context…", "compacting context"] as string[]).includes(normalizedSummary);
 		return html`
-			<div class="chat-row system-row compaction-row" data-message-id=${cycle.id}>
-				<div class="compaction-card ${cycle.status}">
-					<button
-						class="compaction-header"
-						@click=${() => {
-							cycle.expanded = !cycle.expanded;
-							this.render();
-						}}
-					>
-						<span class="compaction-title">Context compaction</span>
-						<span class="compaction-meta">${elapsed} · ${statusText}</span>
-						<span class="compaction-caret">${cycle.expanded ? "▾" : "▸"}</span>
-					</button>
-					${cycle.expanded
-						? html`
-							<div class="compaction-details">
-								<div class="compaction-summary">${cycle.summary}</div>
-								${cycle.errorMessage ? html`<div class="compaction-error">${cycle.errorMessage}</div>` : nothing}
-								${cycle.details.map((line) => html`<div class="compaction-line">${line}</div>`)}
-							</div>
-						`
-						: nothing}
+			<div class="chat-row assistant-row assistant-workflow-row compaction-row" data-message-id=${cycle.id}>
+				<div class="message-shell assistant-message-shell">
+					<div class="assistant-block">
+						<div class="compaction-inline">
+							<button
+								class="tool-workflow-line compaction-inline-toggle"
+								@click=${() => {
+									cycle.expanded = !cycle.expanded;
+									this.render();
+								}}
+							>
+								${cycle.status === "running" ? html`<span class="tool-workflow-inline-pi" aria-hidden="true">${piGlyphIcon()}</span>` : nothing}
+								<span class="tool-workflow-line-text ${cycle.status === "running" ? "running" : ""}">${title}</span>
+								<span class="tool-workflow-count">${elapsed}</span>
+							</button>
+							${cycle.expanded
+								? html`
+									<div class="tool-workflow-details compaction-inline-details">
+										${showSummaryLine ? html`<div class="tool-workflow-output compaction-inline-summary">${cycle.summary}</div>` : nothing}
+										${cycle.errorMessage ? html`<div class="tool-workflow-output compaction-inline-error">${cycle.errorMessage}</div>` : nothing}
+										${cycle.details.map((line) => html`<div class="tool-workflow-output compaction-inline-line">${line}</div>`)}
+									</div>
+								`
+								: nothing}
+						</div>
+					</div>
 				</div>
 			</div>
 		`;
@@ -4905,30 +5828,24 @@ export class ChatView {
 			const menu = this.container.querySelector<HTMLElement>(".composer-slash-menu");
 			const activeItem = this.container.querySelector<HTMLElement>(".composer-slash-item.active");
 			if (!menu || !activeItem) return;
-			const menuTop = menu.scrollTop;
-			const menuBottom = menuTop + menu.clientHeight;
+			activeItem.scrollIntoView({ block: "nearest" });
 			const itemTop = activeItem.offsetTop;
-			const itemBottom = itemTop + activeItem.offsetHeight;
-			if (itemTop < menuTop) {
+			if (itemTop < menu.scrollTop + 4) {
 				menu.scrollTop = Math.max(0, itemTop - 4);
-				return;
-			}
-			if (itemBottom > menuBottom) {
-				menu.scrollTop = itemBottom - menu.clientHeight + 4;
 			}
 		});
 	}
 
 	private renderSlashPalette(items: SlashPaletteItem[]): TemplateResult | typeof nothing {
 		if (!this.slashPaletteOpen) return nothing;
-		if (this.slashSkillsLoading && items.length === 0) {
+		if (this.slashCommandsLoading && items.length === 0) {
 			return html`<div class="composer-slash-menu"><div class="composer-slash-empty">Loading commands…</div></div>`;
 		}
 		if (items.length === 0) {
 			return html`<div class="composer-slash-menu"><div class="composer-slash-empty">No commands match “/${this.slashPaletteQuery}”.</div></div>`;
 		}
 		const activeIndex = Math.max(0, Math.min(this.slashPaletteIndex, items.length - 1));
-		let currentSection: "Actions" | "Skills" | null = null;
+		let currentSection: SlashPaletteSection | null = null;
 		return html`
 			<div
 				class="composer-slash-menu ${this.slashPaletteNavigationMode === "keyboard" ? "keyboard-nav" : ""}"
@@ -4960,8 +5877,10 @@ export class ChatView {
 							data-index=${String(index)}
 							@click=${() => this.selectSlashPaletteItem(item)}
 						>
-							<span class="composer-slash-item-label">${item.label}</span>
-							<span class="composer-slash-item-hint">${item.hint}</span>
+							<span class="composer-slash-item-main">
+								<span class="composer-slash-item-label">${item.label}</span>
+								<span class="composer-slash-item-hint">${item.hint}</span>
+							</span>
 						</button>
 					`;
 				})}
@@ -4974,13 +5893,11 @@ export class ChatView {
 		const interactionLocked = this.isComposerInteractionLocked();
 		const slashItems = this.getSlashPaletteItems();
 		const canSendBase = !interactionLocked && (this.inputText.trim().length > 0 || this.pendingImages.length > 0 || Boolean(this.selectedSkillDraft));
-		const canSend = canSendBase && !(this.slashPaletteOpen && slashItems.length > 0);
+		const canSend = canSendBase;
 		if (slashItems.length > 0 && this.slashPaletteIndex >= slashItems.length) {
 			this.slashPaletteIndex = slashItems.length - 1;
 		}
 		const connectivityStatus = this.bindingStatusText || (!this.isConnected && this.projectPath ? "RPC disconnected" : "");
-		const liveCompactionStatus = this.compactionCycle?.status === "running" ? "Compacting context…" : "";
-		const statusText = [connectivityStatus, liveCompactionStatus, this.retryStatus].filter(Boolean).join(" · ");
 		const ratio = Math.min(1, Math.max(0, this.sessionStats.usageRatio ?? 0));
 		const ratioPercent = `${Math.round(ratio * 100)}%`;
 		const ringRadius = 9;
@@ -4998,7 +5915,7 @@ export class ChatView {
 							<textarea
 								id="chat-input"
 								class="chat-input"
-								placeholder=${interactionLocked ? (connectivityStatus || "Session not ready…") : "Ask for follow-up changes"}
+								placeholder=${interactionLocked ? (connectivityStatus || "Session not ready…") : "Describe the next change — type / for commands"}
 								rows="1"
 								?disabled=${interactionLocked}
 								.value=${this.inputText}
@@ -5007,6 +5924,7 @@ export class ChatView {
 									const ta = e.target as HTMLTextAreaElement;
 									const hadSlashPalette = this.slashPaletteOpen;
 									this.inputText = ta.value;
+									this.resetComposerHistoryNavigation();
 									this.updateSlashPaletteStateFromInput();
 									ta.style.height = "auto";
 									ta.style.height = `${Math.min(ta.scrollHeight, 220)}px`;
@@ -5051,12 +5969,28 @@ export class ChatView {
 										this.removeComposerSkillDraft();
 										return;
 									}
+									const textarea = e.currentTarget as HTMLTextAreaElement;
+									const canHistoryUp = e.key === "ArrowUp" && this.shouldHandleComposerHistoryKey(e, textarea, "up");
+									const canHistoryDown = e.key === "ArrowDown" && this.shouldHandleComposerHistoryKey(e, textarea, "down");
+									const historyBrowsing = this.composerHistoryIndex >= 0;
+									if (canHistoryUp && (historyBrowsing || !this.slashPaletteOpen)) {
+										e.preventDefault();
+										this.navigateComposerHistory("up");
+										return;
+									}
+									if (canHistoryDown && historyBrowsing) {
+										e.preventDefault();
+										this.navigateComposerHistory("down");
+										return;
+									}
 									const liveSlashItems = this.getSlashPaletteItems();
 									if (this.slashPaletteOpen && liveSlashItems.length > 0) {
 										if (e.key === "ArrowDown") {
 											e.preventDefault();
 											this.slashPaletteNavigationMode = "keyboard";
 											this.slashPaletteIndex = (this.slashPaletteIndex + 1) % liveSlashItems.length;
+											const item = liveSlashItems[this.slashPaletteIndex];
+											if (item) this.previewSlashPaletteItem(item);
 											this.render();
 											this.ensureActiveSlashItemVisible();
 											return;
@@ -5065,14 +5999,10 @@ export class ChatView {
 											e.preventDefault();
 											this.slashPaletteNavigationMode = "keyboard";
 											this.slashPaletteIndex = (this.slashPaletteIndex - 1 + liveSlashItems.length) % liveSlashItems.length;
+											const item = liveSlashItems[this.slashPaletteIndex];
+											if (item) this.previewSlashPaletteItem(item);
 											this.render();
 											this.ensureActiveSlashItemVisible();
-											return;
-										}
-										if (e.key === "Enter" && !e.shiftKey) {
-											e.preventDefault();
-											const picked = liveSlashItems[Math.max(0, Math.min(this.slashPaletteIndex, liveSlashItems.length - 1))];
-											if (picked) this.selectSlashPaletteItem(picked);
 											return;
 										}
 									}
@@ -5084,6 +6014,10 @@ export class ChatView {
 									}
 									if (e.key === "Enter" && !e.shiftKey) {
 										e.preventDefault();
+										if (!this.selectedSkillDraft && this.slashQueryFromInput() !== null) {
+											void this.executeSlashCommandFromComposer();
+											return;
+										}
 										if (e.altKey) {
 											void this.sendMessage("followUp");
 										} else {
@@ -5096,7 +6030,6 @@ export class ChatView {
 						</div>
 						${this.renderSlashPalette(slashItems)}
 						${this.renderComposerControls(canSend, isStreaming, interactionLocked)}
-						${statusText ? html`<div class="composer-status-inline">${statusText}</div>` : nothing}
 					</div>
 
 					<div class="composer-under-row">
@@ -5284,40 +6217,379 @@ export class ChatView {
 		return null;
 	}
 
+	private roleFromSessionEntry(roleRaw: string): UiRole {
+		const normalized = roleRaw.trim().toLowerCase();
+		if (normalized === "user") return "user";
+		if (normalized === "assistant") return "assistant";
+		if (normalized === "custom" || normalized === "custom_message") return "custom";
+		return "system";
+	}
+
+	private mapSessionTreeEntry(
+		record: Record<string, unknown>,
+		index: number,
+		labelsByTargetId: Map<string, string>,
+	): SessionTreeEntryRecord | null {
+		const type = typeof record.type === "string" ? record.type.trim() : "";
+		if (!type || type === "session" || type === "label") return null;
+
+		const id = typeof record.id === "string" ? record.id.trim() : "";
+		if (!id) return null;
+
+		const parentRaw = record.parentId;
+		const parentId = typeof parentRaw === "string" && parentRaw.trim().length > 0 ? parentRaw.trim() : null;
+		let role: UiRole = "system";
+		let entryLabel = type.replace(/_/g, " ");
+		let preview = "";
+		let displayText = "";
+		let canFork = false;
+
+		switch (type) {
+			case "message": {
+				const message = record.message;
+				const messageRecord = message && typeof message === "object" ? (message as Record<string, unknown>) : null;
+				const messageRoleRaw = typeof messageRecord?.role === "string" ? messageRecord.role.trim() : "system";
+				const messageRole = messageRoleRaw.toLowerCase();
+
+				if (messageRole === "user") {
+					role = "user";
+					entryLabel = "user";
+					preview = this.extractText(messageRecord?.content).replace(/\s+/g, " ").trim() || "(empty message)";
+					displayText = `user: ${preview}`;
+					canFork = true;
+					break;
+				}
+
+				if (messageRole === "assistant") {
+					role = "assistant";
+					entryLabel = "assistant";
+					const contentPreview = this.extractText(messageRecord?.content).replace(/\s+/g, " ").trim();
+					const stopReason = pickString(messageRecord ?? {}, ["stopReason", "stop_reason"]) ?? "";
+					const errorMessage = pickString(messageRecord ?? {}, ["errorMessage", "error_message"]) ?? "";
+					preview = contentPreview || (stopReason === "aborted" ? "(aborted)" : errorMessage || "(no content)");
+					displayText = `assistant: ${preview}`;
+					break;
+				}
+
+				if (messageRole === "toolresult") {
+					role = "system";
+					entryLabel = "tool";
+					const toolName = pickString(messageRecord ?? {}, ["toolName", "tool_name"]) ?? "tool";
+					const toolOutputRaw = this.extractToolOutput(messageRecord?.content ?? messageRecord?.result ?? messageRecord ?? {});
+					preview = toolOutputRaw.replace(/\s+/g, " ").trim() || "(no output)";
+					displayText = `[${toolName}: ${truncate(preview, 120)}]`;
+					break;
+				}
+
+				if (messageRole === "bashexecution") {
+					role = "system";
+					entryLabel = "bash";
+					const command = pickString(messageRecord ?? {}, ["command"]) ?? "bash";
+					preview = command;
+					displayText = `[bash: ${truncate(command.replace(/\s+/g, " ").trim(), 120)}]`;
+					break;
+				}
+
+				role = this.roleFromSessionEntry(messageRoleRaw);
+				entryLabel = messageRoleRaw || "message";
+				preview = this.extractText(messageRecord?.content).replace(/\s+/g, " ").trim() || `(${entryLabel})`;
+				displayText = `[${entryLabel}]: ${preview}`;
+				break;
+			}
+			case "custom_message": {
+				role = "custom";
+				const customType = pickString(record, ["customType", "custom_type"]) ?? "custom";
+				entryLabel = customType;
+				preview = this.extractText(record.content).replace(/\s+/g, " ").trim() || "(empty)";
+				displayText = `[${customType}]: ${preview}`;
+				break;
+			}
+			case "branch_summary": {
+				role = "system";
+				entryLabel = "branch summary";
+				preview = (pickString(record, ["summary"]) ?? this.extractText(record.content)).replace(/\s+/g, " ").trim() || "(empty)";
+				displayText = `[branch summary]: ${truncate(preview, 180)}`;
+				break;
+			}
+			case "compaction": {
+				role = "system";
+				entryLabel = "compaction";
+				const tokensBefore = pickNumber(record, ["tokensBefore", "tokens_before"]);
+				preview = (pickString(record, ["summary"]) ?? "compaction entry").replace(/\s+/g, " ").trim();
+				const tokensBadge = typeof tokensBefore === "number" && Number.isFinite(tokensBefore) ? `${Math.max(1, Math.round(tokensBefore / 1000))}k tokens` : "summary";
+				displayText = `[compaction: ${tokensBadge}] ${truncate(preview, 160)}`;
+				break;
+			}
+			case "thinking_level_change": {
+				role = "system";
+				entryLabel = "thinking";
+				const level = pickString(record, ["thinkingLevel", "thinking_level"]) ?? "updated";
+				preview = level;
+				displayText = `[thinking: ${level}]`;
+				break;
+			}
+			case "model_change": {
+				role = "system";
+				entryLabel = "model";
+				const provider = pickString(record, ["provider"]) ?? "provider";
+				const modelId = pickString(record, ["modelId", "model_id"]) ?? "model";
+				preview = `${provider}/${modelId}`;
+				displayText = `[model: ${preview}]`;
+				break;
+			}
+			case "session_info": {
+				role = "system";
+				entryLabel = "title";
+				preview = pickString(record, ["name"]) ?? "(untitled)";
+				displayText = `[title: ${preview}]`;
+				break;
+			}
+			case "custom": {
+				role = "custom";
+				const customType = pickString(record, ["customType", "custom_type"]) ?? "custom";
+				entryLabel = customType;
+				preview = this.extractText(record.data).replace(/\s+/g, " ").trim() || "custom entry";
+				displayText = `[custom: ${customType}] ${truncate(preview, 140)}`;
+				break;
+			}
+			default: {
+				role = "system";
+				preview = this.extractText(record.content).replace(/\s+/g, " ").trim() || entryLabel;
+				displayText = `[${entryLabel}]: ${truncate(preview, 160)}`;
+				break;
+			}
+		}
+
+		const resolvedLabel = labelsByTargetId.get(id);
+		if (resolvedLabel) {
+			entryLabel = `${entryLabel} · ${resolvedLabel}`;
+			displayText = `[${resolvedLabel}] ${displayText}`;
+		}
+		const normalizedPreview = preview.replace(/\s+/g, " ").trim();
+		const normalizedDisplayText = displayText.replace(/\s+/g, " ").trim();
+
+		return {
+			id,
+			parentId,
+			type,
+			index,
+			role,
+			entryLabel,
+			preview: normalizedPreview || `(${entryLabel})`,
+			displayText: normalizedDisplayText || `${entryLabel}: ${normalizedPreview || "(empty)"}`,
+			canFork,
+		};
+	}
+
+	private resolveCurrentTreeLeafId(entriesById: Map<string, SessionTreeEntryRecord>, entries: SessionTreeEntryRecord[]): string | null {
+		for (let i = this.messages.length - 1; i >= 0; i--) {
+			const entryId = this.messages[i]?.sessionEntryId;
+			if (entryId && entriesById.has(entryId)) return entryId;
+		}
+		for (let i = entries.length - 1; i >= 0; i--) {
+			const entry = entries[i];
+			if (!entry) continue;
+			if (entriesById.has(entry.id)) return entry.id;
+		}
+		return null;
+	}
+
+	private compactTreeLinePrefix(prefix: string, depth: number): string {
+		const normalized = prefix ?? "";
+		if (!normalized) return "";
+		const maxVisibleDepth = 14;
+		if (depth <= maxVisibleDepth) return normalized;
+		const charsPerLevel = 3;
+		const tail = normalized.slice(Math.max(0, normalized.length - maxVisibleDepth * charsPerLevel));
+		return `… ${tail}`;
+	}
+
+	private parseSessionTreeRows(sessionContent: string): HistoryTreeRow[] {
+		const rawRecords: Array<{ record: Record<string, unknown>; index: number }> = [];
+		const lines = sessionContent.split(/\r?\n/);
+		for (const line of lines) {
+			const trimmed = line.trim();
+			if (!trimmed) continue;
+			let parsed: unknown;
+			try {
+				parsed = JSON.parse(trimmed);
+			} catch {
+				continue;
+			}
+			if (!parsed || typeof parsed !== "object") continue;
+			rawRecords.push({
+				record: parsed as Record<string, unknown>,
+				index: rawRecords.length,
+			});
+		}
+
+		if (rawRecords.length === 0) return [];
+
+		const labelsByTargetId = new Map<string, string>();
+		for (const { record } of rawRecords) {
+			if (record.type !== "label") continue;
+			const targetId = typeof record.targetId === "string" ? record.targetId.trim() : "";
+			if (!targetId) continue;
+			const label = typeof record.label === "string" ? record.label.trim() : "";
+			if (!label) {
+				labelsByTargetId.delete(targetId);
+			} else {
+				labelsByTargetId.set(targetId, label);
+			}
+		}
+
+		const entries: SessionTreeEntryRecord[] = rawRecords
+			.map(({ record, index }) => this.mapSessionTreeEntry(record, index, labelsByTargetId))
+			.filter((entry): entry is SessionTreeEntryRecord => Boolean(entry));
+
+		if (entries.length === 0) return [];
+
+		const entriesById = new Map<string, SessionTreeEntryRecord>();
+		for (const entry of entries) {
+			entriesById.set(entry.id, entry);
+		}
+
+		const childrenByParent = new Map<string, SessionTreeEntryRecord[]>();
+		const roots: SessionTreeEntryRecord[] = [];
+		for (const entry of entries) {
+			const parentId = entry.parentId && entriesById.has(entry.parentId) ? entry.parentId : null;
+			if (!parentId) {
+				roots.push(entry);
+				continue;
+			}
+			const bucket = childrenByParent.get(parentId) ?? [];
+			bucket.push(entry);
+			childrenByParent.set(parentId, bucket);
+		}
+		const byIndex = (a: SessionTreeEntryRecord, b: SessionTreeEntryRecord): number => a.index - b.index;
+		roots.sort(byIndex);
+		for (const bucket of childrenByParent.values()) {
+			bucket.sort(byIndex);
+		}
+
+		const currentLeafId = this.resolveCurrentTreeLeafId(entriesById, entries);
+		const activePath = new Set<string>();
+		let cursor = currentLeafId;
+		while (cursor && entriesById.has(cursor)) {
+			if (activePath.has(cursor)) break;
+			activePath.add(cursor);
+			const parentId = entriesById.get(cursor)?.parentId ?? null;
+			cursor = parentId && entriesById.has(parentId) ? parentId : null;
+		}
+
+		const rows: HistoryTreeRow[] = [];
+		const buildPrefix = (ancestorHasNext: boolean[], isLast: boolean, depth: number): string => {
+			const parts: string[] = ancestorHasNext.map((hasNext) => (hasNext ? "│  " : "   "));
+			if (depth > 0) {
+				parts.push(isLast ? "└─ " : "├─ ");
+			}
+			return parts.join("");
+		};
+		const visit = (entry: SessionTreeEntryRecord, depth: number, ancestorHasNext: boolean[], isLast: boolean): void => {
+			rows.push({
+				entryId: entry.id,
+				depth,
+				role: entry.role,
+				entryLabel: entry.entryLabel,
+				preview: entry.preview,
+				displayText: entry.displayText,
+				linePrefix: buildPrefix(ancestorHasNext, isLast, depth),
+				onActivePath: activePath.has(entry.id),
+				canFork: entry.canFork,
+			});
+			const children = childrenByParent.get(entry.id) ?? [];
+			const nextAncestorHasNext = [...ancestorHasNext, !isLast];
+			for (let i = 0; i < children.length; i += 1) {
+				const child = children[i];
+				if (!child) continue;
+				visit(child, depth + 1, nextAncestorHasNext, i === children.length - 1);
+			}
+		};
+		for (let i = 0; i < roots.length; i += 1) {
+			const root = roots[i];
+			if (!root) continue;
+			visit(root, 0, [], i === roots.length - 1);
+		}
+		return rows;
+	}
+
+	private async loadSessionTreeForHistory(): Promise<void> {
+		if (this.historyViewerMode !== "browse" || !this.historyViewerOpen) return;
+		const requestId = ++this.historyTreeRequestSeq;
+		const sessionPath = this.state?.sessionFile?.trim();
+		if (!sessionPath) {
+			if (requestId !== this.historyTreeRequestSeq || this.historyViewerMode !== "browse") return;
+			this.historyTreeRows = [];
+			this.historyViewerLoading = false;
+			this.render();
+			return;
+		}
+
+		this.historyViewerLoading = true;
+		this.render();
+		try {
+			const content = await rpcBridge.getSessionContent(sessionPath);
+			if (requestId !== this.historyTreeRequestSeq || this.historyViewerMode !== "browse" || !this.historyViewerOpen) return;
+			this.historyTreeRows = this.parseSessionTreeRows(content);
+		} catch (err) {
+			if (requestId !== this.historyTreeRequestSeq || this.historyViewerMode !== "browse" || !this.historyViewerOpen) return;
+			console.error("Failed to load session tree:", err);
+			this.historyTreeRows = [];
+		} finally {
+			if (requestId !== this.historyTreeRequestSeq || this.historyViewerMode !== "browse" || !this.historyViewerOpen) return;
+			this.historyViewerLoading = false;
+			this.render();
+		}
+	}
+
 	private renderHistoryViewer(): TemplateResult | typeof nothing {
 		if (!this.historyViewerOpen) return nothing;
 
 		const forkMode = this.historyViewerMode === "fork";
 		const query = this.historyQuery.trim().toLowerCase();
-		const sourceMessages: UiMessage[] = forkMode
-			? this.messages.filter((msg) => msg.role === "user" || msg.role === "assistant")
-			: this.messages;
-		const forkTimelineRows: ForkTimelineRow[] = forkMode ? this.buildForkTimelineRows(sourceMessages) : [];
-		const filteredRows: ForkTimelineRow[] = forkMode
-			? forkTimelineRows.filter((row) => {
+		const sourceMessages: UiMessage[] = this.messages;
+		const sessionMessageIdByEntryId = new Map<string, string>();
+		for (const message of this.messages) {
+			if (!message.sessionEntryId) continue;
+			if (sessionMessageIdByEntryId.has(message.sessionEntryId)) continue;
+			sessionMessageIdByEntryId.set(message.sessionEntryId, message.id);
+		}
+
+		const filteredForkOptions: ForkOption[] = forkMode
+			? this.forkOptions.filter((option) => {
 				if (!query) return true;
-				const toolsText = row.tools
-					.map((tc) => `${tc.name} ${(tc.result ?? tc.streamingOutput ?? "").toString()}`)
-					.join(" ");
-				const thinkingText = row.thinkingSnippets.join(" ");
-				const haystack = `${row.main.role} ${row.main.label || ""} ${this.messagePreview(row.main)} ${thinkingText} ${toolsText}`.toLowerCase();
+				const haystack = option.text.toLowerCase();
 				return haystack.includes(query);
 			})
 			: [];
-		const filteredMessages: UiMessage[] = forkMode
+		const useTreeRows = !forkMode && this.historyTreeRows.length > 0;
+		const filteredTreeRows: HistoryTreeRow[] = forkMode
 			? []
-			: sourceMessages.filter((msg) => {
-				if (this.historyRoleFilter !== "all" && msg.role !== this.historyRoleFilter) return false;
+			: this.historyTreeRows.filter((row) => {
+				if (this.historyRoleFilter !== "all" && row.role !== this.historyRoleFilter) return false;
 				if (!query) return true;
-				const haystack = `${msg.role} ${msg.label || ""} ${this.messagePreview(msg)}`.toLowerCase();
+				const haystack = `${row.role} ${row.entryLabel} ${row.preview} ${row.displayText} ${row.entryId}`.toLowerCase();
 				return haystack.includes(query);
 			});
+		const filteredBrowseRows: Array<{ msg: UiMessage; sourceIndex: number }> = forkMode || useTreeRows
+			? []
+			: sourceMessages
+				.map((msg, sourceIndex) => ({ msg, sourceIndex }))
+				.filter(({ msg }) => {
+					if (this.historyRoleFilter !== "all" && msg.role !== this.historyRoleFilter) return false;
+					if (!query) return true;
+					const haystack = `${msg.role} ${msg.label || ""} ${this.messagePreview(msg)}`.toLowerCase();
+					return haystack.includes(query);
+				});
+
+		const hasNoRows = forkMode ? filteredForkOptions.length === 0 : useTreeRows ? filteredTreeRows.length === 0 : filteredBrowseRows.length === 0;
+
 		return html`
 			<div class="overlay" @click=${(e: Event) => e.target === e.currentTarget && this.closeHistoryViewer()}>
 				<div class="overlay-card history-card ${forkMode ? "fork-mode" : ""}">
 					<div class="overlay-header">
 						<div>
-							<div>${forkMode ? "Fork from message" : "Session history"}</div>
+							<div>${forkMode ? "Fork from message" : "Session tree"}</div>
 							${forkMode
 								? html`<div class="history-subtitle">${this.historyViewerSessionLabel || "Current session"}</div>`
 								: nothing}
@@ -5327,7 +6599,7 @@ export class ChatView {
 					<div class="history-controls ${forkMode ? "fork" : ""}">
 						<input
 							type="text"
-							placeholder=${forkMode ? "Search visible messages" : "Search messages"}
+							placeholder=${forkMode ? "Search user messages" : "Search tree entries"}
 							.value=${this.historyQuery}
 							@input=${(e: Event) => {
 								this.historyQuery = (e.target as HTMLInputElement).value;
@@ -5356,81 +6628,69 @@ export class ChatView {
 					<div class="overlay-body history-list ${forkMode ? "fork-history-list" : ""}">
 						${this.historyViewerLoading
 							? html`<div class="overlay-empty">Loading session history…</div>`
-							: (forkMode ? filteredRows.length === 0 : filteredMessages.length === 0)
-								? html`<div class="overlay-empty">${forkMode ? "No messages available for forking." : "No messages match your filters."}</div>`
+							: hasNoRows
+								? html`<div class="overlay-empty">${forkMode ? "No messages available for forking." : "No session entries match your filters."}</div>`
 								: forkMode
-									? filteredRows.map((row, idx) => {
-											const msg = row.main;
-											const rowKey = this.forkRowKey(row);
-											const forkEntryId = this.resolveForkEntryId(sourceMessages, row.sourceIndex);
-											const rowCanFork = Boolean(forkEntryId) && (msg.role === "user" || msg.text.trim().length > 0);
-											const fullPreview = this.forkRowPreview(row);
-											const messageExpanded = this.forkExpandedMessageRows.has(rowKey);
-											const canExpandMessage = fullPreview.length > 220;
-											const previewText = messageExpanded ? fullPreview : truncate(fullPreview, 220);
-											const thinkingSnippets = row.thinkingSnippets
-												.map((snippet: string) => snippet.replace(/\s+/g, " ").trim())
-												.filter(Boolean)
-												.map((snippet: string) => truncate(snippet, 140));
-											const tools = row.tools;
-											const toolsExpanded = this.forkExpandedToolRows.has(rowKey);
-											const visibleTools = toolsExpanded ? tools : tools.slice(0, 3);
-											const hiddenToolCount = Math.max(0, tools.length - visibleTools.length);
+									? filteredForkOptions.map((option, idx) => {
+											const preview = truncate(option.text.replace(/\s+/g, " ").trim(), 240);
 											return html`
-												<div class="fork-history-item role-${msg.role}">
-													<div class="fork-history-rail" aria-hidden="true">
-														<span class="fork-history-dot"></span>
-														${idx < filteredRows.length - 1 ? html`<span class="fork-history-line"></span>` : nothing}
-													</div>
-													<div class="fork-history-main">
-														<div class="history-meta">
-															<span class="history-role role-${msg.role}">${msg.role}</span>
-															<span>#${idx + 1}</span>
-														</div>
-														<div class="history-preview ${messageExpanded ? "expanded" : ""}">${previewText}</div>
-														${canExpandMessage
-															? html`<button class="fork-inline-toggle" @click=${() => this.toggleForkMessageExpanded(rowKey)}>${messageExpanded ? "Show less" : "Show full message"}</button>`
-															: nothing}
-														${thinkingSnippets.length > 0 || tools.length > 0
-															? html`
-																<div class="fork-history-subentries">
-																	${thinkingSnippets.map(
-																		(snippet: string) => html`<div class="fork-history-subentry thinking"><span class="fork-subentry-label">thinking</span><span class="fork-subentry-preview">${snippet}</span></div>`,
-																	)}
-																	${visibleTools.map((tc: ToolCallBlock) => {
-																		const toolStatus = tc.isError ? "error" : tc.isRunning ? "running" : "done";
-																		const rawToolPreview = (tc.result ?? tc.streamingOutput ?? "").replace(/\s+/g, " ").trim();
-																		const toolPreview = toolsExpanded ? truncate(rawToolPreview, 240) : truncate(rawToolPreview, 96);
-																		return html`<div class="fork-history-subentry tool"><span class="fork-subentry-label">tool</span><span class="fork-subentry-name">${tc.name} · ${toolStatus}</span>${toolPreview ? html`<span class="fork-subentry-preview">${toolPreview}</span>` : nothing}</div>`;
-																	})}
-																	${tools.length > 3
-																		? html`<button class="fork-inline-toggle" @click=${() => this.toggleForkToolsExpanded(rowKey)}>${toolsExpanded ? "Show fewer tools" : `Show ${hiddenToolCount} more tools`}</button>`
-																		: nothing}
-																</div>
-															`
-															: nothing}
-													</div>
-													<div class="fork-history-actions">
-														${rowCanFork && forkEntryId
-															? html`<button class="message-action-btn" @click=${() => void this.forkFrom(forkEntryId)} title=${msg.role === "assistant" ? "Fork from preceding user message" : "Fork from this user message"}>Fork</button>`
-															: nothing}
+												<div class="history-item fork-user-row">
+													<div class="history-item-main">
+														<button class="history-jump" @click=${() => void this.forkFrom(option.entryId)} title="Fork from this user message">
+															<div class="history-meta">
+																<span class="history-role role-user">user</span>
+																<span>#${idx + 1}</span>
+															</div>
+															<div class="history-preview">${preview}</div>
+														</button>
+														<button class="history-fork-btn" @click=${() => void this.forkFrom(option.entryId)} title="Fork from this user message">Fork</button>
 													</div>
 												</div>
 											`;
 									  })
-									: filteredMessages.map(
-											(msg: UiMessage, idx: number) => html`
-												<div class="history-item">
-													<button class="history-jump" @click=${() => this.revealMessage(msg.id)}>
-														<div class="history-meta">
-															<span class="history-role role-${msg.role}">${msg.role}</span>
-															<span>#${idx + 1}</span>
+									: useTreeRows
+										? filteredTreeRows.map((row, idx) => {
+												const visibleMessageId = sessionMessageIdByEntryId.get(row.entryId) ?? null;
+												const canJump = Boolean(visibleMessageId);
+												const title = canJump ? "Jump to this entry" : "Entry is outside the active branch";
+												const compactPrefix = this.compactTreeLinePrefix(row.linePrefix, row.depth);
+												const rowText = row.displayText.trim() || row.preview || "(entry)";
+												const lineText = `${compactPrefix}${row.onActivePath ? "• " : "  "}${truncate(rowText, 320)}`;
+												const lineBody = html`<span class="history-tree-line-mono role-${row.role}">${lineText}</span>`;
+												return html`
+													<div class="history-tree-line-row ${row.onActivePath ? "on-path" : "off-path"}">
+														${canJump && visibleMessageId
+															? html`<button class="history-tree-line ${row.onActivePath ? "on-path" : ""}" @click=${() => this.revealMessage(visibleMessageId)} title=${title}>${lineBody}</button>`
+															: html`<div class="history-tree-line static" title=${title}>${lineBody}</div>`}
+														<div class="history-tree-line-actions">
+															<span class="history-tree-index">#${idx + 1}</span>
+															${row.canFork
+																? html`<button class="history-fork-btn" @click=${() => void this.forkFrom(row.entryId)} title="Fork from this user message">Fork</button>`
+																: nothing}
 														</div>
-														<div class="history-preview">${truncate(this.messagePreview(msg).replace(/\s+/g, " "), 200)}</div>
-													</button>
-												</div>
-											`,
-									  )}
+													</div>
+												`;
+									  })
+										: filteredBrowseRows.map(({ msg, sourceIndex }, idx: number) => {
+												const forkEntryId = this.resolveForkEntryId(sourceMessages, sourceIndex);
+												const canFork = Boolean(forkEntryId) && (msg.role === "user" || msg.role === "assistant");
+												return html`
+													<div class="history-item">
+														<div class="history-item-main">
+															<button class="history-jump" @click=${() => this.revealMessage(msg.id)}>
+																<div class="history-meta">
+																	<span class="history-role role-${msg.role}">${msg.role}</span>
+																	<span>#${idx + 1}</span>
+																</div>
+																<div class="history-preview">${truncate(this.messagePreview(msg).replace(/\s+/g, " "), 200)}</div>
+															</button>
+															${canFork && forkEntryId
+																? html`<button class="history-fork-btn" @click=${() => void this.forkFrom(forkEntryId)} title=${msg.role === "assistant" ? "Fork from preceding user message" : "Fork from this user message"}>Fork</button>`
+																: nothing}
+														</div>
+													</div>
+												`;
+									  })}
 					</div>
 				</div>
 			</div>
@@ -5498,7 +6758,6 @@ export class ChatView {
 							: this.bindingStatusText
 								? this.renderBindingState()
 								: this.renderEmptyState()}
-					${hasProject ? this.renderCompactionCycle() : nothing}
 					${showWorkingIndicator ? this.renderWorkingIndicatorRow() : nothing}
 				</div>
 				${hasProject ? this.renderComposer() : nothing}

--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -59,6 +59,7 @@ export class CommandPalette {
 		this.filterCommands();
 		this.render();
 		this.focusInput();
+		this.ensureSelectedCommandVisible();
 	}
 
 	close(): void {
@@ -134,11 +135,13 @@ export class CommandPalette {
 				e.preventDefault();
 				this.selectedIndex = Math.min(this.selectedIndex + 1, this.filteredCommands.length - 1);
 				this.render();
+				this.ensureSelectedCommandVisible();
 				break;
 			case "ArrowUp":
 				e.preventDefault();
 				this.selectedIndex = Math.max(this.selectedIndex - 1, 0);
 				this.render();
+				this.ensureSelectedCommandVisible();
 				break;
 			case "Enter":
 				e.preventDefault();
@@ -158,6 +161,15 @@ export class CommandPalette {
 			const input = this.container.querySelector("input");
 			input?.focus();
 		}, 50);
+	}
+
+	private ensureSelectedCommandVisible(): void {
+		requestAnimationFrame(() => {
+			const list = this.container.querySelector<HTMLElement>(".command-palette-list");
+			const selected = this.container.querySelector<HTMLElement>(".command-row.selected");
+			if (!list || !selected) return;
+			selected.scrollIntoView({ block: "nearest" });
+		});
 	}
 
 	private getSourceIcon(source: PaletteCommand["source"]): string {

--- a/src/components/packages-view.ts
+++ b/src/components/packages-view.ts
@@ -1267,6 +1267,25 @@ export class PackagesView {
 		this.render();
 	}
 
+	async openExtensionConfigBySource(source: string): Promise<boolean> {
+		const normalized = normalizeRecommendedSource(source);
+		const installed = this.findInstalledItemForSource(normalized, "global");
+		if (!installed) return false;
+		const item: ExtensionSurfaceItem = {
+			id: `installed:${normalized}`,
+			displayName: installed.displayName,
+			source: installed.source,
+			description: "Installed extension package",
+			note: installed.location || installed.source,
+			openUrl: installed.openUrl,
+			sourceKind: inferSourceKindFromSource(installed.source),
+			installState: this.extensionInstallState(installed.source),
+			installedItemForScope: installed,
+		};
+		await this.openPackagesItemModal({ kind: "extension", item });
+		return true;
+	}
+
 	private closeActivePackageConfig(): void {
 		this.activePackageConfigSource = null;
 		this.activePackageConfigLabel = "";

--- a/src/components/session-browser.ts
+++ b/src/components/session-browser.ts
@@ -52,10 +52,10 @@ export class SessionBrowser {
 		this.render();
 	}
 
-	async open(): Promise<void> {
+	async open(options: { query?: string } = {}): Promise<void> {
 		this.isOpen = true;
 		this.loading = true;
-		this.query = "";
+		this.query = options.query?.trim() ?? "";
 		this.forkMode = false;
 		this.forkOptions = [];
 		this.render();

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -51,6 +51,31 @@ interface SettingsState {
 	followUpMode: QueueMode;
 }
 
+interface ScopedModelOption {
+	fullId: string;
+	provider: string;
+	id: string;
+	name: string;
+}
+
+export type SettingsSectionId = "general" | "appearance" | "account" | "updates";
+
+export interface SettingsSectionNavItem {
+	id: SettingsSectionId;
+	label: string;
+	description: string;
+	runtimeRequired?: boolean;
+}
+
+export interface SettingsSectionNavState extends SettingsSectionNavItem {
+	disabled: boolean;
+}
+
+export interface SettingsNavigationState {
+	activeSection: SettingsSectionId;
+	items: SettingsSectionNavState[];
+}
+
 export class SettingsPanel {
 	private container: HTMLElement;
 	private isOpen = false;
@@ -76,6 +101,7 @@ export class SettingsPanel {
 	private cliUpdating = false;
 	private cliActionMessage = "";
 	private onCliStatusChange: ((status: CliUpdateStatus | null) => void) | null = null;
+	private onNavigationStateChange: ((state: SettingsNavigationState) => void) | null = null;
 	private compatibilityReport: RpcCompatibilityReport | null = null;
 	private compatibilityLoading = false;
 	private appearanceProfiles: DesktopAppearanceProfiles = loadDesktopAppearanceProfiles();
@@ -93,6 +119,18 @@ export class SettingsPanel {
 		light: { accent: "", background: "", foreground: "" },
 		dark: { accent: "", background: "", foreground: "" },
 	};
+	private scopedModelsLoading = false;
+	private scopedModelsSaving = false;
+	private scopedModelsError = "";
+	private scopedModelsMessage = "";
+	private scopedModelsSearch = "";
+	private scopedModels: ScopedModelOption[] = [];
+	private scopedModelsHasFilter = false;
+	private scopedModelsEnabledIds: string[] = [];
+	private scopedModelsSavedSnapshot = "";
+	private scopedModelsSettingsPath: string | null = null;
+	private scopedModelsUnknownPatterns: string[] = [];
+	private activeSection: SettingsSectionId = "general";
 
 	constructor(container: HTMLElement) {
 		this.container = container;
@@ -126,8 +164,64 @@ export class SettingsPanel {
 		this.onCliStatusChange = callback;
 	}
 
+	setOnNavigationStateChange(callback: ((state: SettingsNavigationState) => void) | null): void {
+		this.onNavigationStateChange = callback;
+		if (callback) callback(this.getNavigationState());
+	}
+
+	getActiveSection(): SettingsSectionId {
+		return this.getNavigationState().activeSection;
+	}
+
+	setActiveSection(section: SettingsSectionId): void {
+		const navItems = this.getSettingsNavItems();
+		const target = navItems.find((item) => item.id === section);
+		if (!target) return;
+		const runtimeControlsEnabled = this.isRuntimeControlsEnabled();
+		if (target.runtimeRequired && !runtimeControlsEnabled) return;
+		if (this.activeSection === section) return;
+		this.activeSection = section;
+		this.emitNavigationState(runtimeControlsEnabled);
+		if (this.isOpen) this.render();
+	}
+
+	getNavigationState(): SettingsNavigationState {
+		const runtimeControlsEnabled = this.isRuntimeControlsEnabled();
+		const activeSection = this.normalizeActiveSection(runtimeControlsEnabled);
+		const items = this.getSettingsNavItems().map((item) => ({
+			...item,
+			disabled: Boolean(item.runtimeRequired && !runtimeControlsEnabled),
+		}));
+		return { activeSection, items };
+	}
+
 	setRuntimeProjectPath(projectPath: string | null): void {
 		this.runtimeProjectPath = typeof projectPath === "string" && projectPath.trim().length > 0 ? projectPath : null;
+		this.emitNavigationState();
+	}
+
+	private isRuntimeControlsEnabled(): boolean {
+		return Boolean(this.runtimeProjectPath) && rpcBridge.isConnected;
+	}
+
+	private normalizeActiveSection(runtimeControlsEnabled = this.isRuntimeControlsEnabled()): SettingsSectionId {
+		const navItems = this.getSettingsNavItems();
+		const requested = navItems.find((item) => item.id === this.activeSection) ?? navItems[0];
+		if (requested?.runtimeRequired && !runtimeControlsEnabled) {
+			this.activeSection = "appearance";
+		}
+		return (this.activeSection ?? "appearance") as SettingsSectionId;
+	}
+
+	private emitNavigationState(runtimeControlsEnabled = this.isRuntimeControlsEnabled()): void {
+		if (!this.onNavigationStateChange) return;
+		this.onNavigationStateChange({
+			activeSection: this.normalizeActiveSection(runtimeControlsEnabled),
+			items: this.getSettingsNavItems().map((item) => ({
+				...item,
+				disabled: Boolean(item.runtimeRequired && !runtimeControlsEnabled),
+			})),
+		});
 	}
 
 	isVisible(): boolean {
@@ -136,6 +230,7 @@ export class SettingsPanel {
 
 	async open(): Promise<void> {
 		this.isOpen = true;
+		this.emitNavigationState();
 		this.appearanceProfiles = loadDesktopAppearanceProfiles();
 		this.resetColorDrafts();
 		this.createThemeDialogOpen = false;
@@ -148,6 +243,7 @@ export class SettingsPanel {
 		await this.loadState();
 		if (!this.isOpen) return;
 		this.render();
+		this.emitNavigationState();
 	}
 
 	close(notify = true): void {
@@ -158,6 +254,7 @@ export class SettingsPanel {
 		this.applyAppearanceProfileForCurrentResolvedTheme();
 		this.isOpen = false;
 		this.render();
+		this.emitNavigationState();
 		if (notify) this.onClose?.();
 	}
 
@@ -782,6 +879,17 @@ export class SettingsPanel {
 			this.themeCatalogError = "";
 			this.themeCatalogMessage = "";
 			this.availableThemes = [];
+			this.scopedModelsLoading = false;
+			this.scopedModelsSaving = false;
+			this.scopedModelsError = "";
+			this.scopedModelsMessage = "";
+			this.scopedModelsSearch = "";
+			this.scopedModels = [];
+			this.scopedModelsHasFilter = false;
+			this.scopedModelsEnabledIds = [];
+			this.scopedModelsSavedSnapshot = "";
+			this.scopedModelsSettingsPath = null;
+			this.scopedModelsUnknownPatterns = [];
 		}
 
 		try {
@@ -812,6 +920,7 @@ export class SettingsPanel {
 			this.refreshThemeCatalog(),
 			this.refreshAuthStatus(),
 			this.refreshCompatibilityStatus(),
+			this.refreshScopedModels(),
 		]);
 		this.applyAppearanceProfileForCurrentResolvedTheme(false);
 	}
@@ -993,6 +1102,417 @@ export class SettingsPanel {
 		} catch (err) {
 			console.error("Failed to set follow-up mode:", err);
 		}
+	}
+
+	private readStringPath(source: Record<string, unknown>, path: string): string | null {
+		const parts = path.split(".");
+		let current: unknown = source;
+		for (const part of parts) {
+			if (!current || typeof current !== "object") return null;
+			current = (current as Record<string, unknown>)[part];
+		}
+		if (typeof current !== "string") return null;
+		const value = current.trim();
+		return value.length > 0 ? value : null;
+	}
+
+	private pickStringPath(source: Record<string, unknown>, paths: string[]): string | null {
+		for (const path of paths) {
+			const value = this.readStringPath(source, path);
+			if (value !== null) return value;
+		}
+		return null;
+	}
+
+	private parseScopedModelOptions(rawModels: Array<Record<string, unknown>>): ScopedModelOption[] {
+		const byId = new Map<string, ScopedModelOption>();
+		for (const raw of rawModels) {
+			const provider = this.pickStringPath(raw, ["provider", "target.provider", "model.provider"]);
+			const id = this.pickStringPath(raw, ["id", "modelId", "model_id", "model", "target.id", "target.modelId"]);
+			if (!provider || !id) continue;
+			const fullId = `${provider}/${id}`;
+			const key = fullId.toLowerCase();
+			if (byId.has(key)) continue;
+			const name = this.pickStringPath(raw, ["name", "label", "target.name"]) ?? id;
+			byId.set(key, {
+				fullId,
+				provider,
+				id,
+				name,
+			});
+		}
+		return [...byId.values()].sort((a, b) => {
+			const providerCmp = a.provider.localeCompare(b.provider);
+			if (providerCmp !== 0) return providerCmp;
+			return a.id.localeCompare(b.id);
+		});
+	}
+
+	private async resolvePiSettingsPath(): Promise<string> {
+		let agentDir = "";
+		try {
+			const status = await rpcBridge.getPiAuthStatus();
+			agentDir = typeof status.agent_dir === "string" ? status.agent_dir.trim() : "";
+		} catch {
+			// ignore and fallback to default path
+		}
+		if (!agentDir) {
+			const { homeDir } = await import("@tauri-apps/api/path");
+			const home = (await homeDir()).replace(/\\/g, "/").replace(/\/+$/, "");
+			agentDir = this.joinFsPath(this.joinFsPath(home, ".pi"), "agent");
+		}
+		return this.joinFsPath(agentDir, "settings.json");
+	}
+
+	private async readPiGlobalSettingsDoc(): Promise<{ path: string; doc: Record<string, unknown> }> {
+		const { exists, readTextFile } = await import("@tauri-apps/plugin-fs");
+		const path = await this.resolvePiSettingsPath();
+		this.scopedModelsSettingsPath = path;
+		if (!(await exists(path))) {
+			return { path, doc: {} };
+		}
+		const content = await readTextFile(path);
+		if (!content.trim()) return { path, doc: {} };
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(content);
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			throw new Error(`Failed to parse ${path}: ${message}`);
+		}
+		if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+			throw new Error(`Expected object in ${path}, but found ${Array.isArray(parsed) ? "array" : typeof parsed}`);
+		}
+		return { path, doc: parsed as Record<string, unknown> };
+	}
+
+	private patternToRegex(pattern: string): RegExp | null {
+		const trimmed = pattern.trim();
+		if (!trimmed) return null;
+		const escaped = trimmed.replace(/[.+^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
+		try {
+			return new RegExp(`^${escaped}$`, "i");
+		} catch {
+			return null;
+		}
+	}
+
+	private resolveScopedModelIdsFromPatterns(
+		patterns: string[] | undefined,
+		models: ScopedModelOption[],
+	): { hasFilter: boolean; enabledIds: string[]; unknownPatterns: string[] } {
+		const allIds = models.map((model) => model.fullId);
+		if (!patterns || patterns.length === 0) {
+			return { hasFilter: false, enabledIds: [...allIds], unknownPatterns: [] };
+		}
+
+		const idByLower = new Map(allIds.map((id) => [id.toLowerCase(), id]));
+		const enabledIds: string[] = [];
+		const seen = new Set<string>();
+		const unknownPatterns: string[] = [];
+
+		for (const rawPattern of patterns) {
+			const pattern = rawPattern.trim();
+			if (!pattern) continue;
+			const hasWildcard = pattern.includes("*");
+			if (!hasWildcard) {
+				const exact = idByLower.get(pattern.toLowerCase());
+				if (!exact) {
+					unknownPatterns.push(pattern);
+					continue;
+				}
+				if (!seen.has(exact)) {
+					seen.add(exact);
+					enabledIds.push(exact);
+				}
+				continue;
+			}
+			const regex = this.patternToRegex(pattern);
+			if (!regex) {
+				unknownPatterns.push(pattern);
+				continue;
+			}
+			let matched = false;
+			for (const id of allIds) {
+				if (!regex.test(id)) continue;
+				matched = true;
+				if (!seen.has(id)) {
+					seen.add(id);
+					enabledIds.push(id);
+				}
+			}
+			if (!matched) unknownPatterns.push(pattern);
+		}
+
+		if (enabledIds.length >= allIds.length) {
+			return { hasFilter: false, enabledIds: [...allIds], unknownPatterns };
+		}
+		return { hasFilter: true, enabledIds, unknownPatterns };
+	}
+
+	private setScopedModelsSelection(hasFilter: boolean, enabledIds: string[]): void {
+		const allIds = this.scopedModels.map((model) => model.fullId);
+		const allowed = new Set(allIds);
+		const deduped: string[] = [];
+		for (const id of enabledIds) {
+			if (!allowed.has(id)) continue;
+			if (deduped.includes(id)) continue;
+			deduped.push(id);
+		}
+
+		if (!hasFilter || deduped.length >= allIds.length) {
+			this.scopedModelsHasFilter = false;
+			this.scopedModelsEnabledIds = [...allIds];
+			return;
+		}
+
+		this.scopedModelsHasFilter = true;
+		this.scopedModelsEnabledIds = deduped;
+	}
+
+	private scopedModelsSnapshot(): string {
+		if (!this.scopedModelsHasFilter) return "all:*";
+		return `filtered:${this.scopedModelsEnabledIds.join("|")}`;
+	}
+
+	private scopedModelsDirty(): boolean {
+		return this.scopedModelsSnapshot() !== this.scopedModelsSavedSnapshot;
+	}
+
+	private isScopedModelEnabled(fullId: string): boolean {
+		return !this.scopedModelsHasFilter || this.scopedModelsEnabledIds.includes(fullId);
+	}
+
+	private allScopedModelIds(): string[] {
+		return this.scopedModels.map((model) => model.fullId);
+	}
+
+	private toggleScopedModel(fullId: string): void {
+		const allIds = this.allScopedModelIds();
+		if (allIds.length === 0) return;
+		const currentlyEnabled = this.isScopedModelEnabled(fullId);
+		if (!this.scopedModelsHasFilter) {
+			if (!currentlyEnabled) return;
+			const nextEnabled = allIds.filter((id) => id !== fullId);
+			this.setScopedModelsSelection(true, nextEnabled);
+		} else if (currentlyEnabled) {
+			this.setScopedModelsSelection(
+				true,
+				this.scopedModelsEnabledIds.filter((id) => id !== fullId),
+			);
+		} else {
+			this.setScopedModelsSelection(true, [...this.scopedModelsEnabledIds, fullId]);
+		}
+		this.scopedModelsError = "";
+		this.scopedModelsMessage = "";
+		this.render();
+	}
+
+	private enableAllScopedModels(): void {
+		this.setScopedModelsSelection(false, this.allScopedModelIds());
+		this.scopedModelsError = "";
+		this.scopedModelsMessage = "";
+		this.render();
+	}
+
+	private clearAllScopedModels(): void {
+		this.setScopedModelsSelection(true, []);
+		this.scopedModelsError = "";
+		this.scopedModelsMessage = "";
+		this.render();
+	}
+
+	private toggleScopedProvider(provider: string): void {
+		const providerIds = this.scopedModels
+			.filter((model) => model.provider === provider)
+			.map((model) => model.fullId);
+		if (providerIds.length === 0) return;
+		const allIds = this.allScopedModelIds();
+		const providerFullyEnabled = providerIds.every((id) => this.isScopedModelEnabled(id));
+		if (!this.scopedModelsHasFilter) {
+			if (providerFullyEnabled) {
+				const nextEnabled = allIds.filter((id) => !providerIds.includes(id));
+				this.setScopedModelsSelection(true, nextEnabled);
+			}
+		} else if (providerFullyEnabled) {
+			this.setScopedModelsSelection(
+				true,
+				this.scopedModelsEnabledIds.filter((id) => !providerIds.includes(id)),
+			);
+		} else {
+			const next = [...this.scopedModelsEnabledIds];
+			for (const id of providerIds) {
+				if (!next.includes(id)) next.push(id);
+			}
+			this.setScopedModelsSelection(true, next);
+		}
+		this.scopedModelsError = "";
+		this.scopedModelsMessage = "";
+		this.render();
+	}
+
+	private async refreshScopedModels(): Promise<void> {
+		this.scopedModelsLoading = true;
+		this.scopedModelsError = "";
+		this.scopedModelsMessage = "";
+		this.scopedModelsUnknownPatterns = [];
+		this.render();
+		try {
+			const raw = await rpcBridge.getAvailableModels();
+			const modelRecords = Array.isArray(raw)
+				? raw.filter((entry): entry is Record<string, unknown> => Boolean(entry) && typeof entry === "object")
+				: [];
+			this.scopedModels = this.parseScopedModelOptions(modelRecords);
+
+			const { path, doc } = await this.readPiGlobalSettingsDoc();
+			this.scopedModelsSettingsPath = path;
+			const patterns = Array.isArray(doc.enabledModels)
+				? doc.enabledModels
+					.filter((value): value is string => typeof value === "string")
+					.map((value) => value.trim())
+					.filter(Boolean)
+				: undefined;
+			const resolved = this.resolveScopedModelIdsFromPatterns(patterns, this.scopedModels);
+			this.scopedModelsUnknownPatterns = resolved.unknownPatterns;
+			this.setScopedModelsSelection(resolved.hasFilter, resolved.enabledIds);
+			this.scopedModelsSavedSnapshot = this.scopedModelsSnapshot();
+			if (resolved.unknownPatterns.length > 0) {
+				this.scopedModelsMessage = "Some saved model patterns are not currently available and were skipped in this view.";
+			}
+		} catch (err) {
+			this.scopedModels = [];
+			this.scopedModelsHasFilter = false;
+			this.scopedModelsEnabledIds = [];
+			this.scopedModelsSavedSnapshot = "";
+			this.scopedModelsError = err instanceof Error ? err.message : String(err);
+		} finally {
+			this.scopedModelsLoading = false;
+			this.render();
+		}
+	}
+
+	private async saveScopedModels(): Promise<void> {
+		if (this.scopedModelsSaving) return;
+		this.scopedModelsSaving = true;
+		this.scopedModelsError = "";
+		this.scopedModelsMessage = "Saving scoped models…";
+		this.render();
+		try {
+			const { mkdir, writeTextFile } = await import("@tauri-apps/plugin-fs");
+			const { path, doc } = await this.readPiGlobalSettingsDoc();
+			const nextDoc: Record<string, unknown> = { ...doc };
+			const allIds = this.allScopedModelIds();
+			const enabledIds = this.scopedModelsHasFilter ? this.scopedModelsEnabledIds : allIds;
+			const deduped = enabledIds.filter((id, index) => enabledIds.indexOf(id) === index && allIds.includes(id));
+			const shouldClearFilter = !this.scopedModelsHasFilter || deduped.length >= allIds.length;
+			if (shouldClearFilter) {
+				delete nextDoc.enabledModels;
+				this.setScopedModelsSelection(false, allIds);
+			} else {
+				nextDoc.enabledModels = deduped;
+				this.setScopedModelsSelection(true, deduped);
+			}
+
+			const dir = path.replace(/\\/g, "/").replace(/\/[^/]+$/, "");
+			if (dir) {
+				await mkdir(dir, { recursive: true });
+			}
+			await writeTextFile(path, `${JSON.stringify(nextDoc, null, 2)}\n`);
+			this.scopedModelsSettingsPath = path;
+			this.scopedModelsSavedSnapshot = this.scopedModelsSnapshot();
+			this.scopedModelsMessage = "Scoped models saved. Run /reload to apply this scope to the current runtime.";
+		} catch (err) {
+			this.scopedModelsError = err instanceof Error ? err.message : String(err);
+			this.scopedModelsMessage = "";
+		} finally {
+			this.scopedModelsSaving = false;
+			this.render();
+		}
+	}
+
+	private renderScopedModelsSection(): TemplateResult {
+		const totalModels = this.scopedModels.length;
+		const enabledCount = this.scopedModelsHasFilter ? this.scopedModelsEnabledIds.length : totalModels;
+		const query = this.scopedModelsSearch.trim().toLowerCase();
+		const visibleModels = query
+			? this.scopedModels.filter((model) => `${model.id} ${model.provider} ${model.name}`.toLowerCase().includes(query))
+			: this.scopedModels;
+		const grouped = new Map<string, ScopedModelOption[]>();
+		for (const model of visibleModels) {
+			const bucket = grouped.get(model.provider) ?? [];
+			bucket.push(model);
+			grouped.set(model.provider, bucket);
+		}
+		const providers = [...grouped.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+		const dirty = this.scopedModelsDirty();
+
+		return html`
+			<div class="settings-section">
+				<div class="settings-section-title">Scoped models</div>
+				<div class="settings-desc">Choose which models are included when cycling models with Ctrl+P. This matches CLI <code>/scoped-models</code> behavior.</div>
+				<div class="settings-row scoped-models-toolbar-row">
+					<div class="scoped-models-summary">Enabled: <strong>${enabledCount}</strong> / ${totalModels || "0"}${dirty ? html` <span class="scoped-models-unsaved">(unsaved)</span>` : nothing}</div>
+					<input
+						class="appearance-font-input scoped-models-search"
+						type="text"
+						placeholder="Search models"
+						.value=${this.scopedModelsSearch}
+						@input=${(e: Event) => {
+							this.scopedModelsSearch = (e.target as HTMLInputElement).value;
+							this.render();
+						}}
+					/>
+				</div>
+				<div class="settings-actions scoped-models-actions">
+					<button class="ghost-btn" ?disabled=${this.scopedModelsLoading || totalModels === 0} @click=${() => this.enableAllScopedModels()}>Enable all</button>
+					<button class="ghost-btn" ?disabled=${this.scopedModelsLoading || totalModels === 0} @click=${() => this.clearAllScopedModels()}>Clear all</button>
+					<button class="ghost-btn" ?disabled=${this.scopedModelsLoading || !dirty || this.scopedModelsSaving} @click=${() => this.saveScopedModels()}>
+						${this.scopedModelsSaving ? "Saving…" : "Save scoped models"}
+					</button>
+					<button class="ghost-btn" ?disabled=${this.scopedModelsLoading} @click=${() => this.refreshScopedModels()}>Refresh</button>
+				</div>
+				${this.scopedModelsLoading ? html`<div class="settings-desc">Loading available models…</div>` : nothing}
+				${this.scopedModelsError ? html`<div class="settings-desc scoped-models-error">${this.scopedModelsError}</div>` : nothing}
+				${this.scopedModelsUnknownPatterns.length > 0
+					? html`<div class="settings-desc">Unresolved saved patterns: <code>${this.scopedModelsUnknownPatterns.join(", ")}</code></div>`
+					: nothing}
+				${this.scopedModelsMessage ? html`<div class="settings-desc">${this.scopedModelsMessage}</div>` : nothing}
+				${this.scopedModelsSettingsPath ? html`<div class="settings-desc">Settings file: <code>${this.scopedModelsSettingsPath}</code></div>` : nothing}
+				${!this.scopedModelsLoading && !this.scopedModelsError
+					? providers.length === 0
+						? html`<div class="settings-desc">No models available for scoped configuration.</div>`
+						: html`
+							<div class="scoped-models-list">
+								${providers.map(([provider, models]) => {
+									const providerEnabledCount = models.filter((model) => this.isScopedModelEnabled(model.fullId)).length;
+									const providerAllEnabled = providerEnabledCount === models.length;
+									return html`
+										<div class="scoped-models-provider-header">
+											<div class="scoped-models-provider-meta">
+												<span class="settings-label">${provider}</span>
+												<span class="settings-desc">${providerEnabledCount}/${models.length} enabled</span>
+											</div>
+											<button class="ghost-btn" @click=${() => this.toggleScopedProvider(provider)}>${providerAllEnabled ? "Disable provider" : "Enable provider"}</button>
+										</div>
+										${models.map((model) => {
+											const enabled = this.isScopedModelEnabled(model.fullId);
+											return html`
+												<div class="settings-row scoped-model-row">
+													<div class="scoped-model-row-main">
+														<div class="settings-label">${model.id}</div>
+														<div class="settings-desc">${model.provider}${model.name && model.name !== model.id ? ` · ${model.name}` : ""}</div>
+													</div>
+													<button class="toggle ${enabled ? "on" : "off"}" @click=${() => this.toggleScopedModel(model.fullId)}><span></span></button>
+												</div>
+											`;
+										})}
+									`;
+								})}
+							</div>
+						`
+					: nothing}
+			</div>
+		`;
 	}
 
 	private async saveSettings(): Promise<void> {
@@ -1180,8 +1700,7 @@ export class SettingsPanel {
 				<div class="settings-view-root">
 					<div class="settings-view-header">
 						<div class="settings-view-title-wrap">
-							<div class="settings-view-title">Settings</div>
-							<div class="settings-view-meta">Desktop preferences that work immediately.</div>
+							<div class="settings-view-title">Appearance</div>
 						</div>
 						<div class="settings-view-header-actions">
 							<button class="settings-back-btn" @click=${() => this.close()}>← Back</button>
@@ -1223,243 +1742,374 @@ export class SettingsPanel {
 		);
 	}
 
+	private getSettingsNavItems(): SettingsSectionNavItem[] {
+		return [
+			{
+				id: "general",
+				label: "General",
+				description: "Assistant behavior, model scope, and queue defaults.",
+				runtimeRequired: true,
+			},
+			{
+				id: "appearance",
+				label: "Appearance",
+				description: "Theme mode and desktop appearance profiles.",
+			},
+			{
+				id: "account",
+				label: "Account",
+				description: "Provider auth status and package config notes.",
+				runtimeRequired: true,
+			},
+			{
+				id: "updates",
+				label: "Updates",
+				description: "Desktop releases, CLI version, and runtime diagnostics.",
+			},
+		];
+	}
+
+	private renderAppearanceSection(): TemplateResult {
+		return html`
+			<div class="settings-view-grid">
+				<section class="settings-group settings-group-full">
+					<div class="settings-section">
+						<div class="settings-section-title">Appearance</div>
+						<div class="appearance-theme-block">
+							<div class="appearance-theme-header-row">
+								<div>
+									<div class="settings-label">Theme</div>
+									<div class="settings-desc">Use light, dark, or match your system.</div>
+								</div>
+								<div class="theme-grid">
+									<button class="theme-btn ${this.state.theme === "light" ? "active" : ""}" @click=${() => this.setTheme("light")}>Light</button>
+									<button class="theme-btn ${this.state.theme === "dark" ? "active" : ""}" @click=${() => this.setTheme("dark")}>Dark</button>
+									<button class="theme-btn ${this.state.theme === "system" ? "active" : ""}" @click=${() => this.setTheme("system")}>System</button>
+								</div>
+							</div>
+							${this.themeCatalogLoading ? html`<div class="settings-desc">Loading available Pi themes…</div>` : nothing}
+							${this.themeCatalogError ? html`<div class="settings-desc">Theme catalog error: ${this.themeCatalogError}</div>` : nothing}
+							${this.themeCatalogMessage ? html`<div class="settings-desc">${this.themeCatalogMessage}</div>` : nothing}
+							${this.renderThemeProfileCard("light")}
+							${this.renderThemeProfileCard("dark")}
+						</div>
+					</div>
+				</section>
+			</div>
+		`;
+	}
+
+	private renderGeneralSection(runtimeControlsEnabled: boolean, hasProjectContext: boolean): TemplateResult {
+		if (!runtimeControlsEnabled) {
+			const runtimeMessage = hasProjectContext
+				? "Runtime is still starting for this project. General controls unlock once runtime is ready."
+				: "Open a project to configure assistant behavior and scoped models.";
+			return html`
+				<div class="settings-view-grid">
+					<section class="settings-group settings-group-full">
+						<div class="settings-section">
+							<div class="settings-section-title">General</div>
+							<div class="settings-desc">${runtimeMessage}</div>
+							${!hasProjectContext
+								? html`
+									<div class="settings-actions" style="margin-top:10px;">
+										<button class="ghost-btn" @click=${() => this.onRequestAddProject?.()}>Add project</button>
+									</div>
+								`
+								: nothing}
+						</div>
+					</section>
+				</div>
+			`;
+		}
+
+		return html`
+			<div class="settings-view-grid">
+				<section class="settings-group">
+					<div class="settings-section">
+						<div class="settings-section-title">Assistant</div>
+						${this.renderToggle(
+							"Auto-compaction",
+							"Summarize older context automatically when conversations get long.",
+							this.state.autoCompactionEnabled,
+							(v) => this.setAutoCompaction(v),
+						)}
+						${this.renderToggle(
+							"Auto-retry",
+							"Retry temporary provider errors automatically.",
+							this.state.autoRetryEnabled,
+							(v) => this.setAutoRetry(v),
+						)}
+					</div>
+				</section>
+
+				<section class="settings-group">
+					<div class="settings-section">
+						<div class="settings-section-title">Message queue</div>
+						<div class="settings-row">
+							<div>
+								<div class="settings-label">Steering messages</div>
+								<div class="settings-desc">How queued steering messages are sent while a response is streaming.</div>
+							</div>
+							<select class="settings-select" .value=${this.state.steeringMode} @change=${(e: Event) => this.setSteeringMode((e.target as HTMLSelectElement).value as QueueMode)}>
+								<option value="one-at-a-time">One at a time</option>
+								<option value="all">All queued</option>
+							</select>
+						</div>
+						<div class="settings-row">
+							<div>
+								<div class="settings-label">Follow-up messages</div>
+								<div class="settings-desc">How queued follow-up prompts are sent after each run.</div>
+							</div>
+							<select class="settings-select" .value=${this.state.followUpMode} @change=${(e: Event) => this.setFollowUpMode((e.target as HTMLSelectElement).value as QueueMode)}>
+								<option value="one-at-a-time">One at a time</option>
+								<option value="all">All queued</option>
+							</select>
+						</div>
+					</div>
+				</section>
+
+				<section class="settings-group settings-group-full">
+					${this.renderScopedModelsSection()}
+				</section>
+			</div>
+		`;
+	}
+
+	private renderAccountSection(
+		runtimeControlsEnabled: boolean,
+		hasProjectContext: boolean,
+		authProviders: PiAuthStatus["configured_providers"],
+	): TemplateResult {
+		if (!runtimeControlsEnabled) {
+			const runtimeMessage = hasProjectContext
+				? "Runtime is still starting for this project. Account diagnostics unlock when runtime is ready."
+				: "Open a project to inspect provider auth and runtime-linked account details.";
+			return html`
+				<div class="settings-view-grid">
+					<section class="settings-group settings-group-full">
+						<div class="settings-section">
+							<div class="settings-section-title">Account</div>
+							<div class="settings-desc">${runtimeMessage}</div>
+						</div>
+					</section>
+				</div>
+			`;
+		}
+
+		return html`
+			<div class="settings-view-grid">
+				<section class="settings-group">
+					<div class="settings-section">
+						<div class="settings-section-title">Account</div>
+						${this.authLoading
+							? html`<div class="settings-desc">Checking account status…</div>`
+							: html`
+								<div class="settings-desc">
+									${authProviders.length > 0 ? `Connected providers: ${authProviders.length}` : "No provider connected yet."}
+								</div>
+								<div class="settings-actions">
+									<button class="ghost-btn" @click=${() => this.refreshAuthStatus()}>Refresh account status</button>
+								</div>
+								${authProviders.length > 0
+									? html`
+										<div class="account-chips">
+											${authProviders.map((p) => html`<span class="account-chip">${p.provider} · ${p.source === "environment" ? "env" : p.kind}</span>`) }
+										</div>
+									`
+									: null}
+								<div class="settings-desc">Tip: run <code>/login</code> in terminal once, then restart desktop.</div>
+								${this.authStatus?.auth_file
+									? html`
+										<details class="settings-advanced">
+											<summary>Advanced account details</summary>
+											<div class="settings-desc">Auth file: <code>${this.authStatus.auth_file}</code></div>
+										</details>
+									`
+									: null}
+							`}
+					</div>
+				</section>
+
+				<section class="settings-group">
+					<div class="settings-section">
+						<div class="settings-section-title">Package configuration</div>
+						<div class="settings-desc">Package-specific settings are managed in <strong>Packages</strong> (gear icon on installed packages).</div>
+						<div class="settings-desc">Desktop stays capability-driven: packages can expose config commands, and those run via the normal chat/runtime flow.</div>
+					</div>
+				</section>
+			</div>
+		`;
+	}
+
+	private renderUpdatesSection(runtimeControlsEnabled: boolean, compatibilityChecks: string[]): TemplateResult {
+		return html`
+			<div class="settings-view-grid">
+				<section class="settings-group settings-group-full">
+					<div class="settings-section">
+						<div class="settings-section-title">Desktop updates</div>
+						${this.desktopLoading
+							? html`<div class="settings-desc">Checking desktop release…</div>`
+							: html`
+								<div class="settings-desc">Current: <code>${this.desktopStatus?.currentVersion || "unknown"}</code> · Latest: <code>${this.desktopStatus?.latestVersion || "unknown"}</code></div>
+								${this.desktopStatus
+									? this.desktopStatus.updateAvailable
+										? html`<div class="settings-desc">A newer Pi Desktop release is available.</div>`
+										: html`<div class="settings-desc">No desktop update available right now.</div>`
+									: html`<div class="settings-desc">Desktop update status unavailable. Check your network and try again.</div>`}
+								${this.desktopStatus?.assetName ? html`<div class="settings-desc">Recommended installer: <code>${this.desktopStatus.assetName}</code></div>` : null}
+								${this.desktopStatus?.note ? html`<div class="settings-desc">${this.desktopStatus.note}</div>` : null}
+							`}
+						<div class="settings-actions">
+							<button class="ghost-btn" ?disabled=${this.desktopLoading} @click=${() => this.refreshDesktopStatus()}>Refresh desktop status</button>
+							<button class="ghost-btn" ?disabled=${this.desktopOpening || !this.desktopStatus?.updateAvailable} @click=${() => this.openDesktopUpdateNow()}>
+								${this.desktopOpening ? "Opening…" : this.desktopStatus?.assetUrl ? "Download desktop update" : "Open release page"}
+							</button>
+						</div>
+						${this.desktopActionMessage ? html`<div class="settings-desc">${this.desktopActionMessage}</div>` : null}
+					</div>
+
+					<div class="settings-section">
+						<div class="settings-section-title">CLI updates</div>
+						${this.cliLoading
+							? html`<div class="settings-desc">Checking CLI version…</div>`
+							: html`
+								<div class="settings-desc">Current: <code>${this.cliStatus?.current_version || "unknown"}</code> · Latest: <code>${this.cliStatus?.latest_version || "unknown"}</code></div>
+								${this.cliStatus
+									? this.cliStatus.update_available
+										? html`<div class="settings-desc">A newer Pi CLI is available.</div>`
+										: html`<div class="settings-desc">No update available right now.</div>`
+									: html`<div class="settings-desc">CLI status unavailable. Install or reconnect CLI, then refresh.</div>`}
+								${this.cliStatus?.note ? html`<div class="settings-desc">${this.cliStatus.note}</div>` : null}
+							`}
+						<div class="settings-actions">
+							<button class="ghost-btn" ?disabled=${this.cliLoading || !runtimeControlsEnabled} @click=${() => this.refreshCliStatus()}>Refresh CLI status</button>
+							<button
+								class="ghost-btn"
+								?disabled=${
+									this.cliUpdating ||
+									!runtimeControlsEnabled ||
+									!this.cliStatus?.can_update_in_app ||
+									!this.cliStatus?.npm_available ||
+									!this.cliStatus?.update_available
+								}
+								@click=${() => this.updateCliNow()}
+							>
+								${this.cliUpdating ? "Updating…" : "Update CLI now"}
+							</button>
+						</div>
+						${this.cliActionMessage ? html`<div class="settings-desc">${this.cliActionMessage}</div>` : null}
+						${runtimeControlsEnabled
+							? html`
+								<details class="settings-advanced">
+									<summary>Advanced CLI diagnostics</summary>
+									<div class="settings-desc">Discovery: <code>${this.cliStatus?.discovery || rpcBridge.discoveryInfo || "unknown"}</code></div>
+									${this.cliStatus?.update_command ? html`<div class="settings-desc">Manual update: <code>${this.cliStatus.update_command}</code></div>` : null}
+									<div class="settings-actions">
+										<button class="ghost-btn" ?disabled=${this.compatibilityLoading} @click=${() => this.refreshCompatibilityStatus()}>
+											${this.compatibilityLoading ? "Checking RPC…" : "Run RPC compatibility check"}
+										</button>
+									</div>
+									${this.compatibilityReport
+										? html`
+											<div class="settings-desc">
+												RPC compatibility: ${this.compatibilityReport.ok ? "OK" : "Failed"}
+												${compatibilityChecks.length > 0 ? html` (${compatibilityChecks.join(", ")})` : null}
+											</div>
+											${this.compatibilityReport.error ? html`<div class="settings-desc">${this.compatibilityReport.error}</div>` : null}
+										`
+										: null}
+								</details>
+							`
+							: html`<div class="settings-desc">Open a project to enable CLI runtime diagnostics.</div>`}
+					</div>
+				</section>
+			</div>
+		`;
+	}
+
+	private renderActiveSection(
+		section: SettingsSectionId,
+		runtimeControlsEnabled: boolean,
+		hasProjectContext: boolean,
+		authProviders: PiAuthStatus["configured_providers"],
+		compatibilityChecks: string[],
+	): TemplateResult {
+		switch (section) {
+			case "appearance":
+				return this.renderAppearanceSection();
+			case "account":
+				return this.renderAccountSection(runtimeControlsEnabled, hasProjectContext, authProviders);
+			case "updates":
+				return this.renderUpdatesSection(runtimeControlsEnabled, compatibilityChecks);
+			case "general":
+			default:
+				return this.renderGeneralSection(runtimeControlsEnabled, hasProjectContext);
+		}
+	}
+
+	private renderActiveSectionSafe(
+		section: SettingsSectionId,
+		runtimeControlsEnabled: boolean,
+		hasProjectContext: boolean,
+		authProviders: PiAuthStatus["configured_providers"],
+		compatibilityChecks: string[],
+	): TemplateResult {
+		try {
+			return this.renderActiveSection(section, runtimeControlsEnabled, hasProjectContext, authProviders, compatibilityChecks);
+		} catch (err) {
+			console.error("Settings section render failed:", err);
+			const message = err instanceof Error ? err.message : String(err);
+			return html`
+				<div class="settings-view-grid">
+					<section class="settings-group settings-group-full">
+						<div class="settings-section">
+							<div class="settings-section-title">Section error</div>
+							<div class="settings-desc">Could not render this settings section.</div>
+							<div class="settings-desc"><code>${message}</code></div>
+						</div>
+					</section>
+				</div>
+			`;
+		}
+	}
+
 	render(): void {
 		if (!this.isOpen) {
-			this.container.innerHTML = "";
 			return;
 		}
 
 		const authProviders = Array.isArray(this.authStatus?.configured_providers) ? this.authStatus.configured_providers : [];
 		const compatibilityChecks = Array.isArray(this.compatibilityReport?.checks) ? this.compatibilityReport.checks : [];
 		const hasProjectContext = Boolean(this.runtimeProjectPath);
-		const runtimeControlsEnabled = hasProjectContext && rpcBridge.isConnected;
-
-		if (!runtimeControlsEnabled) {
-			const runtimeMessage = hasProjectContext
-				? "Runtime is still starting for this project. You can change appearance now; assistant/account settings unlock when runtime is ready."
-				: "Open a project to enable assistant, account, update diagnostics, and compatibility settings.";
-			try {
-				this.renderBasicSettingsShell(runtimeMessage, { showAddProject: !hasProjectContext });
-			} catch (err) {
-				console.error("Settings no-project render failed:", err);
-				this.container.innerHTML = "<div class=\"settings-view-root\"><div class=\"settings-view-body\"><div class=\"settings-desc\">Unable to render settings right now.</div></div></div>";
-			}
-			return;
-		}
+		const runtimeControlsEnabled = this.isRuntimeControlsEnabled();
+		const navigation = this.getNavigationState();
+		const activeSection = navigation.activeSection;
+		const activeItem = navigation.items.find((item) => item.id === activeSection) ?? navigation.items[0];
+		this.emitNavigationState(runtimeControlsEnabled);
 
 		try {
 			const template = html`
-			<div class="settings-view-root">
-				<div class="settings-view-header">
-					<div class="settings-view-title-wrap">
-						<div class="settings-view-title">Settings</div>
-						<div class="settings-view-meta">Desktop configuration and runtime preferences.</div>
+				<div class="settings-view-root">
+					<div class="settings-view-header">
+						<div class="settings-view-title-wrap">
+							<div class="settings-view-title">${activeItem?.label ?? "Settings"}</div>
+						</div>
+						<div class="settings-view-header-actions">
+							<button class="settings-back-btn" @click=${() => this.close()}>← Back</button>
+						</div>
 					</div>
-					<div class="settings-view-header-actions">
-						<button class="settings-back-btn" @click=${() => this.close()}>← Back</button>
-					</div>
-				</div>
 
-				<div class="settings-view-body">
-					<div class="settings-view-grid">
-						<section class="settings-group settings-group-full">
-							<div class="settings-section">
-								<div class="settings-section-title">Appearance</div>
-								<div class="appearance-theme-block">
-									<div class="appearance-theme-header-row">
-										<div>
-											<div class="settings-label">Theme</div>
-											<div class="settings-desc">Use light, dark, or match your system.</div>
-										</div>
-										<div class="theme-grid">
-											<button class="theme-btn ${this.state.theme === "light" ? "active" : ""}" @click=${() => this.setTheme("light")}>Light</button>
-											<button class="theme-btn ${this.state.theme === "dark" ? "active" : ""}" @click=${() => this.setTheme("dark")}>Dark</button>
-											<button class="theme-btn ${this.state.theme === "system" ? "active" : ""}" @click=${() => this.setTheme("system")}>System</button>
-										</div>
-									</div>
-									${this.themeCatalogLoading ? html`<div class="settings-desc">Loading available Pi themes…</div>` : nothing}
-									${this.themeCatalogError ? html`<div class="settings-desc">Theme catalog error: ${this.themeCatalogError}</div>` : nothing}
-									${this.themeCatalogMessage ? html`<div class="settings-desc">${this.themeCatalogMessage}</div>` : nothing}
-									${this.renderThemeProfileCard("light")}
-									${this.renderThemeProfileCard("dark")}
-								</div>
-							</div>
-						</section>
-
-						${runtimeControlsEnabled
-							? html`
-								<section class="settings-group">
-									<div class="settings-section">
-										<div class="settings-section-title">Assistant</div>
-										${this.renderToggle(
-											"Auto-compaction",
-											"Summarize older context automatically when conversations get long.",
-											this.state.autoCompactionEnabled,
-											(v) => this.setAutoCompaction(v),
-										)}
-										${this.renderToggle(
-											"Auto-retry",
-											"Retry temporary provider errors automatically.",
-											this.state.autoRetryEnabled,
-											(v) => this.setAutoRetry(v),
-										)}
-									</div>
-									<div class="settings-section">
-										<div class="settings-section-title">Message queue</div>
-										<div class="settings-row">
-											<div>
-												<div class="settings-label">Steering messages</div>
-												<div class="settings-desc">How queued steering messages are sent while a response is streaming.</div>
-											</div>
-											<select class="settings-select" .value=${this.state.steeringMode} @change=${(e: Event) => this.setSteeringMode((e.target as HTMLSelectElement).value as QueueMode)}>
-												<option value="one-at-a-time">One at a time</option>
-												<option value="all">All queued</option>
-											</select>
-										</div>
-										<div class="settings-row">
-											<div>
-												<div class="settings-label">Follow-up messages</div>
-												<div class="settings-desc">How queued follow-up prompts are sent after each run.</div>
-											</div>
-											<select class="settings-select" .value=${this.state.followUpMode} @change=${(e: Event) => this.setFollowUpMode((e.target as HTMLSelectElement).value as QueueMode)}>
-												<option value="one-at-a-time">One at a time</option>
-												<option value="all">All queued</option>
-											</select>
-										</div>
-									</div>
-								</section>
-
-								<section class="settings-group">
-									<div class="settings-section">
-										<div class="settings-section-title">Account</div>
-										${this.authLoading
-											? html`<div class="settings-desc">Checking account status…</div>`
-											: html`
-												<div class="settings-desc">
-													${authProviders.length > 0
-														? `Connected providers: ${authProviders.length}`
-														: "No provider connected yet."}
-												</div>
-												<div class="settings-actions">
-													<button class="ghost-btn" @click=${() => this.refreshAuthStatus()}>Refresh account status</button>
-												</div>
-												${authProviders.length > 0
-													? html`
-														<div class="account-chips">
-															${authProviders.map((p) => html`<span class="account-chip">${p.provider} · ${p.source === "environment" ? "env" : p.kind}</span>`)}
-														</div>
-													`
-													: null}
-												<div class="settings-desc">Tip: run <code>/login</code> in terminal once, then restart desktop.</div>
-												${this.authStatus?.auth_file
-													? html`
-														<details class="settings-advanced">
-															<summary>Advanced account details</summary>
-															<div class="settings-desc">Auth file: <code>${this.authStatus.auth_file}</code></div>
-														</details>
-													`
-													: null}
-											`}
-									</div>
-									<div class="settings-section">
-										<div class="settings-section-title">Package configuration</div>
-										<div class="settings-desc">Package-specific settings are managed in <strong>Packages</strong> (gear icon on installed packages).</div>
-										<div class="settings-desc">Desktop stays capability-driven: packages can expose config commands, and those run via the normal chat/runtime flow.</div>
-									</div>
-								</section>
-							`
-							: html`
-								<section class="settings-group">
-									<div class="settings-section">
-										<div class="settings-section-title">Runtime</div>
-										<div class="settings-desc">Open a project to enable assistant runtime, account, and compatibility settings.</div>
-									</div>
-								</section>
-							`}
-
-						<section class="settings-group settings-group-full">
-							<div class="settings-section">
-								<div class="settings-section-title">Desktop updates</div>
-								${this.desktopLoading
-									? html`<div class="settings-desc">Checking desktop release…</div>`
-									: html`
-										<div class="settings-desc">Current: <code>${this.desktopStatus?.currentVersion || "unknown"}</code> · Latest: <code>${this.desktopStatus?.latestVersion || "unknown"}</code></div>
-										${this.desktopStatus
-											? this.desktopStatus.updateAvailable
-												? html`<div class="settings-desc">A newer Pi Desktop release is available.</div>`
-												: html`<div class="settings-desc">No desktop update available right now.</div>`
-											: html`<div class="settings-desc">Desktop update status unavailable. Check your network and try again.</div>`}
-										${this.desktopStatus?.assetName ? html`<div class="settings-desc">Recommended installer: <code>${this.desktopStatus.assetName}</code></div>` : null}
-										${this.desktopStatus?.note ? html`<div class="settings-desc">${this.desktopStatus.note}</div>` : null}
-									`}
-								<div class="settings-actions">
-									<button class="ghost-btn" ?disabled=${this.desktopLoading} @click=${() => this.refreshDesktopStatus()}>Refresh desktop status</button>
-									<button class="ghost-btn" ?disabled=${this.desktopOpening || !this.desktopStatus?.updateAvailable} @click=${() => this.openDesktopUpdateNow()}>
-										${this.desktopOpening ? "Opening…" : this.desktopStatus?.assetUrl ? "Download desktop update" : "Open release page"}
-									</button>
-								</div>
-								${this.desktopActionMessage ? html`<div class="settings-desc">${this.desktopActionMessage}</div>` : null}
-							</div>
-
-							<div class="settings-section">
-								<div class="settings-section-title">CLI updates</div>
-								${this.cliLoading
-									? html`<div class="settings-desc">Checking CLI version…</div>`
-									: html`
-										<div class="settings-desc">Current: <code>${this.cliStatus?.current_version || "unknown"}</code> · Latest: <code>${this.cliStatus?.latest_version || "unknown"}</code></div>
-										${this.cliStatus
-											? this.cliStatus.update_available
-												? html`<div class="settings-desc">A newer Pi CLI is available.</div>`
-												: html`<div class="settings-desc">No update available right now.</div>`
-											: html`<div class="settings-desc">CLI status unavailable. Install or reconnect CLI, then refresh.</div>`}
-										${this.cliStatus?.note ? html`<div class="settings-desc">${this.cliStatus.note}</div>` : null}
-									`}
-								<div class="settings-actions">
-									<button class="ghost-btn" ?disabled=${this.cliLoading} @click=${() => this.refreshCliStatus()}>Refresh CLI status</button>
-									<button
-										class="ghost-btn"
-										?disabled=${
-											this.cliUpdating ||
-											!this.cliStatus?.can_update_in_app ||
-											!this.cliStatus?.npm_available ||
-											!this.cliStatus?.update_available
-										}
-										@click=${() => this.updateCliNow()}
-									>
-										${this.cliUpdating ? "Updating…" : "Update CLI now"}
-									</button>
-								</div>
-								${this.cliActionMessage ? html`<div class="settings-desc">${this.cliActionMessage}</div>` : null}
-								${runtimeControlsEnabled
-									? html`
-										<details class="settings-advanced">
-											<summary>Advanced CLI diagnostics</summary>
-											<div class="settings-desc">Discovery: <code>${this.cliStatus?.discovery || rpcBridge.discoveryInfo || "unknown"}</code></div>
-											${this.cliStatus?.update_command ? html`<div class="settings-desc">Manual update: <code>${this.cliStatus.update_command}</code></div>` : null}
-											<div class="settings-actions">
-												<button class="ghost-btn" ?disabled=${this.compatibilityLoading} @click=${() => this.refreshCompatibilityStatus()}>
-													${this.compatibilityLoading ? "Checking RPC…" : "Run RPC compatibility check"}
-												</button>
-											</div>
-											${this.compatibilityReport
-												? html`
-													<div class="settings-desc">
-														RPC compatibility: ${this.compatibilityReport.ok ? "OK" : "Failed"}
-														${compatibilityChecks.length > 0 ? html` (${compatibilityChecks.join(", ")})` : null}
-													</div>
-													${this.compatibilityReport.error ? html`<div class="settings-desc">${this.compatibilityReport.error}</div>` : null}
-												`
-												: null}
-										</details>
-									`
-									: html`<div class="settings-desc">Runtime diagnostics become available after opening a project.</div>`}
+					<div class="settings-view-body settings-view-body-flat">
+						<section class="settings-main" aria-live="polite">
+							<div class="settings-main-content settings-main-content-flat">
+								${this.renderActiveSectionSafe(activeSection, runtimeControlsEnabled, hasProjectContext, authProviders, compatibilityChecks)}
 							</div>
 						</section>
 					</div>
+					${this.renderCreateThemeDialog()}
 				</div>
-				${this.renderCreateThemeDialog()}
-			</div>
-		`;
+			`;
 
 			render(template, this.container);
 		} catch (err) {
@@ -1470,12 +2120,15 @@ export class SettingsPanel {
 					{ showAddProject: false, warning: "Open another session or reopen settings once runtime stabilizes." },
 				);
 			} catch {
-				this.container.innerHTML = "<div class=\"settings-view-root\"><div class=\"settings-view-body\"><div class=\"settings-desc\">Unable to render settings right now.</div></div></div>";
+				render(
+					html`<div class="settings-view-root"><div class="settings-view-body"><div class="settings-desc">Unable to render settings right now.</div></div></div>`,
+					this.container,
+				);
 			}
 		}
 	}
 
 	destroy(): void {
-		this.container.innerHTML = "";
+		render(nothing, this.container);
 	}
 }

--- a/src/components/sidebar.ts
+++ b/src/components/sidebar.ts
@@ -16,6 +16,13 @@ export interface SidebarWorkspaceItem {
 	closable?: boolean;
 }
 
+export interface SidebarSettingsNavItem {
+	id: string;
+	label: string;
+	description?: string;
+	disabled?: boolean;
+}
+
 interface SidebarSession {
 	id: string;
 	name: string;
@@ -228,6 +235,9 @@ export class Sidebar {
 	private projectDragStartY = 0;
 	private projectDragSuppressClickUntil = 0;
 	private mode: SidebarMode = "projects";
+	private settingsShellActive = false;
+	private settingsNavItems: SidebarSettingsNavItem[] = [];
+	private activeSettingsNavId: string | null = null;
 	private query = "";
 	private collapsed = false;
 	private storageKey = workspaceStorageKey("workspace_default");
@@ -276,6 +286,7 @@ export class Sidebar {
 	private onFileOpen: ((projectId: string, filePath: string) => void) | null = null;
 	private onFileDelete: ((projectId: string, filePath: string) => void) | null = null;
 	private onModeChange: ((mode: SidebarMode) => void) | null = null;
+	private onSettingsNavSelect: ((id: string) => void) | null = null;
 	private onCollapsedChange: ((collapsed: boolean) => void) | null = null;
 
 	constructor(container: HTMLElement) {
@@ -516,6 +527,30 @@ export class Sidebar {
 		this.onModeChange = cb;
 	}
 
+	setOnSettingsNavSelect(cb: ((id: string) => void) | null): void {
+		this.onSettingsNavSelect = cb;
+	}
+
+	setSettingsShellActive(active: boolean): void {
+		if (this.settingsShellActive === active) return;
+		this.settingsShellActive = active;
+		this.modeFilterMenuOpen = false;
+		this.openProjectMenuId = null;
+		this.closeContextMenu(false);
+		this.render();
+	}
+
+	setSettingsNavigation(items: SidebarSettingsNavItem[], activeId: string | null): void {
+		this.settingsNavItems = items.map((item) => ({
+			id: item.id,
+			label: item.label,
+			description: item.description,
+			disabled: Boolean(item.disabled),
+		}));
+		this.activeSettingsNavId = activeId;
+		if (this.settingsShellActive) this.render();
+	}
+
 	setOnCollapsedChange(cb: (collapsed: boolean) => void): void {
 		this.onCollapsedChange = cb;
 	}
@@ -677,6 +712,16 @@ export class Sidebar {
 		if (this.activeSessionPath === normalized) return;
 		this.activeSessionPath = normalized;
 		this.render();
+	}
+
+	beginSessionRename(projectId: string, sessionPath: string): boolean {
+		const found = this.findSession(projectId, sessionPath);
+		if (!found) return false;
+		this.selectProject(found.project.id, false);
+		this.activeSessionPath = normalizePath(found.session.path);
+		this.activeFilePath = null;
+		this.startSessionRename(found.project, found.session);
+		return true;
 	}
 
 	setActiveFilePath(filePath: string | null): void {
@@ -3728,7 +3773,35 @@ export class Sidebar {
 		`;
 	}
 
+	private renderSettingsShellBody(): TemplateResult {
+		if (this.settingsNavItems.length === 0) {
+			return html`<div class="sidebar-empty">Loading settings sections…</div>`;
+		}
+
+		return html`
+			<div class="sidebar-settings-nav-list">
+				${this.settingsNavItems.map((item) => {
+					const active = item.id === this.activeSettingsNavId;
+					return html`
+						<button
+							class="sidebar-settings-nav-item ${active ? "active" : ""}"
+							?disabled=${Boolean(item.disabled)}
+							@click=${() => {
+								if (item.disabled) return;
+								this.onSettingsNavSelect?.(item.id);
+							}}
+						>
+							<span class="sidebar-settings-nav-label">${item.label}</span>
+							${item.description ? html`<span class="sidebar-settings-nav-desc">${item.description}</span>` : nothing}
+						</button>
+					`;
+				})}
+			</div>
+		`;
+	}
+
 	private renderModeBody(): TemplateResult {
+		if (this.settingsShellActive) return this.renderSettingsShellBody();
 		if (this.mode === "files") return this.renderFilesMode();
 		return this.renderProjectsMode();
 	}
@@ -3865,67 +3938,80 @@ export class Sidebar {
 				${this.renderWorkspaceWindowRow()}
 
 				<div class="sidebar-topbar" data-tauri-drag-region>
-					${this.renderWorkspaceHeader()}
-					${this.desktopUpdateAvailable
+					${this.settingsShellActive ? nothing : this.renderWorkspaceHeader()}
+					${this.settingsShellActive
 						? html`
-							<button class="sidebar-cli-update-banner sidebar-desktop-update-banner" @click=${() => this.onOpenSettings?.()}>
-								<span>
-									Desktop update available${this.desktopUpdateLatestVersion ? ` · v${this.desktopUpdateLatestVersion}` : ""}
-								</span>
-								<span class="sidebar-cli-update-cta">Open settings</span>
-							</button>
+							<div class="sidebar-settings-shell-header">
+								<div class="sidebar-mode-current">Settings</div>
+								<div class="sidebar-settings-shell-subtitle">Choose a section</div>
+							</div>
 						`
-						: nothing}
-					${this.cliUpdateAvailable
-						? html`
-							<button class="sidebar-cli-update-banner" @click=${() => this.onOpenSettings?.()}>
-								<span>
-									CLI update available${this.cliUpdateLatestVersion ? ` · v${this.cliUpdateLatestVersion}` : ""}
-								</span>
-								<span class="sidebar-cli-update-cta">Open settings</span>
-							</button>
-						`
-						: nothing}
-					<div class="sidebar-top-actions sidebar-top-actions-primary">
-						<button
-							class="sidebar-top-action-btn"
-							title=${this.mode === "files" ? "New file" : "New session"}
-							?disabled=${!hasActiveProject}
-							@click=${() => void this.triggerPrimaryTopAction()}
-						>
-							<span>${this.mode === "files" ? "New file" : "New session"}</span>
-						</button>
-						<button class="sidebar-top-action-btn ${this.packagesOpen ? "active" : ""}" title="Packages" @click=${() => this.onTogglePackages?.()}>
-							<span>Packages</span>
-						</button>
-					</div>
+						: html`
+							${this.desktopUpdateAvailable
+								? html`
+									<button class="sidebar-cli-update-banner sidebar-desktop-update-banner" @click=${() => this.onOpenSettings?.()}>
+										<span>
+											Desktop update available${this.desktopUpdateLatestVersion ? ` · v${this.desktopUpdateLatestVersion}` : ""}
+										</span>
+										<span class="sidebar-cli-update-cta">Open settings</span>
+									</button>
+								`
+								: nothing}
+							${this.cliUpdateAvailable
+								? html`
+									<button class="sidebar-cli-update-banner" @click=${() => this.onOpenSettings?.()}>
+										<span>
+											CLI update available${this.cliUpdateLatestVersion ? ` · v${this.cliUpdateLatestVersion}` : ""}
+										</span>
+										<span class="sidebar-cli-update-cta">Open settings</span>
+									</button>
+								`
+								: nothing}
+							<div class="sidebar-top-actions sidebar-top-actions-primary">
+								<button
+									class="sidebar-top-action-btn"
+									title=${this.mode === "files" ? "New file" : "New session"}
+									?disabled=${!hasActiveProject}
+									@click=${() => void this.triggerPrimaryTopAction()}
+								>
+									<span>${this.mode === "files" ? "New file" : "New session"}</span>
+								</button>
+								<button class="sidebar-top-action-btn ${this.packagesOpen ? "active" : ""}" title="Packages" @click=${() => this.onTogglePackages?.()}>
+									<span>Packages</span>
+								</button>
+							</div>
+						`}
 				</div>
 
 				<div class="sidebar-section-divider" aria-hidden="true"></div>
 
-				<div class="sidebar-mode-row">
-					<div class="sidebar-mode-meta">
-						<div class="sidebar-mode-current">${this.mode === "projects" ? "Sessions" : "Files"}</div>
-						<div class="sidebar-mode-switch">
-							${this.renderModeSwitch()}
+				${this.settingsShellActive
+					? nothing
+					: html`
+						<div class="sidebar-mode-row">
+							<div class="sidebar-mode-meta">
+								<div class="sidebar-mode-current">${this.mode === "projects" ? "Sessions" : "Files"}</div>
+								<div class="sidebar-mode-switch">
+									${this.renderModeSwitch()}
+								</div>
+							</div>
+							<div class="sidebar-mode-actions">
+								<button class="sidebar-mode-create-btn" title="Add project" @click=${() => void this.handleModeCreateAction()}>
+									<svg class="sidebar-icon-svg" viewBox="0 0 16 16" aria-hidden="true">
+										<path d="M2.5 4.5h4l1.3 1.5h5.7v5a1 1 0 0 1-1 1h-10a1 1 0 0 1-1-1v-5a1 1 0 0 1 1-1z" />
+										<path d="M8 7.2v3.6" />
+										<path d="M6.2 9h3.6" />
+									</svg>
+								</button>
+								<button class="sidebar-mode-filter-btn" title=${this.mode === "projects" ? "Organize sessions" : "Filter files"} @click=${() => this.toggleModeFilterMenu()}>
+									<svg class="sidebar-icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M3 4h10"/><path d="M5 8h6"/><path d="M7 12h2"/></svg>
+								</button>
+								${this.renderModeFilterMenu()}
+							</div>
 						</div>
-					</div>
-					<div class="sidebar-mode-actions">
-						<button class="sidebar-mode-create-btn" title="Add project" @click=${() => void this.handleModeCreateAction()}>
-							<svg class="sidebar-icon-svg" viewBox="0 0 16 16" aria-hidden="true">
-								<path d="M2.5 4.5h4l1.3 1.5h5.7v5a1 1 0 0 1-1 1h-10a1 1 0 0 1-1-1v-5a1 1 0 0 1 1-1z" />
-								<path d="M8 7.2v3.6" />
-								<path d="M6.2 9h3.6" />
-							</svg>
-						</button>
-						<button class="sidebar-mode-filter-btn" title=${this.mode === "projects" ? "Organize sessions" : "Filter files"} @click=${() => this.toggleModeFilterMenu()}>
-							<svg class="sidebar-icon-svg" viewBox="0 0 16 16" aria-hidden="true"><path d="M3 4h10"/><path d="M5 8h6"/><path d="M7 12h2"/></svg>
-						</button>
-						${this.renderModeFilterMenu()}
-					</div>
-				</div>
+					`}
 
-				<div class="sidebar-panel-body">
+				<div class="sidebar-panel-body ${this.settingsShellActive ? "sidebar-panel-body-settings" : ""}">
 					${this.renderModeBody()}
 				</div>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import { ExtensionUiHandler, normalizeExtensionUiRequest, type NotificationActio
 import { FileViewer } from "./components/file-viewer.js";
 import { PackagesView } from "./components/packages-view.js";
 import { SessionBrowser } from "./components/session-browser.js";
-import { SettingsPanel } from "./components/settings-panel.js";
+import { SettingsPanel, type SettingsSectionId } from "./components/settings-panel.js";
 import { ShortcutsPanel } from "./components/shortcuts-panel.js";
 import { Sidebar, type SidebarMode, type SidebarWorkspaceItem } from "./components/sidebar.js";
 import { TerminalPanel } from "./components/terminal-panel.js";
@@ -1153,6 +1153,120 @@ async function withRpcRetry<T>(label: string, run: () => Promise<T>, attempts = 
 	throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
+async function renameSessionFromWorkspace(projectId: string, sessionPath: string, nextName: string): Promise<boolean> {
+	const workspace = getActiveWorkspace();
+	const project = sidebar?.getProjectById(projectId);
+	const trimmedName = nextName.trim();
+	if (!workspace || !project || !trimmedName) return false;
+
+	ensureWorkspaceContentState(workspace);
+	const targetTab = workspace.sessionTabs.find((tab) => normalizeSessionPath(tab.sessionPath) === normalizeSessionPath(sessionPath));
+	if (targetTab) {
+		setSessionTabProject(targetTab, project.id, project.path);
+		targetTab.title = trimmedName;
+		if (workspace.activeSessionTabId === targetTab.id) {
+			workspace.sessionTitle = trimmedName;
+		}
+		persistWorkspaces();
+		syncContentTabsBar(workspace);
+	}
+
+	let failed = false;
+	await queueProjectTask(
+		async () => {
+			const normalizedTarget = normalizeSessionPath(sessionPath);
+			const openTargetTab = workspace.sessionTabs.find((tab) => normalizeSessionPath(tab.sessionPath) === normalizedTarget) ?? null;
+			const activeTarget = Boolean(openTargetTab && workspace.activeSessionTabId === openTargetTab.id);
+
+			if (openTargetTab) {
+				const targetRuntime = await ensureRuntimeForSessionTab(workspace, openTargetTab, project.path, activeTarget);
+				await targetRuntime.bridge.setSessionName(trimmedName);
+				if (activeTarget) {
+					await chatView?.refreshFromBackend({ throwOnError: true });
+				}
+			} else {
+				const maintenanceBridge = new RpcBridge(uid("rename_rpc"));
+				try {
+					await maintenanceBridge.start({ cliPath: findCliPath(), cwd: project.path });
+					const switched = await maintenanceBridge.switchSession(sessionPath);
+					if (switched.cancelled) return;
+					await maintenanceBridge.setSessionName(trimmedName);
+				} finally {
+					await maintenanceBridge.stop().catch(() => {
+						/* ignore */
+					});
+					await maintenanceBridge.teardownListeners().catch(() => {
+						/* ignore */
+					});
+				}
+			}
+
+			scheduleSidebarSessionsRefresh(0);
+			syncContentTabsBar(workspace);
+			await applyWorkspacePane(workspace);
+		},
+		(err) => {
+			failed = true;
+			console.error("Failed to rename session:", err);
+			chatView?.notify("Failed to rename session", "error");
+		},
+		{ label: "sidebar-session-rename" },
+	);
+
+	return !failed;
+}
+
+async function reloadActiveWorkspaceRuntime(): Promise<boolean> {
+	const workspace = getActiveWorkspace();
+	if (!workspace) return false;
+
+	ensureWorkspaceContentState(workspace);
+	const activeSession = getActiveSessionTab(workspace);
+	if (!activeSession) return false;
+	const projectPath = getSessionTabProjectPath(activeSession) ?? getWorkspaceActiveProjectPath(workspace);
+	if (!projectPath) return false;
+
+	syncActiveChatRuntimeBinding(workspace, { forceReset: true, statusText: "Reloading runtime…" });
+
+	let failed = false;
+	await queueProjectTask(
+		async (version) => {
+			assertProjectTaskCurrent(version);
+			const runtime = getRuntimeForTab(workspace.id, activeSession.id);
+			if (runtime?.bridge.isConnected) {
+				runtime.phase = "starting";
+				await runtime.bridge.stop().catch(() => {
+					/* ignore */
+				});
+				runtime.draftInitialized = false;
+				runtime.lastKnownSessionPath = null;
+				setRuntimeRunning(runtime, false, { suppressNotify: true });
+			}
+
+			assertProjectTaskCurrent(version);
+			await ensureRuntimeForSessionTab(workspace, activeSession, projectPath, true, version);
+			assertProjectTaskCurrent(version);
+			await chatView?.refreshFromBackend({ throwOnError: true });
+			assertProjectTaskCurrent(version);
+			await chatView?.refreshModels();
+			await packagesView?.refreshPackages(true).catch(() => {
+				/* ignore package refresh errors during reload */
+			});
+			scheduleSidebarSessionsRefresh(0);
+			syncContentTabsBar(workspace);
+			await applyWorkspacePane(workspace);
+		},
+		(err) => {
+			failed = true;
+			console.error("Failed to reload runtime:", err);
+			chatView?.notify("Failed to reload runtime", "error");
+		},
+		{ label: "slash-reload-runtime" },
+	);
+
+	return !failed;
+}
+
 function scheduleSidebarSessionsRefresh(delayMs = 180): void {
 	if (sidebarSessionsRefreshTimer) {
 		clearTimeout(sidebarSessionsRefreshTimer);
@@ -1532,10 +1646,31 @@ function syncWorkspaceTabsBar(): void {
 	sidebar?.setWorkspaces(workspaceItems, activeWorkspaceId);
 }
 
+function syncSidebarSettingsNavigation(): void {
+	if (!sidebar) return;
+	if (!settingsPanel) {
+		sidebar.setSettingsNavigation([], null);
+		return;
+	}
+	const navigation = settingsPanel.getNavigationState();
+	sidebar.setSettingsNavigation(
+		navigation.items.map((item) => ({
+			id: item.id,
+			label: item.label,
+			description: item.description,
+			disabled: item.disabled,
+		})),
+		navigation.activeSection,
+	);
+}
+
 function syncWorkspaceContextChrome(workspace: WorkspaceState | null = getActiveWorkspace()): void {
 	const packagesOpen = workspace?.pane === "packages";
+	const settingsOpen = workspace?.pane === "settings";
 	workspaceTabsBar?.setPackagesToolbarVisible(packagesOpen);
 	sidebar?.setPackagesOpen(packagesOpen);
+	sidebar?.setSettingsShellActive(Boolean(settingsOpen));
+	if (settingsOpen) syncSidebarSettingsNavigation();
 }
 
 function syncCliUpdateUiHint(): void {
@@ -2368,8 +2503,8 @@ async function initialize(): Promise<void> {
 		chatView.setOnAddProject(() => {
 			void sidebar?.openFolder();
 		});
-		chatView.setOnOpenSettings(() => {
-			requestOpenSettingsPanel();
+		chatView.setOnOpenSettings((sectionId) => {
+			requestOpenSettingsPanel(sectionId);
 		});
 		chatView.setOnOpenPackages(() => {
 			const workspace = getActiveWorkspace();
@@ -2378,6 +2513,79 @@ async function initialize(): Promise<void> {
 			persistWorkspaces();
 			syncWorkspaceTabsBar();
 			void applyWorkspacePane(workspace);
+		});
+		chatView.setOnOpenExtensionConfig(async (commandName) => {
+			if (commandName !== "name-ai-config") return false;
+			openPackagesPane();
+			return await (packagesView?.openExtensionConfigBySource("npm:pi-session-auto-rename") ?? false);
+		});
+		chatView.setOnBeginRenameCurrentSession(() => {
+			const workspace = getActiveWorkspace();
+			if (!workspace) return false;
+			const activeSession = getActiveSessionTab(workspace);
+			const projectId = getSessionTabProjectId(activeSession) ?? getWorkspaceActiveProjectId(workspace);
+			const sessionPath = normalizeSessionPath(chatView?.getState()?.sessionFile ?? activeSession.sessionPath ?? "");
+			if (!projectId || !sessionPath) return false;
+			return sidebar?.beginSessionRename(projectId, sessionPath) ?? false;
+		});
+		chatView.setOnRenameCurrentSession(async (nextName) => {
+			const workspace = getActiveWorkspace();
+			if (!workspace) return false;
+			const activeSession = getActiveSessionTab(workspace);
+			const projectId = getSessionTabProjectId(activeSession) ?? getWorkspaceActiveProjectId(workspace);
+			const sessionPath = normalizeSessionPath(chatView?.getState()?.sessionFile ?? activeSession.sessionPath ?? "");
+			if (projectId && sessionPath) {
+				return await renameSessionFromWorkspace(projectId, sessionPath, nextName);
+			}
+			try {
+				await rpcBridge.setSessionName(nextName);
+				activeSession.title = nextName;
+				if (workspace.activeSessionTabId === activeSession.id) {
+					workspace.sessionTitle = nextName;
+				}
+				persistWorkspaces();
+				syncContentTabsBar(workspace);
+				await chatView?.refreshFromBackend({ throwOnError: true });
+				return true;
+			} catch (err) {
+				console.error("Failed to rename current session:", err);
+				chatView?.notify("Failed to rename session", "error");
+				return false;
+			}
+		});
+		chatView.setOnCreateFreshSession(async () => {
+			const workspace = getActiveWorkspace();
+			if (!workspace) return false;
+			if (!getWorkspaceActiveProjectPath(workspace)) {
+				chatView?.notify("Add/select a project before creating a new session", "info");
+				return false;
+			}
+			await startFreshSessionTab();
+			return true;
+		});
+		chatView.setOnReloadRuntime(async () => {
+			const workspace = getActiveWorkspace();
+			if (!workspace || !getWorkspaceActiveProjectPath(workspace)) {
+				chatView?.notify("Add/select a project before reloading runtime", "info");
+				return false;
+			}
+			return await reloadActiveWorkspaceRuntime();
+		});
+		chatView.setOnOpenSessionBrowser((query) => {
+			void sessionBrowser?.open({ query });
+		});
+		chatView.setOnOpenShortcuts(() => {
+			shortcutsPanel?.open();
+		});
+		chatView.setOnQuitApp(() => {
+			void (async () => {
+				try {
+					const { getCurrentWindow } = await import("@tauri-apps/api/window");
+					await getCurrentWindow().close();
+				} catch {
+					window.close();
+				}
+			})();
 		});
 		chatView.setOnSelectWelcomeProject((projectId) => {
 			sidebar?.setActiveProject(projectId, true);
@@ -2447,6 +2655,7 @@ function mountSettingsPanel(): SettingsPanel {
 	}
 	if (settingsPanel) {
 		settingsPanel.setContainer(settingsContainer);
+		syncSidebarSettingsNavigation();
 		return settingsPanel;
 	}
 	const panel = new SettingsPanel(settingsContainer);
@@ -2469,7 +2678,11 @@ function mountSettingsPanel(): SettingsPanel {
 	panel.setOnRequestAddProject(() => {
 		void sidebar?.openFolder();
 	});
+	panel.setOnNavigationStateChange(() => {
+		syncSidebarSettingsNavigation();
+	});
 	settingsPanel = panel;
+	syncSidebarSettingsNavigation();
 	return panel;
 }
 
@@ -2654,7 +2867,9 @@ function wireCommandPaletteBuiltins(): void {
 		{
 			name: "compact",
 			description: "Compact current session context",
-			action: async () => chatView?.compactNow(),
+			action: async () => {
+				await chatView?.compactNow();
+			},
 		},
 	]);
 }
@@ -2686,13 +2901,36 @@ async function recoverSettingsPaneIfBlank(reason: string): Promise<void> {
 	}
 }
 
-function requestOpenSettingsPanel(): void {
+function normalizeSettingsSectionId(sectionId: string | null | undefined): SettingsSectionId | null {
+	switch ((sectionId || "").trim().toLowerCase()) {
+		case "general":
+			return "general";
+		case "appearance":
+			return "appearance";
+		case "account":
+			return "account";
+		case "updates":
+			return "updates";
+		default:
+			return null;
+	}
+}
+
+function requestOpenSettingsPanel(sectionId?: string): void {
 	const workspace = getActiveWorkspace();
 	if (!workspace) return;
+	const targetSection = normalizeSettingsSectionId(sectionId);
 	workspace.pane = "settings";
 	persistWorkspaces();
 	syncWorkspaceTabsBar();
 	setPaneVisibility("settings");
+	try {
+		const panel = mountSettingsPanel();
+		panel.setRuntimeProjectPath(resolveSettingsRuntimeProjectPath(workspace));
+		if (targetSection) panel.setActiveSection(targetSection);
+	} catch (mountErr) {
+		console.error("Failed to prepare settings panel before open:", mountErr);
+	}
 	void applyWorkspacePane(workspace)
 		.catch((err) => {
 			console.error("Failed to open settings pane:", err);
@@ -2701,6 +2939,7 @@ function requestOpenSettingsPanel(): void {
 				setPaneVisibility("settings");
 				const panel = mountSettingsPanel();
 				panel.setRuntimeProjectPath(resolveSettingsRuntimeProjectPath(workspace));
+				if (targetSection) panel.setActiveSection(targetSection);
 				void panel.open();
 			} catch (innerErr) {
 				console.error("Settings pane recovery failed:", innerErr);
@@ -3335,6 +3574,12 @@ function renderApp(): void {
 		syncWorkspaceTabsBar();
 	});
 
+	sidebar.setOnSettingsNavSelect((sectionId) => {
+		if (!settingsPanel) return;
+		settingsPanel.setActiveSection(sectionId as SettingsSectionId);
+		syncSidebarSettingsNavigation();
+	});
+
 	sidebar.setOnProjectSelect((project) => {
 		const workspace = getActiveWorkspace();
 		if (!workspace) return;
@@ -3604,61 +3849,7 @@ function renderApp(): void {
 	});
 
 	sidebar.setOnSessionRename((projectId, sessionPath, _currentName, nextName) => {
-		const workspace = getActiveWorkspace();
-		const project = sidebar?.getProjectById(projectId);
-		if (!workspace || !project) return;
-
-		ensureWorkspaceContentState(workspace);
-		const targetTab = workspace.sessionTabs.find((tab) => normalizeSessionPath(tab.sessionPath) === normalizeSessionPath(sessionPath));
-		if (targetTab) {
-			setSessionTabProject(targetTab, project.id, project.path);
-			targetTab.title = nextName;
-			if (workspace.activeSessionTabId === targetTab.id) {
-				workspace.sessionTitle = nextName;
-			}
-			persistWorkspaces();
-			syncContentTabsBar(workspace);
-		}
-
-		void queueProjectTask(
-			async () => {
-				const normalizedTarget = normalizeSessionPath(sessionPath);
-				const openTargetTab =
-					workspace.sessionTabs.find((tab) => normalizeSessionPath(tab.sessionPath) === normalizedTarget) ?? null;
-				const activeTarget = Boolean(openTargetTab && workspace.activeSessionTabId === openTargetTab.id);
-
-				if (openTargetTab) {
-					const targetRuntime = await ensureRuntimeForSessionTab(workspace, openTargetTab, project.path, activeTarget);
-					await targetRuntime.bridge.setSessionName(nextName);
-					if (activeTarget) {
-						await chatView?.refreshFromBackend({ throwOnError: true });
-					}
-				} else {
-					const maintenanceBridge = new RpcBridge(uid("rename_rpc"));
-					try {
-						await maintenanceBridge.start({ cliPath: findCliPath(), cwd: project.path });
-						const switched = await maintenanceBridge.switchSession(sessionPath);
-						if (switched.cancelled) return;
-						await maintenanceBridge.setSessionName(nextName);
-					} finally {
-						await maintenanceBridge.stop().catch(() => {
-							/* ignore */
-						});
-						await maintenanceBridge.teardownListeners().catch(() => {
-							/* ignore */
-						});
-					}
-				}
-
-				scheduleSidebarSessionsRefresh(0);
-				syncContentTabsBar(workspace);
-				await applyWorkspacePane(workspace);
-			},
-			(err) => {
-				console.error("Failed to rename session:", err);
-				chatView?.notify("Failed to rename session", "error");
-			},
-		);
+		void renameSessionFromWorkspace(projectId, sessionPath, nextName);
 	});
 
 	sidebar.setOnSessionDelete((projectId, sessionPath) => {

--- a/src/rpc/bridge.ts
+++ b/src/rpc/bridge.ts
@@ -74,6 +74,11 @@ export interface CliUpdateStatus {
 	note: string | null;
 }
 
+export interface PiChangelogResult {
+	path: string;
+	content: string;
+}
+
 export interface NpmCommandResult {
 	stdout: string;
 	stderr: string;
@@ -84,6 +89,14 @@ export interface GitCommandResult {
 	stdout: string;
 	stderr: string;
 	exit_code: number;
+}
+
+export interface ShareGistResult {
+	gist_url: string;
+	gist_id: string;
+	preview_url: string;
+	stdout: string;
+	stderr: string;
 }
 
 export interface RpcCompatibilityReport {
@@ -446,6 +459,10 @@ export class RpcBridge {
 		return data.text;
 	}
 
+	async getSessionContent(sessionPath: string): Promise<string> {
+		return invoke<string>("get_session_content", { sessionPath });
+	}
+
 	async sendExtensionUiResponse(response: Record<string, unknown>): Promise<void> {
 		await invoke("rpc_ui_response", {
 			response: JSON.stringify(response),
@@ -478,12 +495,30 @@ export class RpcBridge {
 		});
 	}
 
+	async createShareGist(htmlPath: string): Promise<ShareGistResult> {
+		return invoke<ShareGistResult>("create_share_gist", {
+			options: {
+				html_path: htmlPath,
+			},
+		});
+	}
+
 	async getPiAuthStatus(): Promise<PiAuthStatus> {
 		return invoke<PiAuthStatus>("get_pi_auth_status");
 	}
 
 	async getCliUpdateStatus(): Promise<CliUpdateStatus> {
 		return invoke<CliUpdateStatus>("get_cli_update_status", {
+			options: {
+				cli_path: this.lastStartOptions?.cliPath ?? null,
+				cwd: this.lastStartOptions?.cwd ?? null,
+				env: this.lastStartOptions?.env ?? null,
+			},
+		});
+	}
+
+	async getPiChangelog(): Promise<PiChangelogResult> {
+		return invoke<PiChangelogResult>("get_pi_changelog", {
 			options: {
 				cli_path: this.lastStartOptions?.cliPath ?? null,
 				cwd: this.lastStartOptions?.cwd ?? null,
@@ -897,6 +932,10 @@ class ActiveRpcBridgeProxy {
 		return this.activeBridge.getLastAssistantText();
 	}
 
+	async getSessionContent(sessionPath: string): Promise<string> {
+		return this.activeBridge.getSessionContent(sessionPath);
+	}
+
 	async sendExtensionUiResponse(response: Record<string, unknown>): Promise<void> {
 		return this.activeBridge.sendExtensionUiResponse(response);
 	}
@@ -912,12 +951,20 @@ class ActiveRpcBridgeProxy {
 		return this.activeBridge.runGitCommand(args, options);
 	}
 
+	async createShareGist(htmlPath: string): Promise<ShareGistResult> {
+		return this.activeBridge.createShareGist(htmlPath);
+	}
+
 	async getPiAuthStatus(): Promise<PiAuthStatus> {
 		return this.activeBridge.getPiAuthStatus();
 	}
 
 	async getCliUpdateStatus(): Promise<CliUpdateStatus> {
 		return this.activeBridge.getCliUpdateStatus();
+	}
+
+	async getPiChangelog(): Promise<PiChangelogResult> {
+		return this.activeBridge.getPiChangelog();
 	}
 
 	async updateCliViaNpm(): Promise<NpmCommandResult> {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -2980,6 +2980,64 @@ body.sidebar-resizing {
 	line-height: 1.2;
 }
 
+.sidebar-settings-shell-header {
+	display: grid;
+	gap: 4px;
+	padding: 2px 0 2px 1px;
+}
+
+.sidebar-settings-shell-subtitle {
+	font-size: 11px;
+	color: var(--muted);
+	padding-left: 9px;
+}
+
+.sidebar-panel-body-settings {
+	padding-top: 10px;
+}
+
+.sidebar-settings-nav-list {
+	display: grid;
+	gap: 5px;
+	padding: 0 2px;
+}
+
+.sidebar-settings-nav-item {
+	display: grid;
+	gap: 2px;
+	text-align: left;
+	border: none;
+	background: transparent;
+	color: var(--text);
+	border-radius: 9px;
+	padding: 8px 10px;
+	cursor: pointer;
+}
+
+.sidebar-settings-nav-item:hover {
+	background: color-mix(in srgb, var(--bg-soft) 78%, transparent);
+}
+
+.sidebar-settings-nav-item.active {
+	background: color-mix(in srgb, var(--accent) 18%, var(--bg-soft));
+}
+
+.sidebar-settings-nav-item:disabled {
+	opacity: 0.45;
+	cursor: not-allowed;
+}
+
+.sidebar-settings-nav-label {
+	font-size: 12px;
+	font-weight: 600;
+}
+
+.sidebar-settings-nav-desc {
+	font-size: 10px;
+	color: var(--muted);
+	line-height: 1.35;
+}
+
 .sidebar-mode-btn {
 	width: 28px;
 	height: 28px;
@@ -4341,6 +4399,7 @@ body.sidebar-resizing {
 .user-row {
 	display: flex;
 	justify-content: flex-end;
+	width: 100%;
 }
 
 .message-shell {
@@ -4352,6 +4411,9 @@ body.sidebar-resizing {
 
 .user-message-shell {
 	align-items: flex-end;
+	margin-left: auto;
+	width: fit-content;
+	max-width: min(100%, 72ch);
 }
 
 .assistant-message-shell {
@@ -4423,7 +4485,8 @@ body.sidebar-resizing {
 }
 
 .bubble {
-	max-width: min(760px, 84%);
+	max-width: 100%;
+	width: fit-content;
 	padding: 0;
 }
 
@@ -4434,6 +4497,7 @@ body.sidebar-resizing {
 	padding: 9px 14px;
 	display: grid;
 	gap: 6px;
+	max-width: 100%;
 }
 
 :root.light .user-bubble {
@@ -4464,8 +4528,8 @@ body.sidebar-resizing {
 	font-size: 13px;
 	line-height: 1.5;
 	white-space: pre-wrap;
-	overflow-wrap: anywhere;
-	word-break: break-word;
+	overflow-wrap: break-word;
+	word-break: normal;
 }
 
 .attachment-grid {
@@ -5253,77 +5317,85 @@ body.sidebar-resizing {
 }
 
 .compaction-row {
-	margin-top: 8px;
+	margin-top: 2px;
 }
 
-.compaction-card {
-	width: min(720px, 100%);
-	border-radius: 10px;
-	background: color-mix(in srgb, var(--bg-elev) 82%, transparent);
-	border: 1px solid color-mix(in srgb, var(--border) 54%, transparent);
-	overflow: hidden;
+.compaction-inline {
+	width: min(100%, 64ch);
+	max-width: 100%;
 }
 
-.compaction-card.running {
-	border-color: color-mix(in srgb, var(--accent) 46%, var(--border));
-}
-
-.compaction-card.error {
-	border-color: color-mix(in srgb, var(--danger) 48%, var(--border));
-}
-
-.compaction-card.done {
-	border-color: color-mix(in srgb, var(--success) 38%, var(--border));
-}
-
-.compaction-header {
-	width: 100%;
-	border: none;
-	background: transparent;
-	padding: 8px 10px;
-	display: flex;
-	align-items: center;
-	gap: 8px;
-	cursor: pointer;
-	text-align: left;
-}
-
-.compaction-title {
-	font-size: 12px;
-	font-weight: 600;
-	color: color-mix(in srgb, var(--text) 84%, var(--muted));
-}
-
-.compaction-meta {
-	font-size: 11px;
-	color: var(--muted);
-	margin-left: auto;
-}
-
-.compaction-caret {
-	font-size: 11px;
-	color: color-mix(in srgb, var(--muted) 84%, var(--text));
-}
-
-.compaction-details {
-	padding: 0 10px 10px;
-	display: grid;
+.compaction-inline-toggle {
+	width: auto;
+	min-width: 0;
 	gap: 5px;
+	padding-left: 0;
+	padding-right: 0;
 }
 
-.compaction-summary {
-	font-size: 12px;
-	color: color-mix(in srgb, var(--text) 78%, var(--muted));
+.compaction-inline-toggle .tool-workflow-line-text {
+	flex: 0 0 auto;
+	overflow: visible;
+	white-space: nowrap;
 }
 
-.compaction-error {
-	font-size: 12px;
+.compaction-inline-toggle .tool-workflow-count {
+	margin-left: 2px;
+}
+
+.compaction-inline-details {
+	margin-top: 2px;
+}
+
+.compaction-inline-summary,
+.compaction-inline-line {
+	color: color-mix(in srgb, var(--text) 74%, var(--muted));
+}
+
+.compaction-inline-error {
 	color: color-mix(in srgb, var(--danger) 84%, var(--text));
 }
 
-.compaction-line {
-	font-size: 11px;
-	color: color-mix(in srgb, var(--muted) 86%, var(--text));
+.changelog-row {
+	margin-top: 2px;
+}
+
+.changelog-inline {
+	width: min(100%, 64ch);
+	max-width: 100%;
+}
+
+.changelog-inline-toggle {
+	width: auto;
+	min-width: 0;
+	gap: 5px;
+	padding-left: 0;
+	padding-right: 0;
+}
+
+.changelog-inline-toggle .tool-workflow-line-text {
+	flex: 0 0 auto;
+	overflow: visible;
+	white-space: nowrap;
+}
+
+.changelog-inline-details {
+	margin-top: 2px;
+}
+
+.changelog-inline-output {
+	max-height: 280px;
+	overflow: auto;
+}
+
+.changelog-inline-output markdown-block {
+	line-height: 1.45;
+}
+
+.changelog-inline-output markdown-block h1,
+.changelog-inline-output markdown-block h2,
+.changelog-inline-output markdown-block h3 {
+	margin-top: 0.7em;
 }
 
 .system-row {
@@ -5351,6 +5423,52 @@ body.sidebar-resizing {
 	font-size: 11px;
 	color: var(--muted);
 	white-space: pre-wrap;
+}
+
+.system-row-inline {
+	margin-top: 2px;
+	justify-content: flex-start;
+}
+
+.system-message-inline {
+	width: min(100%, 64ch);
+	padding: 0;
+	border-radius: 0;
+	background: transparent;
+	border: none;
+}
+
+.system-label-inline {
+	margin: 0 0 2px;
+	font-size: 10px;
+	letter-spacing: 0.03em;
+	text-transform: lowercase;
+	color: color-mix(in srgb, var(--muted) 90%, var(--text));
+}
+
+.system-text-inline {
+	font-size: 12px;
+	color: color-mix(in srgb, var(--text) 74%, var(--muted));
+	white-space: normal;
+}
+
+.system-text-inline markdown-block {
+	line-height: 1.45;
+}
+
+.system-text-inline markdown-block p,
+.system-text-inline markdown-block p:last-child {
+	margin: 0;
+}
+
+.system-text-inline markdown-block a {
+	color: color-mix(in srgb, var(--accent) 82%, #4f95ff);
+	text-decoration: none;
+}
+
+.system-text-inline markdown-block a:hover,
+.system-text-inline markdown-block a:focus-visible {
+	text-decoration: underline;
 }
 
 .ghost-btn,
@@ -6016,6 +6134,12 @@ body.sidebar-resizing {
 	background: color-mix(in srgb, var(--bg-soft) 72%, transparent);
 }
 
+.composer-slash-item-main {
+	display: grid;
+	gap: 2px;
+	min-width: 0;
+}
+
 .composer-slash-item-label {
 	font-weight: 560;
 }
@@ -6597,6 +6721,7 @@ body.sidebar-resizing {
 .history-list {
 	display: grid;
 	gap: 0;
+	overflow-x: hidden;
 }
 
 .history-item {
@@ -6604,14 +6729,43 @@ body.sidebar-resizing {
 	border-bottom: 1px solid var(--border);
 }
 
+.history-item-main {
+	display: flex;
+	align-items: flex-start;
+	gap: 10px;
+}
+
 .history-jump {
-	width: 100%;
+	flex: 1;
+	min-width: 0;
 	background: transparent;
 	border: none;
 	padding: 0;
 	text-align: left;
 	color: var(--text);
 	cursor: pointer;
+}
+
+.history-jump-static {
+	cursor: default;
+}
+
+.history-fork-btn {
+	height: 24px;
+	padding: 0 9px;
+	border-radius: 8px;
+	border: none;
+	background: color-mix(in srgb, var(--bg-soft) 44%, transparent);
+	color: color-mix(in srgb, var(--text) 76%, var(--muted));
+	font-size: 11px;
+	cursor: pointer;
+	flex-shrink: 0;
+}
+
+.history-fork-btn:hover,
+.history-fork-btn:focus-visible {
+	color: var(--text);
+	background: color-mix(in srgb, var(--bg-soft) 86%, var(--bg-muted));
 }
 
 .history-jump:hover .history-preview {
@@ -6655,6 +6809,77 @@ body.sidebar-resizing {
 	font-size: 12px;
 	line-height: 1.45;
 	color: var(--text);
+}
+
+.history-tree-line-row {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 10px;
+	padding: 9px 10px;
+	min-height: 34px;
+	border-bottom: 1px solid var(--border);
+	overflow: hidden;
+	font-family:
+		ui-monospace,
+		SFMono-Regular,
+		SF Mono,
+		Menlo,
+		Consolas,
+		Liberation Mono,
+		monospace;
+	font-size: 12px;
+	line-height: 1.5;
+}
+
+.history-tree-line-row.on-path {
+	background: color-mix(in srgb, var(--bg-soft) 34%, transparent);
+}
+
+.history-tree-line {
+	all: unset;
+	display: block;
+	width: 100%;
+	min-width: 0;
+	overflow: hidden;
+	cursor: pointer;
+	color: var(--text);
+}
+
+.history-tree-line.static {
+	cursor: default;
+}
+
+.history-tree-line-mono {
+	display: block;
+	white-space: pre;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.history-tree-line-mono.role-user {
+	color: color-mix(in srgb, var(--accent) 76%, var(--text));
+}
+
+.history-tree-line-mono.role-assistant {
+	color: color-mix(in srgb, var(--success) 74%, var(--text));
+}
+
+.history-tree-line-mono.role-system,
+.history-tree-line-mono.role-custom {
+	color: color-mix(in srgb, var(--muted) 88%, var(--text));
+}
+
+.history-tree-line-actions {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	flex-shrink: 0;
+}
+
+.history-tree-index {
+	font-size: 10px;
+	color: var(--muted-2);
 }
 
 .fork-history-list {
@@ -7011,6 +7236,116 @@ body.sidebar-resizing {
 	margin: 0 auto;
 }
 
+.settings-view-body-flat {
+	width: min(980px, 100%);
+}
+
+.settings-layout {
+	display: grid;
+	grid-template-columns: minmax(220px, 260px) minmax(0, 1fr);
+	gap: 16px;
+	min-height: 0;
+	align-items: start;
+}
+
+.settings-nav {
+	display: grid;
+	gap: 8px;
+	padding: 10px;
+	border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+	border-radius: 14px;
+	background: color-mix(in srgb, var(--bg-elev) 94%, transparent);
+	position: sticky;
+	top: 0;
+}
+
+.settings-nav-item {
+	display: grid;
+	gap: 3px;
+	text-align: left;
+	padding: 10px 11px;
+	border-radius: 10px;
+	border: 1px solid transparent;
+	background: transparent;
+	color: var(--text);
+	cursor: pointer;
+}
+
+.settings-nav-item:hover {
+	background: color-mix(in srgb, var(--bg-soft) 85%, transparent);
+}
+
+.settings-nav-item.active {
+	border-color: color-mix(in srgb, var(--accent) 48%, var(--border));
+	background: color-mix(in srgb, var(--accent-soft) 72%, transparent);
+}
+
+.settings-nav-item:disabled {
+	opacity: 0.52;
+	cursor: not-allowed;
+}
+
+.settings-nav-item-label {
+	font-size: 12px;
+	font-weight: 620;
+}
+
+.settings-nav-item-desc {
+	font-size: 11px;
+	color: var(--muted);
+	line-height: 1.35;
+}
+
+.settings-main {
+	min-width: 0;
+	display: grid;
+	gap: 12px;
+}
+
+.settings-main-header {
+	display: grid;
+	gap: 4px;
+}
+
+.settings-main-title {
+	font-size: 15px;
+	font-weight: 620;
+}
+
+.settings-main-meta {
+	font-size: 11px;
+	color: var(--muted);
+}
+
+.settings-main-content {
+	min-width: 0;
+}
+
+.settings-main-content-flat .settings-view-grid {
+	grid-template-columns: 1fr;
+	gap: 0;
+}
+
+.settings-main-content-flat .settings-group {
+	border: none;
+	border-radius: 0;
+	background: transparent;
+	overflow: visible;
+}
+
+.settings-main-content-flat .settings-group + .settings-group {
+	margin-top: 4px;
+}
+
+.settings-main-content-flat .settings-group-full {
+	grid-column: auto;
+}
+
+.settings-main-content-flat .settings-section {
+	padding: 12px 0;
+	border-bottom: 1px solid color-mix(in srgb, var(--border) 84%, transparent);
+}
+
 .settings-view-grid {
 	display: grid;
 	grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -7293,6 +7628,24 @@ body.sidebar-resizing {
 }
 
 @media (max-width: 920px) {
+	.settings-layout {
+		grid-template-columns: 1fr;
+		gap: 12px;
+	}
+
+	.settings-nav {
+		position: static;
+		display: flex;
+		overflow-x: auto;
+		padding: 8px;
+		gap: 8px;
+	}
+
+	.settings-nav-item {
+		min-width: 180px;
+		flex: 0 0 auto;
+	}
+
 	.settings-view-grid {
 		grid-template-columns: 1fr;
 	}
@@ -7410,6 +7763,81 @@ body.sidebar-resizing {
 	border: 1px solid var(--border);
 	background: var(--bg-soft);
 	color: var(--text);
+}
+
+.scoped-models-toolbar-row {
+	align-items: center;
+	gap: 12px;
+}
+
+.scoped-models-summary {
+	font-size: 12px;
+	color: var(--muted);
+	white-space: nowrap;
+}
+
+.scoped-models-unsaved {
+	color: color-mix(in srgb, var(--accent) 74%, var(--text));
+}
+
+.scoped-models-search {
+	max-width: 340px;
+}
+
+.scoped-models-actions {
+	margin-top: 8px;
+}
+
+.scoped-models-error {
+	color: var(--danger);
+}
+
+.scoped-models-list {
+	margin-top: 10px;
+	border: 1px solid var(--border);
+	border-radius: 12px;
+	overflow: hidden;
+}
+
+.scoped-models-provider-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	padding: 10px 12px;
+	background: color-mix(in srgb, var(--bg-soft) 62%, transparent);
+	border-top: 1px solid var(--border);
+}
+
+.scoped-models-provider-header:first-child {
+	border-top: none;
+}
+
+.scoped-models-provider-meta {
+	display: grid;
+	gap: 2px;
+	min-width: 0;
+}
+
+.scoped-models-provider-meta .settings-desc {
+	margin-top: 0;
+}
+
+.scoped-model-row {
+	padding: 10px 12px;
+	margin: 0;
+	border-top: 1px solid color-mix(in srgb, var(--border) 75%, transparent);
+}
+
+.scoped-model-row-main {
+	min-width: 0;
+}
+
+.scoped-model-row .settings-desc {
+	max-width: none;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 /* Shortcuts */


### PR DESCRIPTION
## Summary
This PR finalizes the #70 slash/settings reliability track and folds in the latest Codex-style Settings shell + composer UX polish.

## What’s included

### Settings / shell architecture
- Move Settings section navigation into the main left sidebar while Settings is open.
- Simplify right-side Settings content chrome (section-first content, less card-heavy feel).
- Hide workspace header in sidebar while Settings shell is active.

### Settings reliability hardening
- Fix Lit render lifecycle crash (`ChildPart has no parentNode`) seen when opening Settings via `/scoped-models` while async status refreshes run.
- Remove unsafe `innerHTML` mutation fallbacks inside `SettingsPanel` and keep render lifecycle under Lit control.
- Keep section-safe fallback behavior so one failing section does not blank the entire panel.

### Slash/composer UX
- `/scoped-models` now opens native Settings path reliably.
- Slash palette keyboard navigation now:
  - keeps active selection visible,
  - previews active command text directly in composer.
- Composer now supports terminal-style full history traversal via `ArrowUp` / `ArrowDown` across prior prompts and commands.

### Command palette and chat UI polish
- Command palette keyboard navigation auto-scrolls selected row into view.
- Fix user message bubble width/wrapping regression causing squeezed short text (e.g. `he j`).

### Tracking/docs updates
- Updated:
  - `CHANGELOG.md`
  - `TODO.md`
  - `docs/ISSUE_IMPLEMENTATION_LOG_2026-03-31.md`
  - `commandsdevelopment.md`
- Added follow-up tracker:
  - `issues/tree-fork-polish-followup.md`

## Validation
- `npm run check` ✅
- `npm run build:frontend` ✅
  - Existing non-blocking Vite dynamic-import warnings unchanged.

## Scope note
Remaining known partials from #70 are unchanged:
- `/tree` full CLI `navigateTree` branch-switch parity (tracked as follow-up polish).
- `/login` + `/logout` remain terminal-guidance behavior pending native OAuth scope decision.
