### PR TITLE
feat: polish terminal dock + auto-rename UX and extension compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Composer now supports terminal-style full input history traversal (`ArrowUp` / `ArrowDown`) across previously sent prompts and slash commands.
 - Slash palette keyboard navigation now previews the active command directly in the composer input and keeps the active row visible while traversing.
 - Command palette (`Cmd/Ctrl+K`) keyboard navigation now auto-scrolls the selected row into view for long lists.
+- Terminal UX now uses a VS Code-style bottom dock inside chat instead of opening as a standalone terminal tab/pane, with an xterm-powered shell surface and close/clear dock controls.
+- Composer follow-up queue UX is now minimal and docked near the composer instead of injecting speculative queued bubbles into the chat timeline.
 - Welcome project dropdown now lists all projects in the current workspace and supports direct project switching (plus quick actions for add project, packages, and settings).
 - Welcome heading copy now rotates between Pi-style idle phrases for a calmer ambient experience.
 - Reworked assistant tool-heavy runs into a compact workflow timeline with centered duration summary, grouped repeated tool calls, and progressive disclosure for details.
@@ -20,11 +22,18 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Polished markdown code blocks toward a cleaner Codex-like appearance (single surface, tightened header/content spacing, smaller copy affordance, less chrome).
 - Composer slash palette now shows CLI-first command groups with runtime-discovered extension/prompt/skill commands, while keeping visual chrome minimal.
 - Compaction status rendering was reduced to a minimal workflow-style row with collapsed-by-default details instead of a heavy status card.
+- Auto-rename extension recommendation and desktop config bridge now target `@byteowlz/pi-auto-rename`, with dynamic command-to-package resolution for config-intent slash commands (including `/auto-rename config`) instead of hardcoded package-name routing.
+- Packages modal now includes a dedicated auto-rename settings editor (enabled/mode/model/fallback/prefix/debug + Save/Test actions) backed by `auto-rename.json`, so extension behavior can be configured directly in Desktop.
+- Auto-rename settings now support explicit save target selection (global or project), including choosing among opened sidebar projects for project-scoped config writes.
+- Save target controls were moved next to the Save action in auto-rename settings (instead of top-of-form) for a cleaner, less noisy flow.
+- Runtime slash descriptions now include short argument hints for extension commands such as `/auto-rename` (e.g. `config`, `test`, `init`, `regen`).
+- Expanded package capability docs now define explicit command contracts (`/<base>`, `/<base> config`, `/<base> config <args>`), safe default settings behavior, and extension SDK auth compatibility guidance (`getApiKeyAndHeaders` first, legacy fallback optional).
 
 ### Fixed
 - Bundled default Pi Desktop themes now emit full Pi CLI-compatible theme schema (all required color tokens) instead of a partial Desktop-only color set.
 - Fixed `/scoped-models` settings-open race causing Lit `ChildPart has no parentNode` errors by removing unsupported `innerHTML` mutation paths in `SettingsPanel` render/fallback lifecycle.
 - Fixed user message bubble width/wrapping regression that could squeeze short text into broken wrapping (`he j`) by correcting user-shell width constraints and wrap behavior.
+- Fixed terminal usability gaps by normalizing legacy `pane: "terminal"` workspace state back to chat+dock, adding clearer disconnected/no-project terminal states, improving keyboard handling/history inside the docked terminal, and preventing terminal commands from leaking into the chat canvas timeline.
 - Added bundled-theme auto-repair for legacy invalid `~/.pi/agent/themes/pi-desktop-*.json` files so existing installs stop producing CLI theme validation errors.
 - Theme files created from Settings (“Create theme”) now use the full Pi theme schema, so custom exports are valid in both Desktop and CLI.
 - Hardened Settings pane mounting/open flow to recover from race conditions and stale container rebinding during workspace/project transitions.
@@ -39,6 +48,12 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Fixed workflow summary counters to report mixed outcomes correctly (complete + failed + running) instead of over-reporting failures.
 - Removed blinking assistant-body streaming cursor artifact and removed noisy composer status text beneath model controls.
 - Fixed compaction timeline behavior so compaction rows stay anchored at the correct chronological position instead of drifting to the newest row.
+- Alt+Enter in composer now surfaces explicit queued-message behavior (`followUp`) with clearer queued labeling in user bubbles.
+- Extension `notify` responses are now surfaced as in-app notices while Desktop is foregrounded, so command feedback from extension workflows (including auto-rename commands) is visible instead of appearing to no-op.
+- Extension runtime errors now include better source context in chat notices, and Desktop emits an explicit compatibility hint when an extension still uses deprecated `ctx.modelRegistry.getApiKey()`.
+- Desktop now ensures a global compatibility extension (`~/.pi/agent/extensions/pi-desktop-sdk-compat.ts`) is installed to shim `modelRegistry.getApiKey()` via `getApiKeyAndHeaders()` for legacy extensions, restoring runtime compatibility for packages such as `@byteowlz/pi-auto-rename`.
+- Auto-rename settings now correctly hydrate saved `model`/`fallbackModel` values from object-form config (`{ provider, id }`) and keep those values visible in model dropdowns (including unavailable-but-saved models).
+- Suppressed internal extension status-key events (for example `oqto_title_changed`) from rendering as floating composer status text, fixing stray session-title overlays above the attach/model row.
 
 ## [0.1.8] - 2026-03-23
 

--- a/TODO.md
+++ b/TODO.md
@@ -13,6 +13,7 @@ Done in this session:
 - [x] Fixed workflow summary counts to report combined outcomes (e.g. complete + failed + running).
 - [x] Removed blinking streaming cursor from assistant message body.
 - [x] Removed composer status line noise beneath model picker.
+- [x] Filtered internal extension status keys (e.g. `oqto_title_changed`) so extension title-sync does not render stray text above composer controls.
 
 Remaining before closing #70:
 - [ ] Final command-by-command QA matrix pass and polish (especially less-used built-ins and extension-config command mappings).
@@ -20,6 +21,7 @@ Remaining before closing #70:
   - [x] Slash palette keyboard UX polish complete (active row visibility + live composer command preview while navigating).
   - [x] Command palette keyboard visibility polish complete (selected command row auto-scrolls into view).
   - [x] User message bubble width/render regression fixed (no more squeezed `he j` wrapping artifacts on short messages).
+  - [x] Alt+Enter queued-follow-up UX polished: queued items stay in a minimal composer queue strip and no longer override the active chat canvas flow during tool runs.
   - [x] `/name` parity pass complete (inline sidebar rename when no arg, shared rename pipeline when arg provided).
   - [x] `/new` parity pass complete (reuses sidebar fresh-session flow via `startFreshSessionTab()`).
   - [x] `/import` parity pass complete (supports native file picker when no path arg is provided).
@@ -301,6 +303,7 @@ The app should feel native while still reflecting Pi’s actual resource model.
 - [x] Refine no-project/new-thread welcome dashboard toward clean Codex-inspired centered flow (#63, partial)
 - [ ] Final new-file draft UX polish pass
 - [ ] Final session delete/select stability polish pass
+- [x] Terminal UX baseline pass: switch from terminal-tab pane to bottom docked terminal in chat (VS Code-style), then polish into xterm-powered terminal surface with isolated shell execution (no chat-canvas leakage), `cd` cwd handling, and clear/abort keyboard controls.
 
 ### Manual smoke tests that still matter
 - [ ] Parallel runs in separate session tabs with different models

--- a/commandsdevelopment.md
+++ b/commandsdevelopment.md
@@ -11,6 +11,16 @@ Bring all composer slash commands to a stable, desktop-native behavior model whe
 - 🔴 Not implemented: **0 / 20**
 - 📝 Deferred follow-up polish: `/tree` + `/fork` visual/interaction cleanup tracked separately (`issues/tree-fork-polish-followup.md`).
 
+## Compatibility audit note (2026-04-06)
+
+Composer slash command discovery/execution is aligned with CLI command metadata. A remaining false-negative "commands are broken/outdated" symptom was traced to an extension runtime API mismatch in `@byteowlz/pi-auto-rename` (`ctx.modelRegistry.getApiKey` is no longer available in current Pi runtime; use `getApiKeyAndHeaders`).
+
+Desktop now installs a small global compatibility extension (`pi-desktop-sdk-compat.ts`) that restores legacy `getApiKey` access via `getApiKeyAndHeaders`, so existing extensions keep working while upstream packages migrate. Desktop also surfaces extension runtime errors with clearer context, and capability template docs now define the SDK compatibility/default-behavior contract to prevent this class of failure in extension packages.
+
+Additional UX parity polish:
+- `/auto-rename` command metadata now shows short args hints (`config`, `test`, `init`, `regen`) in slash command descriptions.
+- Packages -> extension settings now provides a dedicated auto-rename config form (mode + model/fallback + prefix/debug + save/test) instead of requiring users to know raw command args.
+
 ## Current implementation snapshot
 
 | Command | Current behavior | Reuse quality | Notes |
@@ -46,8 +56,8 @@ Bring all composer slash commands to a stable, desktop-native behavior model whe
 ## Runtime commands
 Runtime-discovered commands (`extension` / `prompt` / `skill`) come from `get_commands`.
 
-- Extension `*-config` commands can be mapped to Desktop config UI.
-- Current mapping implemented: `name-ai-config` -> opens package config modal for `pi-session-auto-rename`.
+- Extension config-intent commands (`*-config` or commands invoked with `config` args, e.g. `/auto-rename config`) can be mapped to Desktop package config UI.
+- Current mapping is dynamic: Desktop resolves the owning installed extension from runtime command metadata and opens that package’s config modal (no hardcoded package-name mapping).
 
 ## Plan (step-by-step)
 1. Validate `/name` parity smoke checks (with arg + no arg inline edit path).

--- a/docs/CAPABILITY_MODEL.md
+++ b/docs/CAPABILITY_MODEL.md
@@ -4,11 +4,13 @@ Pi Desktop is a **capability host** for the Pi ecosystem.
 
 ## Mental model
 
-- **Desktop app**: exposes host capabilities (UI primitives, native shell integration, runtime bridge)
-- **Extensions/packages**: consume those capabilities to implement optional workflows and behavior
-- **Pi runtime (`pi --mode rpc`)**: orchestrates execution and extension loading
+- **Desktop app**: host capabilities (native shell/window UX, extension UI bridge, runtime bridge)
+- **Extensions/packages**: implement optional workflows on top of host capabilities
+- **Pi runtime (`pi --mode rpc`)**: executes commands, loads extensions/resources, and emits capability events
 
-This keeps app-core lightweight while allowing ecosystem-driven growth.
+This keeps app-core lightweight while enabling ecosystem-driven behavior.
+
+---
 
 ## Extension UI capability contract
 
@@ -29,6 +31,50 @@ Source of truth in code:
   - `SUPPORTED_EXTENSION_UI_METHODS`
   - `normalizeExtensionUiRequest(...)`
 
+---
+
+## Command interoperability contract
+
+Desktop command UX is runtime-driven, not hardcoded per package:
+
+1. Runtime command discovery (`get_commands`) provides command metadata.
+2. Desktop slash palette combines:
+   - built-ins,
+   - runtime extension/prompt/skill commands.
+3. Extension config-intent routing is dynamic and recognizes:
+   - command names ending with `config`,
+   - commands invoked with `config ...` args (example: `/auto-rename config`).
+
+Package/extension command behavior should follow the template in:
+- [`docs/PACKAGE_CAPABILITY_TEMPLATE.md`](./PACKAGE_CAPABILITY_TEMPLATE.md)
+
+---
+
+## Settings/default behavior contract (for package compatibility)
+
+For Desktop-safe package behavior:
+
+- package config must define explicit safe defaults,
+- lifecycle handlers must no-op when disabled,
+- missing config files must not crash runtime hooks,
+- read/status commands must work before manual setup.
+
+Desktop should only store transient UI state; durable settings remain package-owned.
+
+---
+
+## SDK compatibility contract
+
+Extensions must use current Pi SDK/runtime APIs.
+
+Important example:
+- Prefer `ctx.modelRegistry.getApiKeyAndHeaders(model)`
+- Do **not** rely solely on legacy `ctx.modelRegistry.getApiKey(model)`
+
+When supporting mixed runtime versions, use a compatibility helper that tries `getApiKeyAndHeaders` first and falls back to legacy methods.
+
+---
+
 ## Unsupported capability behavior
 
 If an extension emits an unsupported `extension_ui_request` method, Pi Desktop:
@@ -38,11 +84,13 @@ If an extension emits an unsupported `extension_ui_request` method, Pi Desktop:
 
 This avoids hidden hangs and makes compatibility gaps easier to diagnose.
 
+---
+
 ## Development guardrails
 
 When adding features:
 
-- Prefer adding functionality through **capabilities + extensions** first.
+- Prefer capability-driven solutions over package-specific desktop logic.
 - Keep app-core focused on:
   - UI polish
   - performance

--- a/docs/ISSUE_IMPLEMENTATION_LOG_2026-03-31.md
+++ b/docs/ISSUE_IMPLEMENTATION_LOG_2026-03-31.md
@@ -110,6 +110,14 @@ Additional UX hardening (2026-04-06 follow-up):
 - Composer now supports terminal-style full history navigation via `ArrowUp`/`ArrowDown` for prior user prompts and slash commands.
 - Slash keyboard navigation now previews selected command text directly in composer and keeps highlighted rows visible.
 - Command palette keyboard navigation now auto-scrolls selected rows into view.
+- Extension config routing is now dynamic (command-metadata based) instead of hardcoded to `name-ai-config`/`pi-session-auto-rename`, and Desktop now routes config-intent commands like `/auto-rename config` to the owning package modal.
+- Auto-rename package recommendation switched to `@byteowlz/pi-auto-rename` (legacy `pi-session-auto-rename` kept as alias for compatibility).
+- Added dedicated auto-rename settings editor in Packages modal (mode/model/fallback/prefix/debug + save/test) so users can configure behavior without memorizing command args.
+- Added extension-error compatibility hinting in chat for deprecated `ctx.modelRegistry.getApiKey()` usage (actionable guidance toward `getApiKeyAndHeaders`).
+- Desktop now ensures a global compatibility extension (`~/.pi/agent/extensions/pi-desktop-sdk-compat.ts`) that shims legacy `modelRegistry.getApiKey()` via `getApiKeyAndHeaders()` for older extensions (including current `@byteowlz/pi-auto-rename` versions), preventing runtime crashes.
+- Expanded capability docs (`docs/PACKAGE_CAPABILITY_TEMPLATE.md`, `docs/CAPABILITY_MODEL.md`) with explicit command/default-behavior contracts and SDK compatibility requirements for extension authors.
+- Extension `notify` responses now surface in-app while Desktop is foregrounded, so extension command feedback is visible without requiring background notifications.
+- Internal extension status keys used for title-sync (e.g. `oqto_title_changed`) are now suppressed from visible status overlays, preventing stray session-title text from appearing above the composer controls.
 - User message bubble width/wrapping regression fixed (`he j` squeeze artifact removed).
 
 Remaining:

--- a/docs/PACKAGE_CAPABILITY_TEMPLATE.md
+++ b/docs/PACKAGE_CAPABILITY_TEMPLATE.md
@@ -1,69 +1,168 @@
 # Package Capability Template (Desktop)
 
-Use this template whenever we add or adapt package/extension behavior in Pi Desktop.
+Use this template when adding or adapting package/extension behavior for Pi Desktop.
 
 ## Goal
 
-Keep Desktop as a **generic capability host** while allowing packages to add optional behavior.
+Keep Desktop a **generic capability host** while making package commands/settings predictable and Desktop-compatible by default.
 
 ## Non-goals
 
 - No package-specific business logic in app core.
-- No hardcoded package-name switches for UX flows.
-- No package config controls in global `Settings` panel.
+- No hardcoded package-name switches for command routing.
+- No package config controls embedded in global `Settings`.
 
-## Required architecture
+---
 
-1. **Discover capabilities dynamically**
-   - Use runtime command discovery (`get_commands`) and installed package metadata.
-   - Match commands to installed packages by source/path.
+## 1) Required architecture
 
-2. **Render package config in Packages view**
-   - Show per-package settings entrypoint (gear icon) in Installed list.
-   - Open a modal overlay (not inline expansion in crowded list views).
+### 1.1 Discover capabilities dynamically
 
-3. **Run package config through runtime**
-   - Apply settings by executing the package command via RPC prompt.
-   - Let package extension own persistence format and storage location.
+- Discover commands via runtime (`get_commands`) and installed package metadata.
+- Map command -> package by source/path metadata, not by package-name constants.
+- Treat `extension`, `prompt`, and `skill` command sources as first-class.
 
-4. **Use desktop-native form UX**
-   - Show form controls (e.g. model dropdown) instead of command syntax.
-   - User-facing actions should be `Save` / `Apply` (not raw slash-command labels).
+### 1.2 Run package config through runtime
 
-## UI contract
+- Desktop owns only temporary form/input state.
+- Package owns persistence format and storage location.
+- Apply settings by executing package commands through runtime.
 
-- Entry point: Installed package row -> gear icon -> modal.
-- Modal should include:
-  - title with package label
-  - discovered setting actions
-  - action buttons (`Save` / `Apply`)
-  - status/error line
-- If no config actions discovered:
-  - show informational empty state (package adds runtime capability only).
+### 1.3 Keep Desktop UX native
 
-## Data-flow contract
+- Package config entrypoint is the Installed package row (gear icon) -> modal.
+- User actions are UX labels (`Save`, `Apply`, `Test`) rather than raw slash syntax.
 
-- Desktop stores only temporary UI state for the modal.
-- Durable settings are owned by package command handlers.
-- Desktop may offer convenience inputs (e.g. model picker), but final write happens through package command execution.
+---
 
-## Implementation checklist
+## 2) Command behavior contract (required)
 
-- [ ] No hardcoded checks for specific package names in UI behavior.
-- [ ] No package config controls in global Settings panel.
-- [ ] Package settings open in modal from Installed list.
-- [ ] User actions are labeled with UX terms (`Save` / `Apply`), not command names.
+For package command `/<base>`:
+
+1. `/<base>` (no args)
+   - Must be safe/read-only (status/help/current config summary).
+   - Must not perform destructive or expensive side effects.
+
+2. `/<base> config`
+   - Must be valid and deterministic.
+   - Should return config/help output and/or open package config UI intent.
+   - Should not silently fail when config file is missing.
+
+3. `/<base> config <args>`
+   - Applies configuration.
+   - Returns clear success/error feedback via output and/or `ctx.ui.notify`.
+
+4. Optional alias: `/<base>-config`
+   - If exposed, behavior should mirror `/<base> config`.
+
+Desktop config-intent routing currently recognizes both:
+- command names ending with `config`
+- commands invoked with args beginning with `config` (e.g. `/auto-rename config`)
+
+---
+
+## 3) Settings/default behavior contract (required)
+
+### 3.1 Config resolution
+
+Packages should document:
+- config file name,
+- lookup precedence (project -> user/global),
+- write target for `config/apply` commands.
+
+### 3.2 Safe defaults
+
+Required defaults for Desktop compatibility:
+- Explicit `enabled` toggle in config schema.
+- Event hooks (`before_agent_start`, `agent_end`, etc.) must short-circuit when `enabled: false`.
+- Missing config file must fall back to internal defaults (no throw/crash).
+- `config`/`status` commands must work before any manual setup.
+
+### 3.3 Idempotent writes
+
+- Reapplying same settings should be harmless.
+- Validation errors must produce actionable messages (what field failed, expected format).
+
+---
+
+## 4) SDK/API compatibility contract (required)
+
+Avoid deprecated runtime APIs. For model auth in extensions, use modern `ModelRegistry` APIs.
+
+### 4.1 Current auth API
+
+Use `ctx.modelRegistry.getApiKeyAndHeaders(model)` (not `getApiKey`).
+
+### 4.2 Backward/forward-compatible helper
+
+```ts
+async function resolveModelApiKey(ctx: ExtensionContext, model: Model<Api>): Promise<string | undefined> {
+  const registry = ctx.modelRegistry as {
+    getApiKeyAndHeaders?: (m: Model<Api>) => Promise<{ ok: true; apiKey?: string } | { ok: false; error: string }>;
+    getApiKey?: (m: Model<Api>) => Promise<string | undefined>; // legacy
+  };
+
+  if (typeof registry.getApiKeyAndHeaders === "function") {
+    const auth = await registry.getApiKeyAndHeaders(model);
+    return auth.ok ? auth.apiKey : undefined;
+  }
+
+  if (typeof registry.getApiKey === "function") {
+    return await registry.getApiKey(model);
+  }
+
+  return undefined;
+}
+```
+
+If auth cannot be resolved, return a clean user-facing error; do not throw uncaught exceptions from lifecycle handlers.
+
+---
+
+## 5) Desktop UI contract
+
+Package settings modal should include:
+- package title,
+- discovered setting actions,
+- form fields for known args (e.g. model picker),
+- action buttons (`Save` / `Apply`),
+- inline status/error text.
+
+If no config actions are discovered, show an informational empty state.
+
+---
+
+## 6) Error + feedback contract
+
+- Always emit explicit success/failure feedback (`ctx.ui.notify` and/or command output).
+- Never rely on silent side effects.
+- For unsupported Desktop UI capability requests, handle rejection gracefully.
+
+Reference: [`docs/CAPABILITY_MODEL.md`](./CAPABILITY_MODEL.md)
+
+---
+
+## 7) Implementation checklist
+
+- [ ] No hardcoded package-name checks in Desktop logic.
+- [ ] Command behavior follows `/<base>`, `/<base> config`, `/<base> config <args>` contract.
+- [ ] Config schema includes `enabled` and safe defaults.
+- [ ] Lifecycle handlers no-op when disabled.
+- [ ] Uses `getApiKeyAndHeaders` (or compatibility shim) instead of deprecated `getApiKey`.
+- [ ] Package settings open from Installed row -> modal.
+- [ ] UX labels are `Save`/`Apply` (not slash command strings).
 - [ ] `npm run check` passes.
 - [ ] `npm run build:frontend` passes.
-- [ ] Manual smoke test for at least one model-config package and one capability-only package.
+- [ ] Manual smoke: one model-config package + one capability-only package.
 
 ## PR checklist snippet
-
-Copy into PR description:
 
 ```md
 ### Package capability template compliance
 - [ ] Dynamic capability discovery (no package-name hardcoding)
+- [ ] Command contract: /<base>, /<base> config, /<base> config <args>
+- [ ] Safe defaults + enabled short-circuit for lifecycle hooks
+- [ ] Uses ModelRegistry getApiKeyAndHeaders compatibility path
 - [ ] Package config lives in Packages modal
 - [ ] Runtime command execution is the write path
 - [ ] UX labels are Save/Apply (no slash command labels)

--- a/issues/chat-ui-polish-checklist-temp.md
+++ b/issues/chat-ui-polish-checklist-temp.md
@@ -25,6 +25,9 @@ Context: consolidated from latest UX feedback for Codex-like chat/workflow parit
 - [x] Tighten code block spacing, header/footer proportions, and copy icon sizing.
 - [x] Soften copy button/copied state visual weight for minimal look.
 
+## Composer/status cleanliness
+- [x] Suppress internal extension status-key events (for example `oqto_title_changed`) so title-sync events do not render stray text above composer controls.
+
 ## Remaining QA pass
 - [ ] Validate long code blocks (horizontal + vertical scroll behavior).
 - [ ] Validate mixed markdown (paragraph + code block + paragraph) copy button behavior.

--- a/issues/feature-terminal-integration.md
+++ b/issues/feature-terminal-integration.md
@@ -1,0 +1,34 @@
+# Terminal integration follow-up (implemented baseline)
+
+Status: Implemented baseline on `feat/70-slash-actions-reliability` (2026-04-06)
+
+## What changed
+
+- Terminal no longer opens as its own content tab/pane.
+- Terminal now opens as a bottom dock inside the chat pane (VS Code-like layout).
+- Terminal dock now uses an xterm-powered terminal surface (instead of a plain text input row).
+- Terminal toggle uses the existing top-right terminal button in the content tabs bar.
+- Dock behavior:
+  - open/close toggles inline in chat
+  - does not replace the active chat session
+  - keeps chat visible above terminal
+
+## Runtime behavior
+
+- Terminal commands now run in an isolated shell execution path (not through chat-session tool events), so terminal commands no longer appear as chat timeline tool rows.
+- Added clearer guarded runtime states inside the terminal surface:
+  - no project: terminal guidance is shown and command execution is blocked
+- Added terminal keyboard polish (history up/down, Ctrl+C abort, Ctrl+L clear).
+- `cd` commands now update terminal working directory state for subsequent terminal commands.
+- Composer Alt+Enter queue behavior now uses a minimal queue strip near the composer (instead of speculative queued user bubbles in chat).
+
+## Notes
+
+- Legacy persisted `pane: "terminal"` state is auto-normalized back to `pane: "chat"` with terminal dock open.
+- Current implementation is single docked terminal panel (no split panes/multi-terminal tabs yet).
+
+## Potential follow-ups
+
+- Adjustable terminal dock height (drag handle).
+- Multi-terminal sessions/tabs inside the dock.
+- Optional persisted terminal command history per workspace.

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,9 @@
 	"$schema": "../gen/schemas/desktop-schema.json",
 	"identifier": "default",
 	"description": "Default capability for the Pi Desktop app",
-	"windows": ["main"],
+	"windows": [
+		"main"
+	],
 	"permissions": [
 		"core:default",
 		"core:window:default",
@@ -24,14 +26,23 @@
 		"core:event:default",
 		"shell:default",
 		"shell:allow-open",
+		"shell:allow-kill",
 		"fs:default",
 		{
 			"identifier": "fs:allow-home-read-recursive",
-			"allow": ["$HOME/**", "$HOME/**/.*", "$HOME/**/.*/**"]
+			"allow": [
+				"$HOME/**",
+				"$HOME/**/.*",
+				"$HOME/**/.*/**"
+			]
 		},
 		{
 			"identifier": "fs:allow-home-write-recursive",
-			"allow": ["$HOME/**", "$HOME/**/.*", "$HOME/**/.*/**"]
+			"allow": [
+				"$HOME/**",
+				"$HOME/**/.*",
+				"$HOME/**/.*/**"
+			]
 		},
 		"dialog:default",
 		"dialog:allow-open",
@@ -42,6 +53,56 @@
 				{
 					"name": "binaries/pi",
 					"sidecar": true,
+					"args": true
+				},
+				{
+					"name": "terminal-zsh-path",
+					"cmd": "/bin/zsh",
+					"args": true
+				},
+				{
+					"name": "terminal-zsh",
+					"cmd": "zsh",
+					"args": true
+				},
+				{
+					"name": "terminal-bash-path",
+					"cmd": "/bin/bash",
+					"args": true
+				},
+				{
+					"name": "terminal-bash",
+					"cmd": "bash",
+					"args": true
+				},
+				{
+					"name": "terminal-sh-path",
+					"cmd": "/bin/sh",
+					"args": true
+				},
+				{
+					"name": "terminal-sh",
+					"cmd": "sh",
+					"args": true
+				},
+				{
+					"name": "terminal-pwsh-exe",
+					"cmd": "pwsh.exe",
+					"args": true
+				},
+				{
+					"name": "terminal-pwsh",
+					"cmd": "pwsh",
+					"args": true
+				},
+				{
+					"name": "terminal-cmd-exe",
+					"cmd": "cmd.exe",
+					"args": true
+				},
+				{
+					"name": "terminal-cmd",
+					"cmd": "cmd",
 					"args": true
 				}
 			]

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -443,7 +443,13 @@ function uiIcon(name: "edit" | "retry" | "copy" | "attach" | "send" | "stop" | "
 		case "copy":
 			return html`<svg viewBox="0 0 16 16" aria-hidden="true"><rect x="5" y="5" width="8" height="8" rx="1.4"></rect><rect x="3" y="3" width="8" height="8" rx="1.4"></rect></svg>`;
 		case "attach":
-			return html`<svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 3.1v9.8"></path><path d="M3.1 8h9.8"></path></svg>`;
+			return html`
+				<svg viewBox="0 0 16 16" aria-hidden="true">
+					<path d="M4.2 2.6h5.1l2.5 2.5v7.1a1.2 1.2 0 0 1-1.2 1.2H4.2A1.2 1.2 0 0 1 3 12.2V3.8a1.2 1.2 0 0 1 1.2-1.2z"></path>
+					<path d="M9.3 2.6v2.5h2.5"></path>
+					<path d="M5.6 4.5v3.6a2.4 2.4 0 1 0 4.8 0V4.9a1.6 1.6 0 1 0-3.2 0v3a.8.8 0 1 0 1.6 0V5.5"></path>
+				</svg>
+			`;
 		case "send":
 			return html`<svg class="send-arrow-icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 12.7V3.6"></path><path d="M4.6 7L8 3.6 11.4 7"></path></svg>`;
 		case "stop":
@@ -5845,7 +5851,7 @@ export class ChatView {
 				<div class="control-group">
 					<button
 						class="composer-icon-btn"
-						title="Attach image"
+						title="Attach file"
 						?disabled=${interactionLocked}
 						@click=${() => {
 							if (interactionLocked) return;

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -25,6 +25,14 @@ interface PendingImage {
 	size: number;
 }
 
+interface QueuedComposerMessage {
+	id: string;
+	text: string;
+	attachments: PendingImage[];
+	imageCount: number;
+	createdAt: number;
+}
+
 interface ToolCallBlock {
 	id: string;
 	name: string;
@@ -187,6 +195,24 @@ interface CompactionCycleState {
 	errorMessage: string | null;
 	details: string[];
 	expanded: boolean;
+}
+
+function runtimeCommandUsageHint(name: string): string | null {
+	const normalized = normalizeText(name).toLowerCase().replace(/^\/+/, "");
+	if (normalized === "auto-rename" || normalized === "name-ai-config") {
+		return "Args: config, test, init, regen, <name>";
+	}
+	return null;
+}
+
+function withRuntimeCommandUsageHint(name: string, description: string): string {
+	const hint = runtimeCommandUsageHint(name);
+	if (!hint) return description;
+	const normalized = normalizeText(description);
+	if (!normalized) return hint;
+	const lower = normalized.toLowerCase();
+	if (lower.includes("config") && lower.includes("test")) return normalized;
+	return `${normalized} · ${hint}`;
 }
 
 const BUILTIN_SLASH_COMMANDS: Array<{ name: string; description: string }> = [
@@ -406,6 +432,8 @@ function formatThinkingDisplayName(level: ThinkingLevel): string {
 	}
 }
 
+const THINKING_LEVEL_CYCLE_ORDER: ThinkingLevel[] = ["off", "minimal", "low", "medium", "high", "xhigh"];
+
 function uiIcon(name: "edit" | "retry" | "copy" | "attach" | "send" | "stop" | "spinner" | "spark" | "terminal" | "git"): TemplateResult {
 	switch (name) {
 		case "edit":
@@ -460,7 +488,7 @@ export class ChatView {
 	private onAddProject: (() => void) | null = null;
 	private onOpenSettings: ((sectionId?: string) => void) | null = null;
 	private onOpenPackages: (() => void) | null = null;
-	private onOpenExtensionConfig: ((commandName: string) => boolean | Promise<boolean>) | null = null;
+	private onOpenExtensionConfig: ((commandName: string, args: string) => boolean | Promise<boolean>) | null = null;
 	private onBeginRenameCurrentSession: (() => boolean | Promise<boolean>) | null = null;
 	private onRenameCurrentSession: ((nextName: string) => boolean | Promise<boolean>) | null = null;
 	private onCreateFreshSession: (() => boolean | Promise<boolean>) | null = null;
@@ -479,6 +507,7 @@ export class ChatView {
 	private lastBackendSessionFile: string | null = null;
 	private settingModel = false;
 	private settingThinking = false;
+	private unsupportedThinkingLevelsByModel = new Map<string, Set<ThinkingLevel>>();
 	private modelPickerOpen = false;
 	private modelPickerActiveProvider = "";
 	private modelPickerGlobalListenersBound = false;
@@ -494,7 +523,9 @@ export class ChatView {
 	private compactionInsertIndex: number | null = null;
 	private lastRuntimeNoticeSignature = "";
 	private lastRuntimeNoticeAt = 0;
+	private extensionCompatibilityHintsShown = new Set<string>();
 	private pendingDeliveryMode: DeliveryMode = "prompt";
+	private queuedComposerMessages: QueuedComposerMessage[] = [];
 	private openingForkPicker = false;
 	private forkPickerOpen = false;
 	private forkOptions: ForkOption[] = [];
@@ -627,7 +658,7 @@ export class ChatView {
 		this.onOpenPackages = cb;
 	}
 
-	setOnOpenExtensionConfig(cb: (commandName: string) => boolean | Promise<boolean>): void {
+	setOnOpenExtensionConfig(cb: (commandName: string, args: string) => boolean | Promise<boolean>): void {
 		this.onOpenExtensionConfig = cb;
 	}
 
@@ -895,7 +926,7 @@ export class ChatView {
 		if (source !== "extension" && source !== "prompt" && source !== "skill") return null;
 		const name = normalizeText(raw.name).replace(/^\/+/, "").trim().toLowerCase();
 		if (!name) return null;
-		const description = normalizeText(raw.description) || `Run /${name}`;
+		const description = withRuntimeCommandUsageHint(name, normalizeText(raw.description) || `Run /${name}`);
 		return {
 			name,
 			description,
@@ -1127,7 +1158,7 @@ export class ChatView {
 			if (item.source === "builtin") {
 				await this.executeBuiltinSlashCommand(item.commandName, args);
 			} else {
-				await this.executeRuntimeSlashCommand(trimmedCommandText, item.source, item.commandName);
+				await this.executeRuntimeSlashCommand(trimmedCommandText, item.source, item.commandName, args);
 			}
 		} catch (err) {
 			console.error(`Slash command failed (${item.commandName}):`, err);
@@ -1139,11 +1170,24 @@ export class ChatView {
 		}
 	}
 
-	private async executeRuntimeSlashCommand(commandText: string, source: SlashCommandSource, commandName: string): Promise<void> {
+	private async executeRuntimeSlashCommand(
+		commandText: string,
+		source: SlashCommandSource,
+		commandName: string,
+		args: string,
+	): Promise<void> {
 		if (source === "builtin") return;
-		if (source === "extension" && this.onOpenExtensionConfig && commandName.toLowerCase().endsWith("config")) {
-			const handled = await this.onOpenExtensionConfig(commandName.toLowerCase());
-			if (handled) return;
+		if (source === "extension" && this.onOpenExtensionConfig) {
+			const normalizedName = commandName.trim().toLowerCase();
+			const normalizedArgs = args.trim().toLowerCase();
+			const configIntent =
+				normalizedName.endsWith("config") ||
+				normalizedArgs === "config" ||
+				normalizedArgs.startsWith("config ");
+			if (configIntent) {
+				const handled = await this.onOpenExtensionConfig(normalizedName, args);
+				if (handled) return;
+			}
 		}
 		const options = this.currentIsStreaming() ? { streamingBehavior: "steer" as const } : {};
 		await rpcBridge.prompt(commandText, options);
@@ -1635,6 +1679,7 @@ export class ChatView {
 			const previousSessionFile = this.lastBackendSessionFile;
 			const currentSessionFile = state.sessionFile ?? null;
 			this.state = state;
+			this.syncComposerQueueFromState(state);
 			this.lastBackendSessionFile = currentSessionFile;
 			if ((previousSessionFile ?? "") !== (currentSessionFile ?? "")) {
 				this.sessionStats = {
@@ -2119,6 +2164,7 @@ export class ChatView {
 		try {
 			await rpcBridge.setModel(provider, modelId);
 			this.state = await rpcBridge.getState();
+			this.syncComposerQueueFromState(this.state);
 			if (this.state) this.onStateChange?.(this.state);
 			void this.refreshSessionStats(true);
 			this.pushNotice(`Switched to ${provider}/${modelId}`, "success");
@@ -2133,8 +2179,40 @@ export class ChatView {
 		}
 	}
 
-	private async setThinkingLevel(level: ThinkingLevel): Promise<void> {
-		if (this.settingThinking) return;
+	private thinkingLevelModelKey(state: RpcSessionState | null | undefined = this.state): string {
+		const provider = state?.model?.provider?.trim() ?? "";
+		const modelId = state?.model?.id?.trim() ?? "";
+		if (!provider || !modelId) return "";
+		return `${provider}::${modelId}`;
+	}
+
+	private markThinkingLevelUnsupported(level: ThinkingLevel, state: RpcSessionState | null | undefined = this.state): void {
+		const key = this.thinkingLevelModelKey(state);
+		if (!key) return;
+		const existing = this.unsupportedThinkingLevelsByModel.get(key) ?? new Set<ThinkingLevel>();
+		existing.add(level);
+		this.unsupportedThinkingLevelsByModel.set(key, existing);
+	}
+
+	private clearThinkingLevelUnsupported(level: ThinkingLevel, state: RpcSessionState | null | undefined = this.state): void {
+		const key = this.thinkingLevelModelKey(state);
+		if (!key) return;
+		const existing = this.unsupportedThinkingLevelsByModel.get(key);
+		if (!existing) return;
+		existing.delete(level);
+		if (existing.size === 0) {
+			this.unsupportedThinkingLevelsByModel.delete(key);
+		}
+	}
+
+	private unsupportedThinkingLevelsForCurrentModel(): Set<ThinkingLevel> {
+		const key = this.thinkingLevelModelKey(this.state);
+		if (!key) return new Set<ThinkingLevel>();
+		return this.unsupportedThinkingLevelsByModel.get(key) ?? new Set<ThinkingLevel>();
+	}
+
+	private async setThinkingLevel(level: ThinkingLevel): Promise<ThinkingLevel | null> {
+		if (this.settingThinking) return this.state?.thinkingLevel ?? null;
 		const requestedLevel = level;
 		if (this.state) {
 			this.state = { ...this.state, thinkingLevel: requestedLevel };
@@ -2144,17 +2222,51 @@ export class ChatView {
 		try {
 			await rpcBridge.setThinkingLevel(requestedLevel);
 			this.state = await rpcBridge.getState();
+			this.syncComposerQueueFromState(this.state);
 			if (this.state) this.onStateChange?.(this.state);
+			if (this.state?.thinkingLevel === requestedLevel) {
+				this.clearThinkingLevelUnsupported(requestedLevel, this.state);
+			} else {
+				this.markThinkingLevelUnsupported(requestedLevel, this.state);
+			}
 			if (requestedLevel === "xhigh" && this.state?.thinkingLevel !== "xhigh") {
 				this.pushNotice(`xhigh is not available for this model (using ${this.state?.thinkingLevel || "high"})`, "info");
 			}
 			void this.refreshSessionStats(true);
+			return this.state?.thinkingLevel ?? null;
 		} catch (err) {
 			console.error("Failed to set thinking level:", err);
 			this.pushNotice("Failed to set thinking level", "error");
+			return this.state?.thinkingLevel ?? null;
 		} finally {
 			this.settingThinking = false;
 			this.render();
+		}
+	}
+
+	private async cycleThinkingLevel(direction: 1 | -1 = 1): Promise<void> {
+		if (this.settingThinking) return;
+		const order = THINKING_LEVEL_CYCLE_ORDER;
+		let cursor = Math.max(0, order.indexOf((this.state?.thinkingLevel ?? "off") as ThinkingLevel));
+
+		for (let attempt = 0; attempt < order.length; attempt += 1) {
+			const blocked = this.unsupportedThinkingLevelsForCurrentModel();
+			let candidate: ThinkingLevel | null = null;
+			for (let step = 1; step <= order.length; step += 1) {
+				const nextIndex = (cursor + step * direction + order.length * 2) % order.length;
+				const nextLevel = order[nextIndex] ?? "off";
+				if (blocked.has(nextLevel)) continue;
+				candidate = nextLevel;
+				cursor = nextIndex;
+				break;
+			}
+			if (!candidate) return;
+			const applied = await this.setThinkingLevel(candidate);
+			if (applied === candidate) return;
+			const appliedIndex = order.indexOf((applied ?? candidate) as ThinkingLevel);
+			if (appliedIndex >= 0) {
+				cursor = appliedIndex;
+			}
 		}
 	}
 
@@ -2962,12 +3074,42 @@ export class ChatView {
 		this.pushNotice(text, kind);
 	}
 
+	private extensionLabelFromPath(pathValue: string | null | undefined): string {
+		const value = normalizeText(pathValue);
+		if (!value) return "Extension";
+		const normalized = value.replace(/\\/g, "/");
+		const parts = normalized.split("/").filter((part) => part.length > 0);
+		if (parts.length === 0) return value;
+		const last = parts[parts.length - 1];
+		if (/^index\.(?:ts|js|mjs|cjs)$/i.test(last) && parts.length >= 2) {
+			return parts[parts.length - 2];
+		}
+		return last;
+	}
+
+	private maybePushExtensionCompatibilityHint(event: Record<string, unknown>, errorMessage: string): void {
+		const normalizedError = errorMessage.trim().toLowerCase();
+		if (!normalizedError.includes("modelregistry.getapikey is not a function")) return;
+		const extensionPath = pickString(event, ["extensionPath", "extension", "path"]);
+		const callbackEvent = pickString(event, ["event", "callback", "method"]);
+		const signature = `${(extensionPath ?? "").toLowerCase()}::${(callbackEvent ?? "").toLowerCase()}::modelregistry.getapikey`;
+		if (this.extensionCompatibilityHintsShown.has(signature)) return;
+		this.extensionCompatibilityHintsShown.add(signature);
+		const extensionLabel = this.extensionLabelFromPath(extensionPath);
+		const during = callbackEvent ? ` during ${callbackEvent}` : "";
+		this.pushRuntimeNotice(
+			`${extensionLabel} uses deprecated ctx.modelRegistry.getApiKey()${during}. Update the extension to ctx.modelRegistry.getApiKeyAndHeaders() (or add a compatibility fallback).`,
+			"error",
+			12000,
+		);
+	}
+
 	private handleEvent(event: Record<string, unknown>): void {
 		const type = event.type as string;
 		if (type === "response") return;
 
 		switch (type) {
-			case "agent_start":
+			case "agent_start": {
 				this.pendingDeliveryMode = "steer";
 				this.runHasAssistantText = false;
 				this.runSawToolActivity = false;
@@ -2983,6 +3125,7 @@ export class ChatView {
 				this.render();
 				this.scrollToBottom();
 				break;
+			}
 
 			case "agent_end": {
 				this.cancelStreamingUiReconcile();
@@ -3008,6 +3151,7 @@ export class ChatView {
 					.getState()
 					.then((s) => {
 						this.state = s;
+						this.syncComposerQueueFromState(s);
 						this.pendingDeliveryMode = s.isStreaming ? "steer" : "prompt";
 						this.onStateChange?.(s);
 						void this.refreshSessionStats(true);
@@ -3024,6 +3168,10 @@ export class ChatView {
 			case "message_start": {
 				const msg = event.message as Record<string, unknown>;
 				const role = typeof msg.role === "string" ? msg.role : "";
+				if (role === "user") {
+					this.promoteQueuedMessageFromUserEvent(msg);
+					break;
+				}
 				if (role === "assistant") {
 					const last = this.messages[this.messages.length - 1];
 					if (last?.role === "assistant" && last.isStreaming) {
@@ -3155,6 +3303,7 @@ export class ChatView {
 				if (turnRole === "assistant") {
 					const last = this.messages[this.messages.length - 1];
 					if (last?.role === "assistant") {
+						last.isStreaming = false;
 						last.isThinkingStreaming = false;
 						const turnError = this.extractAssistantMessageError(turnMessage);
 						if (turnError) {
@@ -3356,9 +3505,12 @@ export class ChatView {
 
 			case "extension_error": {
 				const error = this.extractRuntimeErrorMessage(event) || "Unknown extension error";
-				const source = pickString(event, ["source", "callback", "method", "extension", "provider"]);
-				const prefix = source ? `Extension error (${source})` : "Extension error";
+				const extensionPath = pickString(event, ["extensionPath", "extension"]);
+				const extensionLabel = this.extensionLabelFromPath(extensionPath);
+				const source = pickString(event, ["event", "source", "callback", "method", "provider"]);
+				const prefix = source ? `Extension error (${extensionLabel}:${source})` : `Extension error (${extensionLabel})`;
 				this.pushRuntimeNotice(`${prefix}: ${truncate(error, 180)}`, "error", 2600);
+				this.maybePushExtensionCompatibilityHint(event, error);
 				break;
 			}
 
@@ -3781,6 +3933,67 @@ export class ChatView {
 		this.scrollToBottom(true);
 	}
 
+	private promoteQueuedMessageFromUserEvent(message: Record<string, unknown>): boolean {
+		if (this.queuedComposerMessages.length === 0) return false;
+		const normalize = (value: string): string => value.replace(/\r\n/g, "\n").replace(/\r/g, "\n").trim();
+		const eventTextRaw = this.extractText(message.content ?? "");
+		const eventText = normalize(eventTextRaw);
+		let matchIndex = -1;
+		if (eventText.length > 0) {
+			matchIndex = this.queuedComposerMessages.findIndex((entry) => normalize(entry.text) === eventText);
+		} else {
+			matchIndex = this.queuedComposerMessages.findIndex((entry) => normalize(entry.text).length === 0);
+			if (matchIndex < 0 && this.queuedComposerMessages.length === 1) {
+				matchIndex = 0;
+			}
+		}
+		if (matchIndex < 0) return false;
+		const [queued] = this.queuedComposerMessages.splice(matchIndex, 1);
+		if (!queued) return false;
+		const last = this.messages[this.messages.length - 1];
+		if (
+			last?.role === "user" &&
+			last.deliveryMode === "followUp" &&
+			normalize(last.text) === normalize(queued.text) &&
+			(last.attachments?.length ?? 0) === queued.attachments.length
+		) {
+			return true;
+		}
+		this.pushUserEcho(queued.text, "followUp", this.cloneImages(queued.attachments));
+		return true;
+	}
+
+	private enqueueComposerQueueMessage(text: string, attachments: PendingImage[]): string {
+		const clonedAttachments = this.cloneImages(attachments);
+		const entry: QueuedComposerMessage = {
+			id: uid("queued"),
+			text,
+			attachments: clonedAttachments,
+			imageCount: clonedAttachments.length,
+			createdAt: Date.now(),
+		};
+		this.queuedComposerMessages = [...this.queuedComposerMessages, entry].slice(-6);
+		return entry.id;
+	}
+
+	private removeComposerQueueMessage(id: string): void {
+		const next = this.queuedComposerMessages.filter((entry) => entry.id !== id);
+		if (next.length === this.queuedComposerMessages.length) return;
+		this.queuedComposerMessages = next;
+	}
+
+	private clearComposerQueueMessages(): void {
+		if (this.queuedComposerMessages.length === 0) return;
+		this.queuedComposerMessages = [];
+	}
+
+	private syncComposerQueueFromState(state: RpcSessionState | null | undefined): void {
+		const pendingCount = Math.max(0, state?.pendingMessageCount ?? 0);
+		if (pendingCount > 0 && this.queuedComposerMessages.length > pendingCount) {
+			this.queuedComposerMessages = this.queuedComposerMessages.slice(this.queuedComposerMessages.length - pendingCount);
+		}
+	}
+
 	private resetComposerHistoryNavigation(): void {
 		this.composerHistoryIndex = -1;
 		this.composerHistoryDraft = "";
@@ -3889,6 +4102,7 @@ export class ChatView {
 				const backendState = await rpcBridge.getState();
 				const backendStreaming = Boolean(backendState.isStreaming);
 				this.state = backendState;
+				this.syncComposerQueueFromState(backendState);
 				this.onStateChange?.(backendState);
 				if (!backendStreaming) {
 					streaming = false;
@@ -3905,7 +4119,13 @@ export class ChatView {
 			actualMode = "prompt";
 		}
 
-		this.pushUserEcho(text, actualMode, images);
+		let queuedMessageId: string | null = null;
+		if (actualMode === "followUp") {
+			queuedMessageId = this.enqueueComposerQueueMessage(text, images);
+			this.pushNotice("Queued message", "info");
+		} else {
+			this.pushUserEcho(text, actualMode, images);
+		}
 		this.clearComposer();
 		this.sendingPrompt = true;
 		this.render();
@@ -3918,9 +4138,23 @@ export class ChatView {
 				await rpcBridge.steer(text, rpcImages);
 			} else {
 				await rpcBridge.followUp(text, rpcImages);
+				void rpcBridge
+					.getState()
+					.then((state) => {
+						this.state = state;
+						this.syncComposerQueueFromState(state);
+						this.onStateChange?.(state);
+						this.render();
+					})
+					.catch(() => {
+						/* ignore */
+					});
 			}
 			this.onPromptSubmitted?.();
 		} catch (err) {
+			if (queuedMessageId) {
+				this.removeComposerQueueMessage(queuedMessageId);
+			}
 			console.error("Failed to send message:", err);
 			this.pushNotice(err instanceof Error ? err.message : "Failed to send message", "error");
 		} finally {
@@ -4075,6 +4309,7 @@ export class ChatView {
 		try {
 			const state = await rpcBridge.getState();
 			this.state = state;
+			this.syncComposerQueueFromState(state);
 			this.pendingDeliveryMode = state.isStreaming ? "steer" : "prompt";
 			this.onStateChange?.(state);
 			this.onRunStateChange?.(Boolean(state.isStreaming));
@@ -4591,9 +4826,7 @@ export class ChatView {
 			<div class="chat-row user-row" data-message-id=${msg.id}>
 				<div class="message-shell user-message-shell">
 					<div class="bubble user-bubble">
-						${msg.deliveryMode && msg.deliveryMode !== "prompt"
-							? html`<div class="bubble-chip">${msg.deliveryMode === "steer" ? "steer" : "follow-up"}</div>`
-							: nothing}
+						${msg.deliveryMode === "steer" ? html`<div class="bubble-chip">steer</div>` : nothing}
 						${msg.text ? html`<div class="bubble-text">${msg.text}</div>` : nothing}
 						${msg.attachments && msg.attachments.length > 0
 							? html`
@@ -5732,7 +5965,7 @@ export class ChatView {
 							: nothing}
 					</div>
 
-					<div class="thinking-select-wrap" title="Reasoning effort">
+					<div class="thinking-select-wrap" title="Reasoning effort · Shift+Tab to cycle">
 						<span class="thinking-select-label">${thinkingLabel}</span>
 						<select
 							class="thinking-select-native"
@@ -5776,7 +6009,7 @@ export class ChatView {
 								<button
 									class="send-btn primary-send"
 									?disabled=${interactionLocked || !canSend}
-									title="Send"
+									title="Send (Enter) · Queue while streaming (Alt+Enter)"
 									@click=${() => {
 										if (interactionLocked) return;
 										void this.sendMessage("prompt");
@@ -5786,6 +6019,24 @@ export class ChatView {
 								</button>
 							`}
 				</div>
+			</div>
+		`;
+	}
+
+	private renderQueuedComposerMessages(): TemplateResult | typeof nothing {
+		if (this.queuedComposerMessages.length === 0) return nothing;
+		const recent = this.queuedComposerMessages.slice(-2);
+		return html`
+			<div class="composer-queued-row" aria-live="polite">
+				${recent.map(
+					(entry) => html`
+						<div class="composer-queued-pill" title=${entry.text}>
+							<span class="composer-queued-label">Queued</span>
+							<span class="composer-queued-text">${truncate(entry.text.replace(/\s+/g, " "), 72)}</span>
+							${entry.imageCount > 0 ? html`<span class="composer-queued-meta">+${entry.imageCount} image${entry.imageCount === 1 ? "" : "s"}</span>` : nothing}
+						</div>
+					`,
+				)}
 			</div>
 		`;
 	}
@@ -5908,6 +6159,7 @@ export class ChatView {
 		return html`
 			<div class="composer-shell">
 				<div class="composer-inner">
+					${this.renderQueuedComposerMessages()}
 					<div class="composer-panel">
 						${this.renderPendingImages()}
 						<div class="composer-row">
@@ -5967,6 +6219,11 @@ export class ChatView {
 									if ((e.key === "Backspace" || e.key === "Delete") && this.inputText.length === 0 && this.selectedSkillDraft) {
 										e.preventDefault();
 										this.removeComposerSkillDraft();
+										return;
+									}
+									if (e.key === "Tab" && e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey) {
+										e.preventDefault();
+										void this.cycleThinkingLevel(1);
 										return;
 									}
 									const textarea = e.currentTarget as HTMLTextAreaElement;

--- a/src/components/extension-ui-handler.ts
+++ b/src/components/extension-ui-handler.ts
@@ -110,6 +110,15 @@ function shouldSuppressUiStatusText(text: string): boolean {
 	return false;
 }
 
+function shouldSuppressUiStatusKey(key: string): boolean {
+	const normalized = key.trim().toLowerCase();
+	if (!normalized) return false;
+	if (normalized === "oqto_title_changed") return true;
+	if (/(^|[_.-])title([_.-])?changed($|[_.-])/.test(normalized)) return true;
+	if (normalized.includes("session.title_changed")) return true;
+	return false;
+}
+
 export interface NotificationActionTarget {
 	workspaceId?: string;
 	tabId?: string;
@@ -655,6 +664,13 @@ export class ExtensionUiHandler {
 
 	private setStatus(request: ExtensionUiRequest): void {
 		if (!this.statusContainer) return;
+
+		const statusKey = typeof request.statusKey === "string" ? request.statusKey.trim() : "";
+		if (statusKey && shouldSuppressUiStatusKey(statusKey)) {
+			this.statusContainer.classList.add("hidden");
+			this.statusContainer.innerHTML = "";
+			return;
+		}
 
 		if (request.statusText === undefined) {
 			// Clear status

--- a/src/components/packages-view.ts
+++ b/src/components/packages-view.ts
@@ -33,6 +33,25 @@ interface PackageConfigCommand {
 	path: string;
 }
 
+interface PackageProjectOption {
+	id: string;
+	name: string;
+	path: string;
+}
+
+interface AutoRenameConfigDraft {
+	enabled: boolean;
+	modelSelection: "current" | "cheapest";
+	model: string;
+	fallbackModel: string;
+	fallbackDeterministic: "truncate" | "words" | "none" | "readable-id";
+	prefix: string;
+	prefixCommand: string;
+	prefixOnly: boolean;
+	readableIdSuffix: boolean;
+	debug: boolean;
+}
+
 interface ModelOption {
 	provider: string;
 	id: string;
@@ -107,6 +126,25 @@ const PACKAGES_SEARCH_URL = "https://registry.npmjs.org/-/v1/search?text=keyword
 const RESOURCE_CREATOR_SKILL_NAME = "creatorskill";
 const DESKTOP_THEMES_PACKAGE_SOURCE = "local:pi-desktop-themes";
 const DESKTOP_THEMES_DOC_URL = "https://github.com/gustavonline/pi-desktop/blob/dev/docs/THEMES_DESKTOP_MAPPING.md";
+const AUTO_RENAME_PRIMARY_SOURCE = normalizeRecommendedSource("npm:@byteowlz/pi-auto-rename");
+const AUTO_RENAME_LEGACY_SOURCE = normalizeRecommendedSource("npm:pi-session-auto-rename");
+const AUTO_RENAME_COMMAND_NAMES = new Set(["auto-rename", "name-ai-config"]);
+const AUTO_RENAME_SCHEMA_RELATIVE = "./auto-rename.schema.json";
+
+function defaultAutoRenameConfigDraft(): AutoRenameConfigDraft {
+	return {
+		enabled: true,
+		modelSelection: "current",
+		model: "",
+		fallbackModel: "",
+		fallbackDeterministic: "readable-id",
+		prefix: "",
+		prefixCommand: "",
+		prefixOnly: false,
+		readableIdSuffix: false,
+		debug: false,
+	};
+}
 
 function uniqueBy<T>(items: T[], getKey: (item: T) => string): T[] {
 	const seen = new Set<string>();
@@ -173,8 +211,20 @@ function normalizeFsPath(path: string | null | undefined): string {
 
 function isLikelyConfigCommand(name: string, description: string): boolean {
 	const haystack = `${name} ${description}`.toLowerCase();
-	return /(^|[-_\s])config(?:$|[-_\s])/.test(haystack) ||
+	return /\bconfig\b/.test(haystack) ||
 		/(^|\b)(configure|settings|setup)(\b|$)/.test(haystack);
+}
+
+function normalizeCommandNameForMatch(name: string): string {
+	const normalized = name.trim().toLowerCase();
+	return normalized.startsWith("/") ? normalized.slice(1) : normalized;
+}
+
+function commandNamesMatch(left: string, right: string): boolean {
+	const leftName = normalizeCommandNameForMatch(left);
+	const rightName = normalizeCommandNameForMatch(right);
+	if (!leftName || !rightName) return false;
+	return leftName === rightName;
 }
 
 function npmPackageNameFromSource(source: string): string {
@@ -191,8 +241,75 @@ function pathMatchesNpmPackage(normalizedPath: string, source: string): boolean 
 }
 
 function commandLikelyNeedsModelArg(command: PackageConfigCommand): boolean {
+	const normalizedName = normalizeCommandNameForMatch(command.name);
+	if (AUTO_RENAME_COMMAND_NAMES.has(normalizedName)) return true;
 	const haystack = `${command.name} ${command.description}`.toLowerCase();
 	return /(^|\b)(model|provider)(\b|$)/.test(haystack) || haystack.includes("provider/model");
+}
+
+function extensionCommandUsageHint(name: string): string | null {
+	const normalizedName = normalizeCommandNameForMatch(name);
+	if (AUTO_RENAME_COMMAND_NAMES.has(normalizedName)) {
+		return "Args: config, test, init, regen, <name>";
+	}
+	return null;
+}
+
+function withExtensionCommandUsageHint(name: string, description: string): string {
+	const hint = extensionCommandUsageHint(name);
+	if (!hint) return description;
+	const normalized = description.trim();
+	if (!normalized) return hint;
+	if (normalized.toLowerCase().includes("config") && normalized.toLowerCase().includes("test")) {
+		return normalized;
+	}
+	return `${normalized} · ${hint}`;
+}
+
+function normalizeAutoRenameConfigDraft(raw: Record<string, unknown>): AutoRenameConfigDraft {
+	const defaults = defaultAutoRenameConfigDraft();
+	let model = "";
+	const modelRaw = raw.model;
+	if (typeof modelRaw === "string" && splitModelRef(modelRaw)) {
+		model = modelRaw.trim();
+	} else if (modelRaw && typeof modelRaw === "object" && !Array.isArray(modelRaw)) {
+		const modelObj = modelRaw as Record<string, unknown>;
+		const provider = readString(modelObj.provider);
+		const id = readString(modelObj.id);
+		if (provider && id) model = modelRef(provider, id);
+	}
+	if (!model) {
+		model = readModelRefFromConfigObject(raw) || "";
+	}
+
+	let fallbackModel = "";
+	const fallbackRaw = raw.fallbackModel;
+	if (typeof fallbackRaw === "string" && splitModelRef(fallbackRaw)) {
+		fallbackModel = fallbackRaw.trim();
+	} else if (fallbackRaw && typeof fallbackRaw === "object" && !Array.isArray(fallbackRaw)) {
+		const fallbackObj = fallbackRaw as Record<string, unknown>;
+		const provider = readString(fallbackObj.provider);
+		const id = readString(fallbackObj.id);
+		if (provider && id) fallbackModel = modelRef(provider, id);
+	}
+	return {
+		enabled: readBoolean(raw.enabled) ?? defaults.enabled,
+		modelSelection: readString(raw.modelSelection) === "cheapest" ? "cheapest" : "current",
+		model,
+		fallbackModel,
+		fallbackDeterministic:
+			readString(raw.fallbackDeterministic) === "truncate" ||
+			readString(raw.fallbackDeterministic) === "words" ||
+			readString(raw.fallbackDeterministic) === "none" ||
+			readString(raw.fallbackDeterministic) === "readable-id"
+				? (readString(raw.fallbackDeterministic) as AutoRenameConfigDraft["fallbackDeterministic"])
+				: defaults.fallbackDeterministic,
+		prefix: readString(raw.prefix),
+		prefixCommand: readString(raw.prefixCommand),
+		prefixOnly: readBoolean(raw.prefixOnly) ?? defaults.prefixOnly,
+		readableIdSuffix: readBoolean(raw.readableIdSuffix) ?? defaults.readableIdSuffix,
+		debug: readBoolean(raw.debug) ?? defaults.debug,
+	};
 }
 
 function modelRef(provider: string, id: string): string {
@@ -383,6 +500,10 @@ function readString(value: unknown): string {
 	return typeof value === "string" ? value.trim() : "";
 }
 
+function readBoolean(value: unknown): boolean | null {
+	return typeof value === "boolean" ? value : null;
+}
+
 function normalizeSourceScope(value: string): "user" | "project" | null {
 	const normalized = value.trim().toLowerCase();
 	if (normalized === "user" || normalized === "global") return "user";
@@ -470,6 +591,19 @@ export class PackagesView {
 	private packageConfigStatus = "";
 	private packageConfigCommandArgs = new Map<string, string>();
 	private packageConfigLoadedModelBySource = new Map<string, string>();
+	private autoRenameConfig = defaultAutoRenameConfigDraft();
+	private autoRenameConfigRaw: Record<string, unknown> = {};
+	private autoRenameConfigPath = "";
+	private autoRenameConfigScopeLabel = "";
+	private autoRenameConfigSaveScope: "global" | "project" = "global";
+	private autoRenameConfigTargetProjectId = "";
+	private autoRenameConfigTargetProjectPath = "";
+	private autoRenameProjectOptions: PackageProjectOption[] = [];
+	private projectOptionsProvider: (() => PackageProjectOption[]) | null = null;
+	private autoRenameConfigLoading = false;
+	private autoRenameConfigSaving = false;
+	private autoRenameConfigLoadedSource = "";
+	private autoRenameConfigError = "";
 	private configModels: ModelOption[] = [];
 	private configModelsLoading = false;
 	private configModelsLoaded = false;
@@ -518,7 +652,54 @@ export class PackagesView {
 			this.resourceEditorScope = "global";
 		}
 		this.resourceCreatorScope = "global";
+		this.refreshAutoRenameProjectOptions();
 		this.render();
+	}
+
+	setProjectOptionsProvider(cb: (() => PackageProjectOption[]) | null): void {
+		this.projectOptionsProvider = cb;
+		this.refreshAutoRenameProjectOptions();
+		this.render();
+	}
+
+	private refreshAutoRenameProjectOptions(): void {
+		const providerItems = this.projectOptionsProvider ? this.projectOptionsProvider() : [];
+		const merged = uniqueBy(
+			[
+				...providerItems
+					.filter((item) => item && item.id && item.path)
+					.map((item) => ({ id: item.id, name: item.name || item.path, path: item.path })),
+				...(this.currentProjectPath
+					? [{ id: `current:${normalizeFsPath(this.currentProjectPath)}`, name: pathBaseName(this.currentProjectPath), path: this.currentProjectPath }]
+					: []),
+			],
+			(item) => normalizeFsPath(item.path),
+		).sort((a, b) => a.name.localeCompare(b.name));
+		this.autoRenameProjectOptions = merged;
+
+		if (this.autoRenameConfigSaveScope === "project") {
+			const selected = this.autoRenameProjectOptions.find((item) => item.id === this.autoRenameConfigTargetProjectId)
+				?? this.autoRenameProjectOptions.find((item) => normalizeFsPath(item.path) === normalizeFsPath(this.autoRenameConfigTargetProjectPath))
+				?? (this.currentProjectPath
+					? this.autoRenameProjectOptions.find((item) => normalizeFsPath(item.path) === normalizeFsPath(this.currentProjectPath))
+					: null)
+				?? this.autoRenameProjectOptions[0]
+				?? null;
+			if (selected) {
+				this.autoRenameConfigTargetProjectId = selected.id;
+				this.autoRenameConfigTargetProjectPath = selected.path;
+			} else {
+				this.autoRenameConfigSaveScope = "global";
+				this.autoRenameConfigTargetProjectId = "";
+				this.autoRenameConfigTargetProjectPath = "";
+			}
+		} else if (!this.autoRenameConfigTargetProjectPath && this.currentProjectPath) {
+			const currentMatch = this.autoRenameProjectOptions.find((item) => normalizeFsPath(item.path) === normalizeFsPath(this.currentProjectPath));
+			if (currentMatch) {
+				this.autoRenameConfigTargetProjectId = currentMatch.id;
+				this.autoRenameConfigTargetProjectPath = currentMatch.path;
+			}
+		}
 	}
 
 	setOnBack(cb: () => void): void {
@@ -805,9 +986,10 @@ export class PackagesView {
 		for (const raw of commands) {
 			const source = readString(raw.source).toLowerCase();
 			const name = readString(raw.name);
-			const description = readString(raw.description);
+			const baseDescription = readString(raw.description);
 			const sourceInfo = readCommandSourceInfo(raw);
 			if (source !== "extension" || !name) continue;
+			const description = withExtensionCommandUsageHint(name, baseDescription);
 			if (!isLikelyConfigCommand(name, description)) continue;
 
 			const matchedPackage = this.findInstalledItemForCommand(
@@ -1250,6 +1432,316 @@ export class PackagesView {
 		return this.getInstalledItems(false).some((item) => normalizeRecommendedSource(item.source) === normalizedSource);
 	}
 
+	private isAutoRenameSource(source: string): boolean {
+		const normalized = normalizeRecommendedSource(source);
+		return normalized === AUTO_RENAME_PRIMARY_SOURCE || normalized === AUTO_RENAME_LEGACY_SOURCE;
+	}
+
+	private isAutoRenameConfigCommand(source: string, command: PackageConfigCommand): boolean {
+		const normalizedName = normalizeCommandNameForMatch(command.name);
+		if (AUTO_RENAME_COMMAND_NAMES.has(normalizedName)) return true;
+		return this.isAutoRenameSource(source);
+	}
+
+	private resolveAutoRenameCommandForSource(source: string): PackageConfigCommand | null {
+		const commands = this.packageConfigCommands.get(source) ?? [];
+		for (const command of commands) {
+			if (this.isAutoRenameConfigCommand(source, command)) return command;
+		}
+		return null;
+	}
+
+	private resolveGlobalAutoRenameConfigPath(): string {
+		if (!this.homePath) return "";
+		return joinFsPath(joinFsPath(joinFsPath(this.homePath, ".pi"), "agent"), "auto-rename.json");
+	}
+
+	private resolveProjectOptionForPath(path: string): PackageProjectOption | null {
+		const normalized = normalizeFsPath(path);
+		if (!normalized) return null;
+		const sorted = [...this.autoRenameProjectOptions]
+			.sort((a, b) => normalizeFsPath(b.path).length - normalizeFsPath(a.path).length);
+		for (const option of sorted) {
+			const projectPath = normalizeFsPath(option.path);
+			if (!projectPath) continue;
+			if (normalized === projectPath || normalized.startsWith(`${projectPath}/`)) {
+				return option;
+			}
+		}
+		return null;
+	}
+
+	private async findExistingProjectAutoRenameConfig(projectPath: string): Promise<{ path: string; scopeLabel: string } | null> {
+		const normalizedProjectPath = projectPath.trim();
+		if (!normalizedProjectPath) return null;
+		const { exists } = await import("@tauri-apps/plugin-fs");
+		const option = this.resolveProjectOptionForPath(normalizedProjectPath);
+		const projectLabel = option?.name || pathBaseName(normalizedProjectPath) || "Project";
+		const candidates = [
+			joinFsPath(normalizedProjectPath, "auto-rename.json"),
+			joinFsPath(joinFsPath(normalizedProjectPath, ".pi"), "auto-rename.json"),
+		];
+		for (const candidate of candidates) {
+			try {
+				if (await exists(candidate)) {
+					return { path: candidate, scopeLabel: `Project · ${projectLabel}` };
+				}
+			} catch {
+				// ignore path errors
+			}
+		}
+		return null;
+	}
+
+	private async resolveProjectAutoRenameConfigPath(projectPath: string): Promise<{ path: string; scopeLabel: string }> {
+		const normalizedProjectPath = projectPath.trim();
+		if (!normalizedProjectPath) return { path: "", scopeLabel: "" };
+		const existing = await this.findExistingProjectAutoRenameConfig(normalizedProjectPath);
+		if (existing) return existing;
+		const option = this.resolveProjectOptionForPath(normalizedProjectPath);
+		const projectLabel = option?.name || pathBaseName(normalizedProjectPath) || "Project";
+		return {
+			path: joinFsPath(joinFsPath(normalizedProjectPath, ".pi"), "auto-rename.json"),
+			scopeLabel: `Project · ${projectLabel}`,
+		};
+	}
+
+	private applyAutoRenameScopeFromPath(path: string): void {
+		const normalized = normalizeFsPath(path);
+		const globalPath = normalizeFsPath(this.resolveGlobalAutoRenameConfigPath());
+		if (normalized && globalPath && normalized === globalPath) {
+			this.autoRenameConfigSaveScope = "global";
+			this.autoRenameConfigTargetProjectId = "";
+			this.autoRenameConfigTargetProjectPath = "";
+			return;
+		}
+		const projectOption = this.resolveProjectOptionForPath(path)
+			?? this.autoRenameProjectOptions.find((item) => normalizeFsPath(item.path) === normalizeFsPath(this.currentProjectPath))
+			?? this.autoRenameProjectOptions[0]
+			?? null;
+		if (projectOption) {
+			this.autoRenameConfigSaveScope = "project";
+			this.autoRenameConfigTargetProjectId = projectOption.id;
+			this.autoRenameConfigTargetProjectPath = projectOption.path;
+		}
+	}
+
+	private async resolveAutoRenameConfigPathPreference(options?: {
+		scope?: "global" | "project";
+		projectPath?: string | null;
+	}): Promise<{ path: string; scopeLabel: string }> {
+		await this.ensureHomePath();
+		this.refreshAutoRenameProjectOptions();
+
+		const requestedScope = options?.scope;
+		const requestedProjectPath = options?.projectPath?.trim() || "";
+		const globalPath = this.resolveGlobalAutoRenameConfigPath();
+
+		if (requestedScope === "global") {
+			return { path: globalPath, scopeLabel: "Global" };
+		}
+
+		if (requestedScope === "project") {
+			const projectPath = requestedProjectPath || this.autoRenameConfigTargetProjectPath || this.currentProjectPath || "";
+			if (!projectPath) {
+				throw new Error("No project selected for project-scoped auto-rename settings.");
+			}
+			return await this.resolveProjectAutoRenameConfigPath(projectPath);
+		}
+
+		const preferredProjectPaths = uniqueBy(
+			[this.autoRenameConfigTargetProjectPath, this.currentProjectPath || ""].filter((entry) => entry && entry.trim().length > 0),
+			(entry) => normalizeFsPath(entry),
+		);
+		for (const projectPath of preferredProjectPaths) {
+			const existing = await this.findExistingProjectAutoRenameConfig(projectPath);
+			if (existing) return existing;
+		}
+
+		if (globalPath) {
+			const { exists } = await import("@tauri-apps/plugin-fs");
+			try {
+				if (await exists(globalPath)) {
+					return { path: globalPath, scopeLabel: "Global" };
+				}
+			} catch {
+				// ignore exists errors
+			}
+		}
+
+		if (preferredProjectPaths.length > 0) {
+			return await this.resolveProjectAutoRenameConfigPath(preferredProjectPaths[0]);
+		}
+		if (globalPath) {
+			return { path: globalPath, scopeLabel: "Global" };
+		}
+		return { path: "", scopeLabel: "" };
+	}
+
+	private async ensureAutoRenameConfigLoaded(
+		source: string,
+		force = false,
+		options?: { scope?: "global" | "project"; projectPath?: string | null },
+	): Promise<void> {
+		const normalizedSource = normalizeRecommendedSource(source);
+		const preferred = await this.resolveAutoRenameConfigPathPreference(options);
+		if (!force && this.autoRenameConfigLoadedSource === normalizedSource && normalizeFsPath(this.autoRenameConfigPath) === normalizeFsPath(preferred.path)) {
+			return;
+		}
+		if (this.autoRenameConfigLoading) return;
+		this.autoRenameConfigLoading = true;
+		this.autoRenameConfigError = "";
+		this.render();
+		try {
+			this.autoRenameConfigPath = preferred.path;
+			this.autoRenameConfigScopeLabel = preferred.scopeLabel;
+			this.autoRenameConfigRaw = {};
+			this.autoRenameConfig = defaultAutoRenameConfigDraft();
+
+			if (preferred.path) {
+				const { exists, readTextFile } = await import("@tauri-apps/plugin-fs");
+				if (await exists(preferred.path)) {
+					const rawText = await readTextFile(preferred.path);
+					const parsedUnknown = JSON.parse(rawText) as unknown;
+					if (parsedUnknown && typeof parsedUnknown === "object" && !Array.isArray(parsedUnknown)) {
+						const parsed = parsedUnknown as Record<string, unknown>;
+						this.autoRenameConfigRaw = parsed;
+						this.autoRenameConfig = normalizeAutoRenameConfigDraft(parsed);
+					}
+				}
+			}
+			this.applyAutoRenameScopeFromPath(preferred.path);
+			if (options?.scope === "project" && options.projectPath?.trim()) {
+				const selected = this.resolveProjectOptionForPath(options.projectPath.trim());
+				if (selected) {
+					this.autoRenameConfigTargetProjectId = selected.id;
+					this.autoRenameConfigTargetProjectPath = selected.path;
+				}
+			}
+			if (options?.scope === "global") {
+				this.autoRenameConfigSaveScope = "global";
+			}
+			this.autoRenameConfigLoadedSource = normalizedSource;
+		} catch (err) {
+			this.autoRenameConfigRaw = {};
+			this.autoRenameConfig = defaultAutoRenameConfigDraft();
+			this.autoRenameConfigError = err instanceof Error ? err.message : String(err);
+		} finally {
+			this.autoRenameConfigLoading = false;
+			this.render();
+		}
+	}
+
+	private async setAutoRenameSaveScope(source: string, scope: "global" | "project"): Promise<void> {
+		this.autoRenameConfigSaveScope = scope;
+		if (scope === "project") {
+			this.refreshAutoRenameProjectOptions();
+			const selected = this.autoRenameProjectOptions.find((item) => item.id === this.autoRenameConfigTargetProjectId)
+				?? this.autoRenameProjectOptions.find((item) => normalizeFsPath(item.path) === normalizeFsPath(this.currentProjectPath))
+				?? this.autoRenameProjectOptions[0]
+				?? null;
+			if (!selected) {
+				this.autoRenameConfigError = "No opened project is available for project-scoped save.";
+				this.render();
+				return;
+			}
+			this.autoRenameConfigTargetProjectId = selected.id;
+			this.autoRenameConfigTargetProjectPath = selected.path;
+			await this.ensureAutoRenameConfigLoaded(source, true, { scope: "project", projectPath: selected.path });
+			return;
+		}
+		this.autoRenameConfigTargetProjectId = "";
+		this.autoRenameConfigTargetProjectPath = "";
+		await this.ensureAutoRenameConfigLoaded(source, true, { scope: "global" });
+	}
+
+	private async setAutoRenameTargetProject(source: string, projectId: string): Promise<void> {
+		const selected = this.autoRenameProjectOptions.find((item) => item.id === projectId) ?? null;
+		if (!selected) return;
+		this.autoRenameConfigTargetProjectId = selected.id;
+		this.autoRenameConfigTargetProjectPath = selected.path;
+		this.autoRenameConfigSaveScope = "project";
+		await this.ensureAutoRenameConfigLoaded(source, true, { scope: "project", projectPath: selected.path });
+	}
+
+	private setAutoRenameConfigField<K extends keyof AutoRenameConfigDraft>(key: K, value: AutoRenameConfigDraft[K]): void {
+		this.autoRenameConfig = {
+			...this.autoRenameConfig,
+			[key]: value,
+		};
+		this.render();
+	}
+
+	private async saveAutoRenameConfig(source: string): Promise<void> {
+		if (this.autoRenameConfigSaving || this.runningConfigCommand || this.runningCommand) return;
+		this.autoRenameConfigSaving = true;
+		this.autoRenameConfigError = "";
+		this.packageConfigStatus = "Saving auto-rename settings…";
+		this.render();
+		try {
+			const targetScope = this.autoRenameConfigSaveScope;
+			const targetProjectPath = targetScope === "project" ? this.autoRenameConfigTargetProjectPath : "";
+			if (targetScope === "project" && !targetProjectPath) {
+				throw new Error("Choose a project for project-scoped save.");
+			}
+			const preferred = await this.resolveAutoRenameConfigPathPreference({
+				scope: targetScope,
+				projectPath: targetProjectPath,
+			});
+			const configPath = preferred.path;
+			const scopeLabel = preferred.scopeLabel;
+			this.autoRenameConfigPath = configPath;
+			this.autoRenameConfigScopeLabel = scopeLabel;
+			if (!configPath) {
+				throw new Error("Could not resolve auto-rename config path.");
+			}
+
+			const primaryModelValue = this.autoRenameConfig.model.trim();
+			const fallbackModelValue = this.autoRenameConfig.fallbackModel.trim();
+			const primaryModel = primaryModelValue ? splitModelRef(primaryModelValue) : null;
+			const fallbackModel = fallbackModelValue ? splitModelRef(fallbackModelValue) : null;
+
+			if (primaryModelValue && !primaryModel) {
+				throw new Error("Primary model must use provider/model format.");
+			}
+			if (fallbackModelValue && !fallbackModel) {
+				throw new Error("Fallback model must use provider/model format.");
+			}
+
+			const nextDoc: Record<string, unknown> = {
+				...this.autoRenameConfigRaw,
+				$schema: readString(this.autoRenameConfigRaw.$schema) || AUTO_RENAME_SCHEMA_RELATIVE,
+				model: primaryModel ? { provider: primaryModel.provider, id: primaryModel.id } : null,
+				fallbackModel: fallbackModel ? { provider: fallbackModel.provider, id: fallbackModel.id } : null,
+				modelSelection: this.autoRenameConfig.modelSelection,
+				fallbackDeterministic: this.autoRenameConfig.fallbackDeterministic,
+				prefix: this.autoRenameConfig.prefix,
+				prefixCommand: this.autoRenameConfig.prefixCommand.trim() ? this.autoRenameConfig.prefixCommand.trim() : null,
+				prefixOnly: this.autoRenameConfig.prefixOnly,
+				readableIdSuffix: this.autoRenameConfig.readableIdSuffix,
+				enabled: this.autoRenameConfig.enabled,
+				debug: this.autoRenameConfig.debug,
+			};
+
+			const { mkdir, writeTextFile } = await import("@tauri-apps/plugin-fs");
+			await mkdir(pathDirName(configPath), { recursive: true });
+			await writeTextFile(configPath, `${JSON.stringify(nextDoc, null, 2)}\n`);
+
+			this.autoRenameConfigRaw = nextDoc;
+			this.autoRenameConfigLoadedSource = normalizeRecommendedSource(source);
+			this.packageConfigStatus = `Saved auto-rename settings to ${configPath}${scopeLabel ? ` (${scopeLabel})` : ""}.`;
+			this.commandStatus = "Saved auto-rename settings.";
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			this.autoRenameConfigError = message;
+			this.packageConfigStatus = `Failed to save auto-rename settings: ${message}`;
+			this.commandStatus = `Auto-rename settings failed: ${message}`;
+		} finally {
+			this.autoRenameConfigSaving = false;
+			this.render();
+		}
+	}
+
 	private async openPackageConfig(item: InstalledDisplayItem): Promise<void> {
 		const source = normalizeRecommendedSource(item.source);
 		const commands = this.getConfigCommandsForItem(item);
@@ -1284,6 +1776,115 @@ export class PackagesView {
 		};
 		await this.openPackagesItemModal({ kind: "extension", item });
 		return true;
+	}
+
+	private async findInstalledItemForExtensionCommand(commandName: string): Promise<InstalledDisplayItem | null> {
+		const normalizedCommand = normalizeCommandNameForMatch(commandName);
+		if (!normalizedCommand) return null;
+		const installedItems = this.getInstalledItems(false);
+		if (installedItems.length === 0) return null;
+
+		let commands: Array<Record<string, unknown>> = [];
+		try {
+			commands = await rpcBridge.getCommands();
+		} catch {
+			return null;
+		}
+
+		for (const raw of commands) {
+			const source = readString(raw.source).toLowerCase();
+			const name = readString(raw.name);
+			if (source !== "extension" || !name) continue;
+			if (!commandNamesMatch(name, normalizedCommand)) continue;
+
+			const sourceInfo = readCommandSourceInfo(raw);
+			const matchedPackage = this.findInstalledItemForCommand(
+				{
+					path: sourceInfo.path,
+					sourceHint: sourceInfo.source,
+					baseDir: sourceInfo.baseDir,
+				},
+				installedItems,
+			);
+			if (matchedPackage) return matchedPackage;
+		}
+
+		return null;
+	}
+
+	private ensureSyntheticExtensionConfigCommand(
+		source: string,
+		commandName: string,
+		args: string,
+		installed: InstalledDisplayItem | null,
+	): void {
+		const normalizedSource = normalizeRecommendedSource(source);
+		const normalizedCommand = normalizeCommandNameForMatch(commandName);
+		if (!normalizedSource || !normalizedCommand) return;
+
+		const currentCommands = [...(this.packageConfigCommands.get(normalizedSource) ?? [])];
+		if (!currentCommands.some((command) => commandNamesMatch(command.name, normalizedCommand))) {
+			const hintedDescription = withExtensionCommandUsageHint(
+				normalizedCommand,
+				"Run extension config command",
+			);
+			currentCommands.push({
+				name: normalizedCommand,
+				description: hintedDescription,
+				path: installed?.location || "",
+			});
+			currentCommands.sort((a, b) => a.name.localeCompare(b.name));
+			this.packageConfigCommands.set(normalizedSource, currentCommands);
+		}
+
+		if (args.trim()) {
+			this.setPackageConfigCommandArg(normalizedSource, normalizedCommand, args.trim());
+		}
+	}
+
+	async openExtensionConfigByCommand(commandName: string, args = ""): Promise<boolean> {
+		const normalizedCommand = normalizeCommandNameForMatch(commandName);
+		if (!normalizedCommand) return false;
+
+		const normalizedArgs = args.trim().toLowerCase();
+		const configIntent =
+			normalizedCommand.endsWith("config") ||
+			normalizedArgs === "config" ||
+			normalizedArgs.startsWith("config ");
+		if (!configIntent) return false;
+
+		await this.refreshPackageConfigCommands();
+
+		for (const [source, commands] of this.packageConfigCommands.entries()) {
+			if (!commands.some((command) => commandNamesMatch(command.name, normalizedCommand))) continue;
+			if (args.trim()) {
+				this.setPackageConfigCommandArg(source, normalizedCommand, args.trim());
+			}
+			return await this.openExtensionConfigBySource(source);
+		}
+
+		const installed = await this.findInstalledItemForExtensionCommand(normalizedCommand);
+		if (installed) {
+			const source = normalizeRecommendedSource(installed.source);
+			this.ensureSyntheticExtensionConfigCommand(source, normalizedCommand, args, installed);
+			return await this.openExtensionConfigBySource(source);
+		}
+
+		const heuristicMatches = this.getInstalledItems(false).filter((item) => {
+			const normalizedSource = normalizeRecommendedSource(item.source);
+			const sourceName = normalizedSource.startsWith("npm:") ? normalizedSource.slice(4) : normalizedSource;
+			const sourceTail = sourceName.split("/").filter(Boolean).pop() || sourceName;
+			const display = item.displayName.toLowerCase();
+			return display.includes(normalizedCommand) || sourceName.includes(normalizedCommand) || sourceTail.includes(normalizedCommand);
+		});
+		if (heuristicMatches.length === 1) {
+			const match = heuristicMatches[0];
+			const source = normalizeRecommendedSource(match.source);
+			this.ensureSyntheticExtensionConfigCommand(source, normalizedCommand, args, match);
+			return await this.openExtensionConfigBySource(source);
+		}
+
+		return false;
 	}
 
 	private closeActivePackageConfig(): void {
@@ -1382,7 +1983,7 @@ export class PackagesView {
 								value = modelFromObject;
 							} else {
 								for (const k of Object.keys(parsed)) {
-									if (!/model|name-ai-config/i.test(k)) continue;
+									if (!/model|name-ai-config|auto-rename/i.test(k)) continue;
 									const raw = parsed[k];
 									if (typeof raw === "string" && raw.trim()) {
 										value = raw.trim();
@@ -1426,8 +2027,10 @@ export class PackagesView {
 		const trimmedArgs = args.trim();
 		const promptText = trimmedArgs ? `${slashCommand} ${trimmedArgs}` : slashCommand;
 		const supportsModelPicker = commandLikelyNeedsModelArg(command);
-		const actionVerb = supportsModelPicker ? "save" : "apply";
-		const actionVerbPast = supportsModelPicker ? "Saved" : "Applied";
+		const parsedModelArg = splitModelRef(trimmedArgs);
+		const isModelSave = supportsModelPicker && Boolean(parsedModelArg || !trimmedArgs);
+		const actionVerb = isModelSave ? "save" : "run";
+		const actionVerbPast = isModelSave ? "Saved" : "Ran";
 		this.packageConfigStatus = `${actionVerb[0].toUpperCase()}${actionVerb.slice(1)} package setting…`;
 		this.render();
 		try {
@@ -1436,18 +2039,18 @@ export class PackagesView {
 			this.commandStatus = `${actionVerbPast} package setting for ${this.activePackageConfigLabel || "package"}.`;
 			this.commandOutput += `${this.commandOutput ? "\n" : ""}[package-config] ${promptText}\n`;
 
-			if (supportsModelPicker && this.activePackageConfigSource && trimmedArgs) {
+			if (supportsModelPicker && this.activePackageConfigSource && parsedModelArg) {
 				this.packageConfigLoadedModelBySource.set(normalizeRecommendedSource(this.activePackageConfigSource), trimmedArgs);
 			}
 
 			// Persist model-picker changes to canonical extension config file when possible.
-			if (supportsModelPicker && this.activePackageConfigSource) {
+			if (supportsModelPicker && this.activePackageConfigSource && parsedModelArg) {
 				try {
 					const normalized = this.activePackageConfigSource;
 					const installed = this.findInstalledItemForSource(normalized, "global");
 					const basePath = installed?.location?.trim() || command.path?.trim() || "";
 					const key = command.name.startsWith("/") ? command.name.slice(1) : command.name;
-					const parsedModel = splitModelRef(trimmedArgs);
+					const parsedModel = parsedModelArg;
 					const pkgName = this.getDisplayName(normalized);
 					await this.ensureHomePath();
 					const { exists, readTextFile, writeTextFile, stat, mkdir } = await import("@tauri-apps/plugin-fs");
@@ -1529,6 +2132,9 @@ export class PackagesView {
 	}
 
 	private renderPackageConfigCommandEditor(source: string, command: PackageConfigCommand): TemplateResult {
+		if (this.isAutoRenameConfigCommand(source, command)) {
+			return this.renderAutoRenameConfigEditor(source, command);
+		}
 		const supportsModelPicker = commandLikelyNeedsModelArg(command);
 		const sourceLoadedModel = this.packageConfigLoadedModelBySource.get(normalizeRecommendedSource(source)) || "";
 		const currentArgs = this.getPackageConfigCommandArg(source, command.name) || (supportsModelPicker ? sourceLoadedModel : "");
@@ -1594,6 +2200,312 @@ export class PackagesView {
 						${this.runningConfigCommand ? buttonBusyLabel : buttonLabel}
 					</button>
 				</div>
+			</div>
+		`;
+	}
+
+	private renderAutoRenameConfigEditor(source: string, command: PackageConfigCommand): TemplateResult {
+		const busy = this.runningConfigCommand || this.runningCommand || this.autoRenameConfigSaving;
+		const modelOptions = this.configModels;
+		const modelValue = this.autoRenameConfig.model;
+		const fallbackModelValue = this.autoRenameConfig.fallbackModel;
+		const usageHint = extensionCommandUsageHint(command.name) || "Args: config, test, init, regen, <name>";
+		const supportsProjectScope = Boolean(this.currentProjectPath);
+		const configScopeLabel = this.autoRenameConfigScopeLabel || (supportsProjectScope ? "Project (.pi)" : "Global");
+		const projectOptions = this.autoRenameProjectOptions;
+		const canUseProjectScope = projectOptions.length > 0;
+		const saveScope = this.autoRenameConfigSaveScope;
+		const activeProjectTarget = projectOptions.find((item) => item.id === this.autoRenameConfigTargetProjectId)
+			?? projectOptions.find((item) => normalizeFsPath(item.path) === normalizeFsPath(this.autoRenameConfigTargetProjectPath))
+			?? null;
+		const hasPrimaryModel = modelValue.trim().length > 0;
+		const hasFallbackModel = fallbackModelValue.trim().length > 0;
+		const primaryInOptions = modelOptions.some((model) => modelRef(model.provider, model.id) === modelValue);
+		const fallbackInOptions = modelOptions.some((model) => modelRef(model.provider, model.id) === fallbackModelValue);
+		const hasExplicitModels = hasPrimaryModel || hasFallbackModel;
+		const extensionDisabled = !this.autoRenameConfig.enabled;
+		const prefixOnlyActive = this.autoRenameConfig.prefixOnly;
+
+		const modelControlsDisabled = busy || extensionDisabled || prefixOnlyActive;
+		const modeControlsDisabled = busy || extensionDisabled || prefixOnlyActive || hasExplicitModels;
+		const basicControlsDisabled = busy || extensionDisabled;
+		const targetProjectMissing = saveScope === "project" && !activeProjectTarget;
+		const saveDisabled = busy || this.autoRenameConfigLoading || targetProjectMissing;
+
+		const autoModeHelper = extensionDisabled
+			? "Auto mode is disabled while auto-rename is turned off."
+			: prefixOnlyActive
+				? "Auto mode is disabled in prefix-only mode."
+				: hasExplicitModels
+					? "Auto mode is locked while Primary/Fallback model is set. Clear those to use auto mode."
+					: this.autoRenameConfig.modelSelection === "current"
+						? "Auto mode: use the currently selected chat model first."
+						: "Auto mode: use the cheapest available model first.";
+
+		const resolutionOrder = [
+			hasPrimaryModel ? `Primary (${modelValue})` : null,
+			hasFallbackModel ? `Fallback (${fallbackModelValue})` : null,
+			`Auto (${this.autoRenameConfig.modelSelection})`,
+		]
+			.filter((entry): entry is string => Boolean(entry))
+			.join(" → ");
+
+		const boolSelect = (value: boolean): string => (value ? "true" : "false");
+
+		return html`
+			<div class="packages-config-command-card">
+				<div class="packages-config-command-name">Auto-rename settings</div>
+				<div class="packages-config-command-desc">${usageHint}</div>
+				<div class="packages-section-submeta">Resolution order: ${resolutionOrder}</div>
+
+				${this.autoRenameConfigLoading
+					? html`<div class="packages-section-submeta">Loading auto-rename configuration…</div>`
+					: html`
+						<div class="packages-config-field-grid">
+							<div class="packages-config-toggle-row ${busy ? "disabled" : ""}">
+								<span class="packages-config-field-label">Enabled</span>
+								<label class="packages-config-toggle-switch" aria-label="Enabled">
+									<input
+										type="checkbox"
+										class="packages-config-toggle-input"
+										?checked=${this.autoRenameConfig.enabled}
+										?disabled=${busy}
+										@change=${(event: Event) => {
+											const value = (event.target as HTMLInputElement).checked;
+											this.setAutoRenameConfigField("enabled", value);
+										}}
+									/>
+									<span class="packages-config-toggle-slider"></span>
+								</label>
+							</div>
+							<div class="packages-config-toggle-row ${busy || extensionDisabled ? "disabled" : ""}">
+								<span class="packages-config-field-label">Prefix-only mode</span>
+								<label class="packages-config-toggle-switch" aria-label="Prefix-only mode">
+									<input
+										type="checkbox"
+										class="packages-config-toggle-input"
+										?checked=${this.autoRenameConfig.prefixOnly}
+										?disabled=${busy || extensionDisabled}
+										@change=${(event: Event) => {
+											const value = (event.target as HTMLInputElement).checked;
+											this.setAutoRenameConfigField("prefixOnly", value);
+										}}
+									/>
+									<span class="packages-config-toggle-slider"></span>
+								</label>
+							</div>
+						</div>
+
+						<div class="packages-config-field-grid">
+							<div class="packages-config-field">
+								<label class="packages-config-field-label">Primary model</label>
+								<select
+									class="packages-config-select"
+									.value=${modelValue}
+									?disabled=${modelControlsDisabled || this.configModelsLoading}
+									@change=${(event: Event) => {
+										const value = (event.target as HTMLSelectElement).value;
+										this.setAutoRenameConfigField("model", value);
+									}}
+								>
+									<option value="">None (use auto mode)</option>
+									${hasPrimaryModel && !primaryInOptions ? html`<option value=${modelValue}>${modelValue} (saved)</option>` : nothing}
+									${modelOptions.map((model) => {
+										const ref = modelRef(model.provider, model.id);
+										return html`<option value=${ref} ?selected=${modelValue === ref}>${model.label}</option>`;
+									})}
+								</select>
+							</div>
+							<div class="packages-config-field">
+								<label class="packages-config-field-label">Fallback model</label>
+								<select
+									class="packages-config-select"
+									.value=${fallbackModelValue}
+									?disabled=${modelControlsDisabled || this.configModelsLoading}
+									@change=${(event: Event) => {
+										const value = (event.target as HTMLSelectElement).value;
+										this.setAutoRenameConfigField("fallbackModel", value);
+									}}
+								>
+									<option value="">None</option>
+									${hasFallbackModel && !fallbackInOptions ? html`<option value=${fallbackModelValue}>${fallbackModelValue} (saved)</option>` : nothing}
+									${modelOptions.map((model) => {
+										const ref = modelRef(model.provider, model.id);
+										return html`<option value=${ref} ?selected=${fallbackModelValue === ref}>${model.label}</option>`;
+									})}
+								</select>
+							</div>
+						</div>
+
+						<div class="packages-config-field-grid">
+							<div class="packages-config-field">
+								<label class="packages-config-field-label">Auto mode</label>
+								<select
+									class="packages-config-select"
+									.value=${this.autoRenameConfig.modelSelection}
+									?disabled=${modeControlsDisabled}
+									@change=${(event: Event) => {
+										const value = (event.target as HTMLSelectElement).value === "cheapest" ? "cheapest" : "current";
+										this.setAutoRenameConfigField("modelSelection", value);
+									}}
+								>
+									<option value="current">Prefer current model</option>
+									<option value="cheapest">Prefer cheapest model</option>
+								</select>
+							</div>
+							<div class="packages-config-field">
+								<label class="packages-config-field-label">Prefix</label>
+								<input
+									class="packages-config-input"
+									type="text"
+									placeholder="Optional static prefix"
+									.value=${this.autoRenameConfig.prefix}
+									?disabled=${basicControlsDisabled}
+									@input=${(event: Event) => {
+										const value = (event.target as HTMLInputElement).value;
+										this.setAutoRenameConfigField("prefix", value);
+									}}
+								/>
+							</div>
+						</div>
+
+						<div class="packages-section-submeta">${autoModeHelper}</div>
+
+						<details class="packages-config-advanced">
+							<summary>More options (optional)</summary>
+							<div class="packages-config-field-grid">
+								<div class="packages-config-field">
+									<label class="packages-config-field-label">Deterministic fallback</label>
+									<select
+										class="packages-config-select"
+										.value=${this.autoRenameConfig.fallbackDeterministic}
+										?disabled=${busy || extensionDisabled || prefixOnlyActive}
+										@change=${(event: Event) => {
+											const value = (event.target as HTMLSelectElement).value as AutoRenameConfigDraft["fallbackDeterministic"];
+											this.setAutoRenameConfigField("fallbackDeterministic", value);
+										}}
+									>
+										<option value="readable-id">readable-id</option>
+										<option value="words">words</option>
+										<option value="truncate">truncate</option>
+										<option value="none">none</option>
+									</select>
+								</div>
+								<div class="packages-config-field">
+									<label class="packages-config-field-label">Prefix command</label>
+									<input
+										class="packages-config-input"
+										type="text"
+										placeholder="Optional shell command"
+										.value=${this.autoRenameConfig.prefixCommand}
+										?disabled=${basicControlsDisabled}
+										@input=${(event: Event) => {
+											const value = (event.target as HTMLInputElement).value;
+											this.setAutoRenameConfigField("prefixCommand", value);
+										}}
+									/>
+								</div>
+							</div>
+							<div class="packages-config-field-grid">
+								<div class="packages-config-field">
+									<label class="packages-config-field-label">Readable-id suffix</label>
+									<select
+										class="packages-config-select"
+										.value=${boolSelect(this.autoRenameConfig.readableIdSuffix)}
+										?disabled=${basicControlsDisabled}
+										@change=${(event: Event) => {
+											const value = (event.target as HTMLSelectElement).value === "true";
+											this.setAutoRenameConfigField("readableIdSuffix", value);
+										}}
+									>
+										<option value="false">Off</option>
+										<option value="true">On</option>
+									</select>
+								</div>
+								<div class="packages-config-field">
+									<label class="packages-config-field-label">Debug notifications</label>
+									<select
+										class="packages-config-select"
+										.value=${boolSelect(this.autoRenameConfig.debug)}
+										?disabled=${basicControlsDisabled}
+										@change=${(event: Event) => {
+											const value = (event.target as HTMLSelectElement).value === "true";
+											this.setAutoRenameConfigField("debug", value);
+										}}
+									>
+										<option value="false">Off</option>
+										<option value="true">On</option>
+									</select>
+								</div>
+							</div>
+						</details>
+					`}
+
+				<div class="packages-config-command-actions">
+					<div class="packages-config-save-inline">
+						<span class="packages-config-field-label">Save to</span>
+						<select
+							class="packages-config-select"
+							.value=${saveScope}
+							?disabled=${busy}
+							@change=${(event: Event) => {
+								const value = (event.target as HTMLSelectElement).value === "project" ? "project" : "global";
+								if (value === "project" && !canUseProjectScope) {
+									this.autoRenameConfigError = "No opened projects available for project-scoped save.";
+									this.render();
+									return;
+								}
+								void this.setAutoRenameSaveScope(source, value);
+							}}
+						>
+							<option value="global">Global</option>
+							<option value="project" ?disabled=${!canUseProjectScope}>Project</option>
+						</select>
+						${saveScope === "project"
+							? html`
+								<select
+									class="packages-config-select"
+									.value=${activeProjectTarget?.id || ""}
+									?disabled=${busy || !canUseProjectScope}
+									@change=${(event: Event) => {
+										const nextId = (event.target as HTMLSelectElement).value;
+										void this.setAutoRenameTargetProject(source, nextId);
+									}}
+								>
+									<option value="" ?selected=${!activeProjectTarget}>Select project…</option>
+									${projectOptions.map((item) => html`<option value=${item.id} ?selected=${activeProjectTarget?.id === item.id}>${item.name}</option>`)}
+								</select>
+							`
+							: nothing}
+					</div>
+					<button
+						class="ghost-btn"
+						?disabled=${saveDisabled}
+						@click=${() => void this.saveAutoRenameConfig(source)}
+					>
+						${this.autoRenameConfigSaving ? "Saving…" : "Save settings"}
+					</button>
+					<button
+						class="ghost-btn"
+						?disabled=${this.runningConfigCommand || this.runningCommand || this.autoRenameConfigLoading}
+						@click=${() => void this.runPackageConfigCommand(command, "config")}
+					>
+						Show config
+					</button>
+					<button
+						class="ghost-btn"
+						?disabled=${this.runningConfigCommand || this.runningCommand || this.autoRenameConfigLoading || extensionDisabled}
+						@click=${() => void this.runPackageConfigCommand(command, "test")}
+					>
+						Run test
+					</button>
+				</div>
+
+				${this.autoRenameConfigPath
+					? html`<div class="packages-section-submeta">Config file: ${this.autoRenameConfigPath}${configScopeLabel ? ` (${configScopeLabel})` : ""}</div>`
+					: nothing}
+				${targetProjectMissing ? html`<div class="packages-config-inline-error">Choose a project for project-scoped save.</div>` : nothing}
+				${this.autoRenameConfigError ? html`<div class="packages-config-inline-error">${this.autoRenameConfigError}</div>` : nothing}
 			</div>
 		`;
 	}
@@ -2893,15 +3805,28 @@ Execute the required file creation/edits directly, then summarize exactly which 
 		this.activeSkillContentLoading = false;
 		if (modal.kind === "extension") {
 			const source = normalizeRecommendedSource(modal.item.source);
-			const commands = this.packageConfigCommands.get(source) ?? [];
+			let commands = this.packageConfigCommands.get(source) ?? [];
+			if (commands.length === 0 && this.isAutoRenameSource(source)) {
+				this.ensureSyntheticExtensionConfigCommand(source, "auto-rename", "config", modal.item.installedItemForScope ?? null);
+				commands = this.packageConfigCommands.get(source) ?? [];
+			}
 			this.activePackageConfigSource = source;
 			this.activePackageConfigLabel = modal.item.displayName;
 			this.packageConfigStatus = "";
+			this.autoRenameConfigError = "";
+			this.refreshAutoRenameProjectOptions();
+			this.autoRenameConfigSaveScope = "global";
+			this.autoRenameConfigTargetProjectId = "";
+			this.autoRenameConfigTargetProjectPath = "";
 			this.render();
 
 			await this.loadPackageConfigFromPackage(source, commands).catch(() => {});
 			if (commands.some((command) => commandLikelyNeedsModelArg(command))) {
 				await this.ensureConfigModelsLoaded();
+			}
+			const autoRenameCommand = this.resolveAutoRenameCommandForSource(source);
+			if (autoRenameCommand) {
+				await this.ensureAutoRenameConfigLoaded(source, false, { scope: "global" }).catch(() => {});
 			}
 			this.seedModelArgsForSource(source, commands);
 			this.render();
@@ -2935,6 +3860,17 @@ Execute the required file creation/edits directly, then summarize exactly which 
 		this.activePackageConfigSource = null;
 		this.activePackageConfigLabel = "";
 		this.packageConfigStatus = "";
+		this.autoRenameConfigError = "";
+		this.autoRenameConfigLoading = false;
+		this.autoRenameConfigSaving = false;
+		this.autoRenameConfigPath = "";
+		this.autoRenameConfigScopeLabel = "";
+		this.autoRenameConfigSaveScope = "global";
+		this.autoRenameConfigTargetProjectId = "";
+		this.autoRenameConfigTargetProjectPath = "";
+		this.autoRenameConfigLoadedSource = "";
+		this.autoRenameConfigRaw = {};
+		this.autoRenameConfig = defaultAutoRenameConfigDraft();
 		this.activeSkillContent = "";
 		this.activeSkillContentPath = null;
 		this.activeSkillContentLoading = false;

--- a/src/components/terminal-panel.ts
+++ b/src/components/terminal-panel.ts
@@ -1,18 +1,25 @@
 /**
- * TerminalPanel - lightweight command runner panel
+ * TerminalPanel - docked terminal experience (xterm surface + local shell execution)
  */
 
-import { html, nothing, render } from "lit";
-import { rpcBridge } from "../rpc/bridge.js";
+import { Command } from "@tauri-apps/plugin-shell";
+import { FitAddon } from "@xterm/addon-fit";
+import { Terminal } from "@xterm/xterm";
+import { html, render } from "lit";
 
-interface TerminalEntry {
-	id: string;
-	kind: "command" | "stdout" | "stderr" | "meta";
-	text: string;
+type ShellKind = "posix" | "powershell" | "cmd";
+
+interface ShellProfile {
+	name: string;
+	label: string;
+	kind: ShellKind;
 }
 
-function uid(prefix = "entry"): string {
-	return `${prefix}_${Math.random().toString(36).slice(2, 8)}_${Date.now().toString(36)}`;
+interface TerminalExecResult {
+	code: number | null;
+	signal: number | null;
+	stdout: string;
+	stderr: string;
 }
 
 function normalizeText(value: unknown): string {
@@ -25,127 +32,478 @@ function normalizeText(value: unknown): string {
 	}
 }
 
+function shellProfilesForPlatform(): ShellProfile[] {
+	const platform = navigator.platform.toLowerCase();
+	if (platform.includes("win")) {
+		return [
+			{ name: "terminal-pwsh-exe", label: "pwsh", kind: "powershell" },
+			{ name: "terminal-pwsh", label: "pwsh", kind: "powershell" },
+			{ name: "terminal-cmd-exe", label: "cmd", kind: "cmd" },
+			{ name: "terminal-cmd", label: "cmd", kind: "cmd" },
+		];
+	}
+	if (platform.includes("mac")) {
+		return [
+			{ name: "terminal-zsh-path", label: "zsh", kind: "posix" },
+			{ name: "terminal-zsh", label: "zsh", kind: "posix" },
+			{ name: "terminal-bash-path", label: "bash", kind: "posix" },
+			{ name: "terminal-bash", label: "bash", kind: "posix" },
+			{ name: "terminal-sh-path", label: "sh", kind: "posix" },
+			{ name: "terminal-sh", label: "sh", kind: "posix" },
+		];
+	}
+	return [
+		{ name: "terminal-bash-path", label: "bash", kind: "posix" },
+		{ name: "terminal-bash", label: "bash", kind: "posix" },
+		{ name: "terminal-sh-path", label: "sh", kind: "posix" },
+		{ name: "terminal-sh", label: "sh", kind: "posix" },
+	];
+}
+
+function compactPath(path: string | null): string {
+	if (!path) return "~";
+	const normalized = path.replace(/\\/g, "/");
+	const globalHome = (globalThis as { __PI_HOME__?: string }).__PI_HOME__;
+	const home = (typeof globalHome === "string" ? globalHome : "").replace(/\\/g, "/").replace(/\/+$/, "");
+	if (home && normalized.startsWith(home)) {
+		const suffix = normalized.slice(home.length).replace(/^\//, "");
+		return suffix ? `~/${suffix}` : "~";
+	}
+	return normalized;
+}
+
+function isPrintableKey(event: KeyboardEvent, key: string): boolean {
+	if (event.ctrlKey || event.metaKey || event.altKey) return false;
+	return key.length === 1;
+}
+
 export class TerminalPanel {
 	private container: HTMLElement;
-	private entries: TerminalEntry[] = [];
-	private command = "";
-	private running = false;
 	private cwd: string | null = null;
+	private running = false;
+	private onRequestClose: (() => void) | null = null;
+
+	private xterm: Terminal | null = null;
+	private fitAddon: FitAddon | null = null;
+	private resizeObserver: ResizeObserver | null = null;
+
+	private inputBuffer = "";
+	private commandHistory: string[] = [];
+	private commandHistoryIndex = -1;
+	private commandHistoryDraft = "";
+
+	private shellProfile: ShellProfile | null = null;
+	private resolvingShellProfile: Promise<ShellProfile> | null = null;
 
 	constructor(container: HTMLElement) {
 		this.container = container;
 		this.render();
 	}
 
+	setOnRequestClose(cb: () => void): void {
+		this.onRequestClose = cb;
+	}
+
 	setProjectPath(path: string | null): void {
-		this.cwd = path;
+		const next = path && path.trim().length > 0 ? path : null;
+		if (this.cwd === next) return;
+		this.cwd = next;
 		this.render();
 	}
 
 	focusInput(): void {
-		const input = this.container.querySelector("#terminal-input") as HTMLInputElement | null;
-		input?.focus();
+		this.xterm?.focus();
 	}
 
-	private push(kind: TerminalEntry["kind"], text: string): void {
-		this.entries.push({ id: uid(kind), kind, text });
-		if (this.entries.length > 350) {
-			this.entries = this.entries.slice(this.entries.length - 350);
+	private applyTheme(): void {
+		if (!this.xterm) return;
+		const styles = getComputedStyle(document.documentElement);
+		const background = styles.getPropertyValue("--bg").trim() || "#0f1115";
+		const foreground = styles.getPropertyValue("--text").trim() || "#d7dce2";
+		const muted = styles.getPropertyValue("--muted").trim() || "#95a1b2";
+		this.xterm.options.theme = {
+			background,
+			foreground,
+			cursor: foreground,
+			selectionBackground: muted,
+		};
+	}
+
+	private ensureTerminal(): void {
+		const viewport = this.container.querySelector<HTMLElement>("#terminal-viewport");
+		if (!viewport) return;
+
+		if (!this.xterm) {
+			this.fitAddon = new FitAddon();
+			this.xterm = new Terminal({
+				cursorBlink: true,
+				convertEol: true,
+				scrollback: 6000,
+				fontSize: 12,
+				lineHeight: 1.35,
+				fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+			});
+			this.xterm.loadAddon(this.fitAddon);
+			this.applyTheme();
+			this.xterm.open(viewport);
+			this.fitAddon.fit();
+			this.installKeyboardBindings();
+			this.printPrompt();
 		}
-		this.render();
-		requestAnimationFrame(() => {
-			const body = this.container.querySelector("#terminal-log") as HTMLElement | null;
-			if (body) body.scrollTop = body.scrollHeight;
+
+		if (!this.resizeObserver) {
+			this.resizeObserver = new ResizeObserver(() => {
+				this.fitAddon?.fit();
+			});
+			this.resizeObserver.observe(viewport);
+		}
+	}
+
+	private installKeyboardBindings(): void {
+		if (!this.xterm) return;
+		this.xterm.onKey(({ key, domEvent }) => {
+			if (domEvent.ctrlKey && !domEvent.metaKey && domEvent.key.toLowerCase() === "c") {
+				domEvent.preventDefault();
+				if (this.running) {
+					void this.abortRunningCommand();
+				} else {
+					this.clearCurrentInput();
+					this.xterm?.write("^C\r\n");
+					this.printPrompt();
+				}
+				return;
+			}
+
+			if (this.running) {
+				domEvent.preventDefault();
+				return;
+			}
+
+			if (domEvent.key === "Enter") {
+				domEvent.preventDefault();
+				const command = this.inputBuffer;
+				this.inputBuffer = "";
+				this.xterm?.write("\r\n");
+				void this.executeCommand(command);
+				return;
+			}
+
+			if (domEvent.key === "Backspace") {
+				domEvent.preventDefault();
+				if (this.inputBuffer.length === 0) return;
+				this.inputBuffer = this.inputBuffer.slice(0, -1);
+				this.xterm?.write("\b \b");
+				return;
+			}
+
+			if (domEvent.key === "ArrowUp") {
+				domEvent.preventDefault();
+				this.navigateHistory("up");
+				return;
+			}
+
+			if (domEvent.key === "ArrowDown") {
+				domEvent.preventDefault();
+				this.navigateHistory("down");
+				return;
+			}
+
+			if (domEvent.ctrlKey && !domEvent.metaKey && domEvent.key.toLowerCase() === "l") {
+				domEvent.preventDefault();
+				this.clearScreen();
+				return;
+			}
+
+			if (!isPrintableKey(domEvent, key)) return;
+			this.inputBuffer += key;
+			this.xterm?.write(key);
 		});
 	}
 
-	private clear(): void {
-		this.entries = [];
-		this.render();
+	private replaceCurrentInput(value: string): void {
+		if (!this.xterm) return;
+		for (let i = 0; i < this.inputBuffer.length; i += 1) {
+			this.xterm.write("\b \b");
+		}
+		this.inputBuffer = value;
+		if (value) this.xterm.write(value);
 	}
 
-	private async run(): Promise<void> {
-		if (this.running) return;
-		const command = this.command.trim();
-		if (!command) return;
-		this.command = "";
+	private navigateHistory(direction: "up" | "down"): void {
+		if (this.commandHistory.length === 0) return;
+		if (direction === "up") {
+			if (this.commandHistoryIndex < 0) {
+				this.commandHistoryDraft = this.inputBuffer;
+				this.commandHistoryIndex = this.commandHistory.length - 1;
+			} else if (this.commandHistoryIndex > 0) {
+				this.commandHistoryIndex -= 1;
+			}
+			const next = this.commandHistory[this.commandHistoryIndex] ?? "";
+			this.replaceCurrentInput(next);
+			return;
+		}
+
+		if (this.commandHistoryIndex < 0) return;
+		if (this.commandHistoryIndex < this.commandHistory.length - 1) {
+			this.commandHistoryIndex += 1;
+			const next = this.commandHistory[this.commandHistoryIndex] ?? "";
+			this.replaceCurrentInput(next);
+			return;
+		}
+
+		this.commandHistoryIndex = -1;
+		this.replaceCurrentInput(this.commandHistoryDraft);
+	}
+
+	private rememberHistory(command: string): void {
+		const trimmed = command.trim();
+		if (!trimmed) return;
+		const last = this.commandHistory[this.commandHistory.length - 1] ?? "";
+		if (last !== trimmed) {
+			this.commandHistory.push(trimmed);
+			if (this.commandHistory.length > 150) {
+				this.commandHistory.splice(0, this.commandHistory.length - 150);
+			}
+		}
+		this.commandHistoryIndex = -1;
+		this.commandHistoryDraft = "";
+	}
+
+	private clearCurrentInput(): void {
+		this.replaceCurrentInput("");
+	}
+
+	private scrollTerminalToBottom(): void {
+		requestAnimationFrame(() => {
+			this.xterm?.scrollToBottom();
+		});
+	}
+
+	private printPrompt(): void {
+		if (!this.xterm) return;
+		this.commandHistoryIndex = -1;
+		this.commandHistoryDraft = "";
+		const pathLabel = compactPath(this.cwd);
+		this.xterm.write(`\x1b[34m${pathLabel}\x1b[0m $ `);
+		this.scrollTerminalToBottom();
+	}
+
+	private writeInfo(text: string): void {
+		if (!this.xterm) return;
+		this.xterm.writeln(`\x1b[90m${text}\x1b[0m`);
+		this.scrollTerminalToBottom();
+	}
+
+	private writeStdErr(text: string): void {
+		if (!this.xterm) return;
+		const lines = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").split("\n");
+		for (const line of lines) {
+			if (!line) continue;
+			this.xterm.writeln(`\x1b[31m${line}\x1b[0m`);
+		}
+		this.scrollTerminalToBottom();
+	}
+
+	private writeStdOut(text: string): void {
+		if (!this.xterm) return;
+		if (!text) return;
+		const normalized = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n").replace(/\n/g, "\r\n");
+		this.xterm.write(normalized);
+		this.scrollTerminalToBottom();
+	}
+
+	private isCdCommand(command: string): boolean {
+		return /^cd(?:\s+.*)?$/i.test(command.trim());
+	}
+
+	private buildShellArgs(profile: ShellProfile, command: string): string[] {
+		switch (profile.kind) {
+			case "powershell":
+				return ["-NoLogo", "-NoProfile", "-Command", command];
+			case "cmd":
+				return ["/C", command];
+			default:
+				return ["-lc", command];
+		}
+	}
+
+	private buildShellProbeArgs(profile: ShellProfile): string[] {
+		switch (profile.kind) {
+			case "powershell":
+				return ["-NoLogo", "-NoProfile", "-Command", "Write-Output __PI_SHELL_OK__"];
+			case "cmd":
+				return ["/C", "echo __PI_SHELL_OK__"];
+			default:
+				return ["-lc", "printf __PI_SHELL_OK__"];
+		}
+	}
+
+	private buildCdProbeCommand(profile: ShellProfile, cdCommand: string): string {
+		switch (profile.kind) {
+			case "powershell":
+				return `${cdCommand}; (Get-Location).Path`;
+			case "cmd":
+				return `${cdCommand} && cd`;
+			default:
+				return `${cdCommand}\npwd`;
+		}
+	}
+
+	private async ensureShellProfile(): Promise<ShellProfile> {
+		if (this.shellProfile) return this.shellProfile;
+		if (this.resolvingShellProfile) return this.resolvingShellProfile;
+		this.resolvingShellProfile = (async () => {
+			const profiles = shellProfilesForPlatform();
+			const failures: string[] = [];
+			for (const profile of profiles) {
+				try {
+					const probe = await Command.create(profile.name, this.buildShellProbeArgs(profile), {
+						cwd: this.cwd || undefined,
+					}).execute();
+					if ((probe.code ?? 1) === 0) {
+						this.shellProfile = profile;
+						return profile;
+					}
+					failures.push(`${profile.name}: probe exit ${probe.code ?? -1}`);
+				} catch (err) {
+					const message = err instanceof Error ? err.message : String(err);
+					failures.push(`${profile.name}: ${message}`);
+				}
+			}
+			const preview = failures.slice(0, 2).join(" | ");
+			throw new Error(
+				`No allowed shell command found. Restart app and verify capabilities.${preview ? ` (${preview})` : ""}`,
+			);
+		})();
+		try {
+			return await this.resolvingShellProfile;
+		} finally {
+			this.resolvingShellProfile = null;
+		}
+	}
+
+	private async executeShell(command: string): Promise<TerminalExecResult> {
+		const profile = await this.ensureShellProfile();
+		const output = await Command.create(profile.name, this.buildShellArgs(profile, command), {
+			cwd: this.cwd || undefined,
+		}).execute();
+		return {
+			code: output.code,
+			signal: output.signal,
+			stdout: normalizeText(output.stdout),
+			stderr: normalizeText(output.stderr),
+		};
+	}
+
+	private async executeCdCommand(command: string): Promise<void> {
+		const profile = await this.ensureShellProfile();
+		const probeCommand = this.buildCdProbeCommand(profile, command);
+		const result = await this.executeShell(probeCommand);
+		if (result.stderr.trim()) {
+			this.writeStdErr(result.stderr.trimEnd());
+		}
+
+		const normalizedStdout = result.stdout.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+		const lines = normalizedStdout
+			.split("\n")
+			.map((line) => line.trim())
+			.filter((line) => line.length > 0);
+
+		if ((result.code ?? 1) === 0) {
+			const nextCwd = lines.length > 0 ? lines[lines.length - 1] : "";
+			if (nextCwd) {
+				this.cwd = nextCwd;
+				this.render();
+			}
+			const extraStdout = lines.slice(0, -1).join("\n");
+			if (extraStdout) this.writeStdOut(`${extraStdout}\n`);
+		} else if (lines.length > 0) {
+			this.writeStdOut(`${lines.join("\n")}\n`);
+		}
+	}
+
+	private async executeCommand(rawCommand: string): Promise<void> {
+		const command = rawCommand.trim();
+		if (!command) {
+			this.printPrompt();
+			return;
+		}
+		this.rememberHistory(command);
+
+		if (command === "clear" || command === "cls") {
+			this.clearScreen();
+			return;
+		}
+
+		if (!this.cwd) {
+			this.writeInfo("Open a project to run terminal commands.");
+			this.printPrompt();
+			return;
+		}
+
 		this.running = true;
-		this.push("command", `$ ${command}`);
-
+		this.render();
 		try {
-			const result = await rpcBridge.bash(command);
-			const stdout = normalizeText((result as Record<string, unknown>).stdout);
-			const stderr = normalizeText((result as Record<string, unknown>).stderr);
-			const exitCode = (result as Record<string, unknown>).exitCode;
-
-			if (stdout.trim()) this.push("stdout", stdout.trimEnd());
-			if (stderr.trim()) this.push("stderr", stderr.trimEnd());
-			if (typeof exitCode === "number") this.push("meta", `exit ${exitCode}`);
+			if (this.isCdCommand(command)) {
+				await this.executeCdCommand(command);
+			} else {
+				const result = await this.executeShell(command);
+				if (result.stdout.length > 0) this.writeStdOut(result.stdout);
+				if (result.stderr.length > 0) this.writeStdErr(result.stderr);
+				if (typeof result.code === "number" && result.code !== 0 && !result.stderr.trim()) {
+					this.writeStdErr(`exit ${result.code}`);
+				}
+			}
 		} catch (err) {
-			this.push("stderr", err instanceof Error ? err.message : String(err));
+			this.writeStdErr(err instanceof Error ? err.message : String(err));
 		} finally {
 			this.running = false;
 			this.render();
+			this.printPrompt();
 		}
 	}
 
-	private async abort(): Promise<void> {
+	private async abortRunningCommand(): Promise<void> {
 		if (!this.running) return;
-		try {
-			await rpcBridge.abortBash();
-			this.push("meta", "Command aborted");
-		} catch {
-			// ignore
-		} finally {
-			this.running = false;
-			this.render();
-		}
+		this.writeInfo("Abort is not available for this shell command path yet.");
+	}
+
+	private clearScreen(): void {
+		this.inputBuffer = "";
+		this.xterm?.write("\x1b[2J\x1b[3J\x1b[H");
+		this.printPrompt();
+		this.scrollTerminalToBottom();
 	}
 
 	render(): void {
+		const shellLabel = this.shellProfile?.label ?? shellProfilesForPlatform()[0]?.label ?? "shell";
+		const headerTitle = this.running ? `Terminal ${shellLabel} · running` : `Terminal ${shellLabel}`;
+		const cwdLabel = this.cwd ? compactPath(this.cwd) : "No project open";
 		const template = html`
-			<div class="terminal-panel-root">
+			<div
+				class="terminal-panel-root"
+				@mousedown=${(event: MouseEvent) => {
+					const target = event.target instanceof Element ? event.target : null;
+					if (target?.closest(".terminal-resize-handle")) return;
+					this.xterm?.focus();
+				}}
+			>
+				<div class="terminal-resize-handle" title="Resize terminal" aria-hidden="true"></div>
 				<div class="terminal-panel-header">
-					<div class="terminal-panel-title">Terminal</div>
-					<div class="terminal-panel-cwd" title=${this.cwd || ""}>${this.cwd || "."}</div>
+					<div class="terminal-panel-title">${headerTitle}</div>
+					<div class="terminal-panel-cwd" title=${this.cwd || ""}>${cwdLabel}</div>
 					<div class="terminal-panel-actions">
-						<button class="ghost-btn" @click=${() => this.clear()}>Clear</button>
-						${this.running
-							? html`<button class="ghost-btn" @click=${() => void this.abort()}>Stop</button>`
-							: nothing}
+						<button class="ghost-btn" title="Clear terminal" @click=${() => this.clearScreen()}>Clear</button>
+						<button class="ghost-btn terminal-close-btn" title="Close terminal" @click=${() => this.onRequestClose?.()}>✕</button>
 					</div>
 				</div>
-				<div class="terminal-panel-log" id="terminal-log">
-					${this.entries.length === 0
-						? html`<div class="terminal-panel-empty">Run a shell command in this workspace.</div>`
-						: this.entries.map(
-								(entry) => html`<pre class="terminal-entry ${entry.kind}">${entry.text}</pre>`,
-							)}
-				</div>
-				<div class="terminal-panel-input-row">
-					<span class="terminal-prompt">$</span>
-					<input
-						id="terminal-input"
-						type="text"
-						placeholder="Type a command"
-						.value=${this.command}
-						?disabled=${this.running}
-						@input=${(e: Event) => {
-							this.command = (e.target as HTMLInputElement).value;
-							this.render();
-						}}
-						@keydown=${(e: KeyboardEvent) => {
-							if (e.key === "Enter") {
-								e.preventDefault();
-								void this.run();
-							}
-						}}
-					/>
-					<button class="ghost-btn" ?disabled=${this.running || !this.command.trim()} @click=${() => void this.run()}>Run</button>
-				</div>
+				<div id="terminal-viewport" class="terminal-panel-viewport"></div>
 			</div>
 		`;
 
 		render(template, this.container);
+		this.ensureTerminal();
+		this.applyTheme();
+		this.fitAddon?.fit();
 	}
 }

--- a/src/extensions/sdk-compat-extension.ts
+++ b/src/extensions/sdk-compat-extension.ts
@@ -1,0 +1,123 @@
+const DESKTOP_COMPAT_EXTENSION_FILE = "pi-desktop-sdk-compat.ts";
+const DESKTOP_COMPAT_EXTENSION_MARKER = "pi-desktop-sdk-compat-extension/v1";
+
+const DESKTOP_COMPAT_EXTENSION_CONTENT = `/**
+ * ${DESKTOP_COMPAT_EXTENSION_MARKER}
+ *
+ * Compatibility shim for extensions that still call
+ *   ctx.modelRegistry.getApiKey(model)
+ * against runtimes that now expose getApiKeyAndHeaders(model).
+ *
+ * Safe behavior:
+ * - no-op if getApiKey already exists
+ * - no-op if getApiKeyAndHeaders is unavailable
+ * - returns undefined on resolution failure
+ */
+export default function (pi) {
+\tconst ensureModelRegistryGetApiKeyCompat = (_event, ctx) => {
+\t\tconst registry = ctx?.modelRegistry;
+\t\tif (!registry || typeof registry !== "object") return;
+\t\tif (typeof registry.getApiKey === "function") return;
+\t\tconst resolver = registry.getApiKeyAndHeaders;
+\t\tif (typeof resolver !== "function") return;
+\n\t\tregistry.getApiKey = async (model) => {
+\t\t\ttry {
+\t\t\t\tconst resolved = await resolver.call(registry, model);
+\t\t\t\tif (resolved && typeof resolved === "object" && resolved.ok === true) {
+\t\t\t\t\tconst apiKey = resolved.apiKey;
+\t\t\t\t\tif (typeof apiKey === "string" && apiKey.trim().length > 0) {
+\t\t\t\t\t\treturn apiKey;
+\t\t\t\t\t}
+\t\t\t\t}
+\t\t\t} catch {
+\t\t\t\t// no-op: keep compatibility shim non-fatal
+\t\t\t}
+\t\t\treturn undefined;
+\t\t};
+\t};
+\n\tpi.on("session_start", ensureModelRegistryGetApiKeyCompat);
+\tpi.on("before_agent_start", ensureModelRegistryGetApiKeyCompat);
+\tpi.on("agent_start", ensureModelRegistryGetApiKeyCompat);
+}
+`;
+
+function joinFsPath(base: string, child: string): string {
+	const b = base.replace(/\\/g, "/").replace(/\/+$/, "");
+	const c = child.replace(/\\/g, "/").replace(/^\/+/, "");
+	return b ? `${b}/${c}` : c;
+}
+
+async function resolveGlobalExtensionsRoot(): Promise<string | null> {
+	const { homeDir } = await import("@tauri-apps/api/path");
+	const home = (await homeDir()).replace(/\\/g, "/").replace(/\/+$/, "");
+	if (!home) return null;
+	return joinFsPath(joinFsPath(joinFsPath(home, ".pi"), "agent"), "extensions");
+}
+
+export interface DesktopCompatExtensionInstallResult {
+	path: string;
+	created: boolean;
+	updated: boolean;
+	skipped: boolean;
+	error?: string;
+}
+
+export async function ensureDesktopSdkCompatExtensionInstalled(): Promise<DesktopCompatExtensionInstallResult> {
+	const root = await resolveGlobalExtensionsRoot();
+	if (!root) {
+		return {
+			path: "",
+			created: false,
+			updated: false,
+			skipped: true,
+			error: "Could not resolve home directory",
+		};
+	}
+
+	const extensionPath = joinFsPath(root, DESKTOP_COMPAT_EXTENSION_FILE);
+
+	try {
+		const { exists, mkdir, readTextFile, writeTextFile } = await import("@tauri-apps/plugin-fs");
+		await mkdir(root, { recursive: true });
+
+		const hasExisting = await exists(extensionPath);
+		const existingContent = hasExisting ? await readTextFile(extensionPath).catch(() => "") : "";
+
+		const normalizedExisting = existingContent.replace(/\r\n/g, "\n").trim();
+		const normalizedTarget = DESKTOP_COMPAT_EXTENSION_CONTENT.trim();
+		if (normalizedExisting === normalizedTarget) {
+			return {
+				path: extensionPath,
+				created: false,
+				updated: false,
+				skipped: false,
+			};
+		}
+
+		if (hasExisting && normalizedExisting.length > 0 && !existingContent.includes(DESKTOP_COMPAT_EXTENSION_MARKER)) {
+			return {
+				path: extensionPath,
+				created: false,
+				updated: false,
+				skipped: true,
+				error: `Skipped writing compatibility extension because ${DESKTOP_COMPAT_EXTENSION_FILE} is user-managed.`,
+			};
+		}
+
+		await writeTextFile(extensionPath, DESKTOP_COMPAT_EXTENSION_CONTENT);
+		return {
+			path: extensionPath,
+			created: !hasExisting,
+			updated: hasExisting,
+			skipped: false,
+		};
+	} catch (err) {
+		return {
+			path: extensionPath,
+			created: false,
+			updated: false,
+			skipped: false,
+			error: err instanceof Error ? err.message : String(err),
+		};
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import {
 import { syncDesktopThemeWithPiTheme } from "./theme/pi-theme-bridge.js";
 import { DESKTOP_THEME_CHANGED_EVENT, getResolvedDesktopTheme, initializeDesktopTheme, toggleDesktopTheme } from "./theme/theme-manager.js";
 import { ensureBundledThemesInstalled } from "./theme/bundled-themes.js";
+import { ensureDesktopSdkCompatExtensionInstalled } from "./extensions/sdk-compat-extension.js";
 import "./styles/app.css";
 
 interface WorkspaceSessionTab {
@@ -92,6 +93,10 @@ const SIDEBAR_WIDTH_KEY = "pi-desktop.sidebar.width.v1";
 const SIDEBAR_COLLAPSED_STATE_KEY = "pi-desktop.sidebar.collapsed.v1";
 const SIDEBAR_WIDTH_MIN = 240;
 const SIDEBAR_WIDTH_MAX = 540;
+const TERMINAL_DOCK_HEIGHT_KEY = "pi-desktop.terminal-dock-height.v1";
+const TERMINAL_DOCK_MIN_HEIGHT = 180;
+const TERMINAL_DOCK_MAX_HEIGHT = 640;
+const TERMINAL_DOCK_DEFAULT_HEIGHT = 280;
 const NEW_SESSION_TAB_TITLE = "New session";
 const NEW_FILE_TAB_TITLE = "New file";
 const DEBUG_OVERLAY_STORAGE_KEY = "pi-desktop.debug-overlay.v1";
@@ -143,6 +148,8 @@ let workspaces: WorkspaceState[] = [];
 let activeWorkspaceId: string | null = null;
 let sidebarWidth = 320;
 let removeSidebarResizeHandlers: (() => void) | null = null;
+let removeTerminalDockResizeHandlers: (() => void) | null = null;
+let terminalDockHeightPx = loadTerminalDockHeight();
 let sidebarSessionsRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 let sidebarSessionsWarmInterval: ReturnType<typeof setInterval> | null = null;
 let sidebarSessionsWarmStopTimer: ReturnType<typeof setTimeout> | null = null;
@@ -176,6 +183,63 @@ function recordDebugTrace(message: string): void {
 
 function uid(prefix = "id"): string {
 	return `${prefix}_${Math.random().toString(36).slice(2, 8)}_${Date.now().toString(36)}`;
+}
+
+function clampTerminalDockHeight(value: number): number {
+	return Math.min(TERMINAL_DOCK_MAX_HEIGHT, Math.max(TERMINAL_DOCK_MIN_HEIGHT, Math.round(value)));
+}
+
+function loadTerminalDockHeight(): number {
+	try {
+		const raw = localStorage.getItem(TERMINAL_DOCK_HEIGHT_KEY);
+		const parsed = raw ? Number(raw) : TERMINAL_DOCK_DEFAULT_HEIGHT;
+		if (!Number.isFinite(parsed)) return TERMINAL_DOCK_DEFAULT_HEIGHT;
+		return clampTerminalDockHeight(parsed);
+	} catch {
+		return TERMINAL_DOCK_DEFAULT_HEIGHT;
+	}
+}
+
+function persistTerminalDockHeight(): void {
+	try {
+		localStorage.setItem(TERMINAL_DOCK_HEIGHT_KEY, String(terminalDockHeightPx));
+	} catch {
+		// ignore
+	}
+}
+
+function setTerminalDockHeight(nextHeight: number, persist = false): void {
+	const clamped = clampTerminalDockHeight(nextHeight);
+	if (clamped === terminalDockHeightPx) return;
+	terminalDockHeightPx = clamped;
+	if (persist) persistTerminalDockHeight();
+	syncTerminalDockVisibility(getActiveWorkspace());
+}
+
+function setupTerminalDockResize(terminalPane: HTMLElement): void {
+	removeTerminalDockResizeHandlers?.();
+	const onPointerDown = (event: PointerEvent) => {
+		const target = event.target instanceof Element ? event.target.closest(".terminal-resize-handle") : null;
+		if (!target) return;
+		event.preventDefault();
+		const startY = event.clientY;
+		const startHeight = terminalDockHeightPx;
+		const onPointerMove = (moveEvent: PointerEvent) => {
+			const deltaY = startY - moveEvent.clientY;
+			setTerminalDockHeight(startHeight + deltaY, false);
+		};
+		const onPointerUp = () => {
+			window.removeEventListener("pointermove", onPointerMove);
+			window.removeEventListener("pointerup", onPointerUp);
+			persistTerminalDockHeight();
+		};
+		window.addEventListener("pointermove", onPointerMove);
+		window.addEventListener("pointerup", onPointerUp);
+	};
+	terminalPane.addEventListener("pointerdown", onPointerDown);
+	removeTerminalDockResizeHandlers = () => {
+		terminalPane.removeEventListener("pointerdown", onPointerDown);
+	};
 }
 
 function pickSessionAttentionMessage(current?: string | null): string {
@@ -1577,11 +1641,11 @@ function loadWorkspaces(): void {
 						emoji: typeof w.emoji === "string" && w.emoji.trim().length > 0 ? w.emoji.trim() : null,
 						pinned: false,
 						leftMode: w.leftMode === "files" ? "files" : "projects",
-						pane: w.pane === "file" || w.pane === "packages" || w.pane === "settings" || w.pane === "terminal" ? w.pane : "chat",
+						pane: w.pane === "file" || w.pane === "packages" || w.pane === "settings" ? w.pane : "chat",
 						activeProjectId: normalizeStoredId(w.activeProjectId),
 						activeProjectPath: normalizeStoredPath(w.activeProjectPath),
 						filePath: typeof w.filePath === "string" ? w.filePath : null,
-						terminalOpen: Boolean(w.terminalOpen),
+						terminalOpen: Boolean(w.terminalOpen || w.pane === "terminal"),
 						sessionTitle: fallbackSessionTitle,
 						sessionTabs,
 						activeSessionTabId:
@@ -1864,26 +1928,14 @@ function syncContentTabsBar(workspace: WorkspaceState | null = getActiveWorkspac
 			path: tab.path ?? undefined,
 			closable: true,
 		})),
-		...(workspace.terminalOpen
-			? [
-				{
-					id: "terminal",
-					type: "terminal" as const,
-					title: "Terminal",
-					closable: true,
-				},
-			]
-			: []),
 	];
 
 	const activeTabId =
 		workspace.pane === "file" && workspace.activeFileTabId
 			? workspace.activeFileTabId
-			: workspace.pane === "terminal" && workspace.terminalOpen
-				? "terminal"
-				: workspace.activeSessionTabId;
+			: workspace.activeSessionTabId;
 
-	contentTabsBar.setTerminalActive(workspace.pane === "terminal");
+	contentTabsBar.setTerminalActive(workspace.pane === "chat" && workspace.terminalOpen);
 	contentTabsBar.setTabs(tabs, activeTabId);
 }
 
@@ -1893,13 +1945,28 @@ function setPaneVisibility(pane: WorkspaceState["pane"]): void {
 	const terminalPane = document.getElementById("terminal-pane");
 	const packagesPane = document.getElementById("packages-pane");
 	const settingsPane = document.getElementById("settings-pane");
-	if (!sessionPane || !filePane || !terminalPane || !packagesPane || !settingsPane) return;
+	if (!sessionPane || !filePane || !packagesPane || !settingsPane) return;
 
 	sessionPane.classList.toggle("hidden-pane", pane !== "chat");
 	filePane.classList.toggle("hidden-pane", pane !== "file");
-	terminalPane.classList.toggle("hidden-pane", pane !== "terminal");
 	packagesPane.classList.toggle("hidden-pane", pane !== "packages");
 	settingsPane.classList.toggle("hidden-pane", pane !== "settings");
+	if (pane !== "chat") {
+		terminalPane?.classList.add("hidden-pane");
+		terminalPane?.classList.remove("terminal-dock-visible");
+	}
+}
+
+function syncTerminalDockVisibility(workspace: WorkspaceState | null = getActiveWorkspace()): void {
+	const terminalPane = document.getElementById("terminal-pane");
+	if (!terminalPane) return;
+	terminalPane.style.setProperty("--terminal-dock-height", `${terminalDockHeightPx}px`);
+	const shouldShow = Boolean(workspace && workspace.pane === "chat" && workspace.terminalOpen);
+	terminalPane.classList.toggle("hidden-pane", !shouldShow);
+	terminalPane.classList.toggle("terminal-dock-visible", shouldShow);
+	if (shouldShow && workspace) {
+		terminalPanel?.setProjectPath(getWorkspaceActiveProjectPath(workspace));
+	}
 }
 
 function resolveSettingsRuntimeProjectPath(workspace: WorkspaceState | null): string | null {
@@ -1926,10 +1993,17 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 		settingsPanel?.hideWithoutClearing();
 		syncRunningSessionIndicators();
 		setPaneVisibility("chat");
+		syncTerminalDockVisibility(null);
 		return;
 	}
 
 	ensureWorkspaceContentState(workspace);
+	if (workspace.pane === "terminal") {
+		workspace.pane = "chat";
+		workspace.terminalOpen = true;
+		persistWorkspaces();
+		syncWorkspaceTabsBar();
+	}
 	const workspaceProjectPath = getWorkspaceActiveProjectPath(workspace);
 	const resolved = getResolvedDesktopTheme();
 	const profiles = loadDesktopAppearanceProfiles();
@@ -1947,9 +2021,11 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 	if (workspace.pane !== "file") {
 		fileViewer?.setProjectPath(workspaceProjectPath);
 	}
+	syncTerminalDockVisibility(workspace);
 	if (isStale()) return;
 
 	if (workspace.pane === "file") {
+		syncTerminalDockVisibility({ ...workspace, terminalOpen: false, pane: "file" });
 		const activeFileTab = getActiveFileTab(workspace);
 		const draftBasePath = activeFileTab && isDraftFileTab(activeFileTab) ? normalizeStoredPath(activeFileTab.draftDirectoryPath) : null;
 		fileViewer?.setProjectPath(draftBasePath ?? getFileTabProjectPath(activeFileTab) ?? getWorkspaceActiveProjectPath(workspace));
@@ -1965,15 +2041,8 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 		return;
 	}
 
-	if (workspace.pane === "terminal" && workspace.terminalOpen) {
-		terminalPanel?.setProjectPath(getWorkspaceActiveProjectPath(workspace));
-		if (isStale()) return;
-		setPaneVisibility("terminal");
-		terminalPanel?.focusInput();
-		return;
-	}
-
 	if (workspace.pane === "packages") {
+		syncTerminalDockVisibility({ ...workspace, terminalOpen: false, pane: "packages" });
 		settingsPanel?.hideWithoutClearing();
 		packagesView?.setProjectPath(getWorkspaceActiveProjectPath(workspace));
 		if (isStale()) return;
@@ -1986,6 +2055,7 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 	}
 
 	if (workspace.pane === "settings") {
+		syncTerminalDockVisibility({ ...workspace, terminalOpen: false, pane: "settings" });
 		if (isStale()) return;
 		setPaneVisibility("settings");
 		try {
@@ -2010,7 +2080,12 @@ async function applyWorkspacePane(workspace: WorkspaceState | null = getActiveWo
 	settingsPanel?.hideWithoutClearing();
 	syncActiveChatRuntimeBinding(workspace);
 	setPaneVisibility("chat");
-	chatView?.focusInput();
+	syncTerminalDockVisibility(workspace);
+	if (workspace.terminalOpen) {
+		terminalPanel?.focusInput();
+	} else {
+		chatView?.focusInput();
+	}
 	syncDebugOverlay();
 }
 
@@ -2412,6 +2487,10 @@ async function initialize(): Promise<void> {
 	loadSidebarWidth();
 	applySidebarWidth();
 	await ensureBundledThemesInstalled();
+	const compatInstall = await ensureDesktopSdkCompatExtensionInstalled();
+	if (compatInstall.error && !compatInstall.skipped) {
+		console.warn("Failed to install desktop compatibility extension:", compatInstall.error);
+	}
 
 	try {
 		connectionError = null;
@@ -2494,8 +2573,9 @@ async function initialize(): Promise<void> {
 		chatView.setOnOpenTerminal(() => {
 			const workspace = getActiveWorkspace();
 			if (!workspace) return;
-			workspace.terminalOpen = true;
-			workspace.pane = "terminal";
+			const shouldOpen = workspace.pane !== "chat" ? true : !workspace.terminalOpen;
+			workspace.terminalOpen = shouldOpen;
+			workspace.pane = "chat";
 			persistWorkspaces();
 			syncWorkspaceTabsBar();
 			void applyWorkspacePane(workspace);
@@ -2514,10 +2594,18 @@ async function initialize(): Promise<void> {
 			syncWorkspaceTabsBar();
 			void applyWorkspacePane(workspace);
 		});
-		chatView.setOnOpenExtensionConfig(async (commandName) => {
-			if (commandName !== "name-ai-config") return false;
+		chatView.setOnOpenExtensionConfig(async (commandName, args) => {
+			const normalizedName = commandName.trim().toLowerCase().replace(/^\/+/, "");
+			const normalizedArgs = args.trim().toLowerCase();
+			const configIntent =
+				normalizedName.endsWith("config") ||
+				normalizedArgs === "config" ||
+				normalizedArgs.startsWith("config ");
+			if (!configIntent) return false;
 			openPackagesPane();
-			return await (packagesView?.openExtensionConfigBySource("npm:pi-session-auto-rename") ?? false);
+			if (!packagesView) return false;
+			await packagesView.refreshPackages(false);
+			return await packagesView.openExtensionConfigByCommand(normalizedName, args);
 		});
 		chatView.setOnBeginRenameCurrentSession(() => {
 			const workspace = getActiveWorkspace();
@@ -2764,6 +2852,16 @@ function initializeComponents(): void {
 						tabId: targetTabId,
 						sessionPath: targetSessionPath,
 					});
+				}
+
+				const notifyText =
+					(typeof request.message === "string" && request.message.trim()) ||
+					(typeof request.title === "string" && request.title.trim()) ||
+					"";
+				const notifyType = typeof request.notifyType === "string" ? request.notifyType.trim().toLowerCase() : "info";
+				const isForeground = typeof document !== "undefined" && document.visibilityState !== "hidden" && document.hasFocus();
+				if (notifyText && isForeground) {
+					chatView?.notify(notifyText, notifyType === "error" ? "error" : "info");
 				}
 			}
 
@@ -3183,9 +3281,11 @@ function renderApp(): void {
 							</svg>
 						</button>
 						<div id="content-tabs-container" data-tauri-drag-region></div>
-						<div id="session-pane"><div id="chat-container"></div></div>
+						<div id="session-pane">
+							<div id="chat-container"></div>
+							<div id="terminal-pane" class="hidden-pane"></div>
+						</div>
 						<div id="file-pane" class="hidden-pane"></div>
-						<div id="terminal-pane" class="hidden-pane"></div>
 						<div id="packages-pane" class="hidden-pane"></div>
 						<div id="settings-pane" class="hidden-pane"></div>
 					</div>
@@ -3220,7 +3320,7 @@ function renderApp(): void {
 
 			if (tabId === "terminal") {
 				workspace.terminalOpen = true;
-				workspace.pane = "terminal";
+				workspace.pane = "chat";
 				pruneEphemeralTabsWhenLeavingDraft(workspace);
 				persistWorkspaces();
 				syncWorkspaceTabsBar();
@@ -3275,8 +3375,9 @@ function renderApp(): void {
 		contentTabsBar.setOnOpenTerminal(() => {
 			const workspace = getActiveWorkspace();
 			if (!workspace) return;
-			workspace.terminalOpen = true;
-			workspace.pane = "terminal";
+			const shouldOpen = workspace.pane !== "chat" ? true : !workspace.terminalOpen;
+			workspace.terminalOpen = shouldOpen;
+			workspace.pane = "chat";
 			persistWorkspaces();
 			syncWorkspaceTabsBar();
 			void applyWorkspacePane(workspace);
@@ -3319,7 +3420,7 @@ function renderApp(): void {
 
 			if (tabId === "terminal") {
 				workspace.terminalOpen = false;
-				if (workspace.pane === "terminal") workspace.pane = "chat";
+				workspace.pane = "chat";
 				persistWorkspaces();
 				syncWorkspaceTabsBar();
 				void applyWorkspacePane(workspace);
@@ -3451,8 +3552,18 @@ function renderApp(): void {
 
 	const terminalPane = document.getElementById("terminal-pane");
 	if (terminalPane) {
+		setupTerminalDockResize(terminalPane);
 		terminalPanel = new TerminalPanel(terminalPane);
 		terminalPanel.setProjectPath(null);
+		terminalPanel.setOnRequestClose(() => {
+			const workspace = getActiveWorkspace();
+			if (!workspace) return;
+			workspace.terminalOpen = false;
+			workspace.pane = "chat";
+			persistWorkspaces();
+			syncWorkspaceTabsBar();
+			void applyWorkspacePane(workspace);
+		});
 	}
 
 	const packagesPane = document.getElementById("packages-pane");
@@ -3482,6 +3593,7 @@ function renderApp(): void {
 	const sidebarContainer = document.getElementById("sidebar-container");
 	if (!sidebarContainer) return;
 	sidebar = new Sidebar(sidebarContainer);
+	packagesView?.setProjectOptionsProvider(() => sidebar?.listProjects() ?? []);
 	sidebar.setOnCollapsedChange(() => {
 		applyWorkspaceTopbarOffset();
 		syncSidebarCollapseToggleButton();

--- a/src/recommended-packages.ts
+++ b/src/recommended-packages.ts
@@ -37,16 +37,16 @@ export const RECOMMENDED_PACKAGES: RecommendedPackageDefinition[] = [
 		aliases: ["pi-desktop-notify"],
 	},
 	{
-		id: "pi-session-auto-rename",
-		name: "Pi Session Auto Rename",
-		description: "Automatically renames Pi sessions with AI after turns, with configurable naming behavior.",
+		id: "pi-auto-rename",
+		name: "Pi Auto Rename",
+		description: "Automatically renames Pi sessions from the first prompt, with configurable model, fallback, and prefix behavior.",
 		installScopeHint: "global",
-		source: "npm:pi-session-auto-rename",
+		source: "npm:@byteowlz/pi-auto-rename",
 		sourceKind: "npm",
 		publisher: "community",
 		resourcesLabel: "1 extension",
-		installSourceHint: "npm:pi-session-auto-rename",
-		aliases: ["pi-session-auto-rename"],
+		installSourceHint: "npm:@byteowlz/pi-auto-rename",
+		aliases: ["@byteowlz/pi-auto-rename", "pi-session-auto-rename"],
 	},
 ];
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1332,6 +1332,22 @@ body.sidebar-resizing {
 	background: var(--bg);
 }
 
+#session-pane {
+	flex-direction: column;
+}
+
+#chat-container {
+	flex: 1;
+	min-height: 0;
+}
+
+#terminal-pane.terminal-dock-visible {
+	display: flex;
+	flex: 0 0 var(--terminal-dock-height, 280px);
+	height: var(--terminal-dock-height, 280px);
+	background: color-mix(in srgb, var(--bg-elev) 96%, var(--bg));
+}
+
 #content-tabs-container.hidden {
 	display: none;
 }
@@ -1572,19 +1588,39 @@ body.sidebar-resizing {
 	background: var(--bg);
 }
 
+.terminal-resize-handle {
+	height: 9px;
+	cursor: ns-resize;
+	position: relative;
+	flex-shrink: 0;
+}
+
+.terminal-resize-handle::before {
+	content: "";
+	position: absolute;
+	left: 50%;
+	top: 3px;
+	transform: translateX(-50%);
+	width: 64px;
+	height: 2px;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--muted-2) 50%, transparent);
+}
+
 .terminal-panel-header {
-	min-height: 42px;
+	min-height: 38px;
 	display: grid;
 	grid-template-columns: auto 1fr auto;
 	align-items: center;
 	gap: 10px;
-	padding: 0 12px;
-	border-bottom: 1px solid var(--border);
+	padding: 0 10px;
+	background: color-mix(in srgb, var(--bg-elev) 70%, var(--bg));
 }
 
 .terminal-panel-title {
 	font-size: 12px;
 	font-weight: 600;
+	letter-spacing: 0.01em;
 }
 
 .terminal-panel-cwd {
@@ -1600,76 +1636,25 @@ body.sidebar-resizing {
 	gap: 6px;
 }
 
-.terminal-panel-log {
+.terminal-close-btn {
+	width: 28px;
+	padding: 0;
+	line-height: 1;
+}
+
+.terminal-panel-viewport {
 	flex: 1;
 	min-height: 0;
-	overflow: auto;
-	padding: 10px 12px;
-	display: grid;
-	align-content: start;
-	gap: 7px;
-	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	padding: 8px 10px 16px;
+	scrollbar-gutter: stable;
 }
 
-.terminal-entry {
-	margin: 0;
-	padding: 0;
-	font-size: 12px;
-	line-height: 1.45;
-	white-space: pre-wrap;
+.terminal-panel-viewport .xterm {
+	height: 100%;
 }
 
-.terminal-entry.command {
-	color: var(--accent);
-}
-
-.terminal-entry.stdout {
-	color: var(--text);
-}
-
-.terminal-entry.stderr {
-	color: var(--danger);
-}
-
-.terminal-entry.meta {
-	color: var(--muted);
-}
-
-.terminal-panel-empty {
-	font-size: 12px;
-	color: var(--muted);
-}
-
-.terminal-panel-input-row {
-	height: 42px;
-	display: grid;
-	grid-template-columns: auto 1fr auto;
-	gap: 8px;
-	align-items: center;
-	padding: 0 12px;
-	border-top: 1px solid var(--border);
-}
-
-.terminal-prompt {
-	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-	font-size: 12px;
-	color: var(--muted-2);
-}
-
-#terminal-input {
-	height: 30px;
-	border-radius: 8px;
-	border: 1px solid var(--border);
-	background: var(--bg-muted);
-	color: var(--text);
-	padding: 0 9px;
-	font-size: 12px;
-}
-
-#terminal-input:focus {
-	outline: none;
-	border-color: color-mix(in srgb, var(--accent) 68%, var(--border));
-	box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 44%, transparent);
+.terminal-panel-viewport .xterm .xterm-viewport {
+	overflow-y: auto;
 }
 
 .packages-view-root {
@@ -2298,6 +2283,15 @@ body.sidebar-resizing {
 	line-height: 1.45;
 }
 
+.packages-config-resolution {
+	display: grid;
+	gap: 4px;
+	padding: 8px 10px;
+	border-radius: 10px;
+	border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+	background: color-mix(in srgb, var(--bg-muted) 92%, transparent);
+}
+
 .packages-config-field {
 	display: grid;
 	gap: 7px;
@@ -2312,6 +2306,80 @@ body.sidebar-resizing {
 	display: grid;
 	grid-template-columns: repeat(2, minmax(0, 1fr));
 	gap: 12px;
+}
+
+.packages-config-toggle-row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 10px;
+	min-height: 36px;
+}
+
+.packages-config-toggle-row.disabled {
+	opacity: 0.68;
+}
+
+.packages-config-toggle-switch {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	width: 38px;
+	height: 22px;
+}
+
+.packages-config-toggle-input {
+	position: absolute;
+	opacity: 0;
+	width: 0;
+	height: 0;
+}
+
+.packages-config-toggle-slider {
+	position: absolute;
+	inset: 0;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--border) 78%, transparent);
+	transition: background-color 120ms ease;
+}
+
+.packages-config-toggle-slider::after {
+	content: "";
+	position: absolute;
+	top: 2px;
+	left: 2px;
+	width: 18px;
+	height: 18px;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--text) 92%, transparent);
+	transition: transform 120ms ease;
+}
+
+.packages-config-toggle-input:checked + .packages-config-toggle-slider {
+	background: color-mix(in srgb, var(--accent) 65%, transparent);
+}
+
+.packages-config-toggle-input:checked + .packages-config-toggle-slider::after {
+	transform: translateX(16px);
+}
+
+.packages-config-toggle-input:disabled + .packages-config-toggle-slider {
+	opacity: 0.6;
+}
+
+.packages-config-advanced {
+	margin-top: 2px;
+}
+
+.packages-config-advanced > summary {
+	cursor: pointer;
+	font-size: 12px;
+	color: var(--muted);
+	user-select: none;
+}
+
+.packages-config-advanced[open] > summary {
+	margin-bottom: 8px;
 }
 
 .packages-config-select,
@@ -2356,6 +2424,17 @@ body.sidebar-resizing {
 	display: flex;
 	gap: 10px;
 	flex-wrap: wrap;
+}
+
+.packages-config-save-inline {
+	display: inline-flex;
+	align-items: center;
+	gap: 8px;
+	flex-wrap: wrap;
+}
+
+.packages-config-save-inline .packages-config-select {
+	min-width: 140px;
 }
 
 .packages-config-modal-actions {
@@ -4391,15 +4470,14 @@ body.sidebar-resizing {
 }
 
 .chat-row {
-	width: min(760px, calc(100% - 24px));
+	width: min(760px, calc(100% - 112px));
 	margin: 0 auto 16px;
-	padding: 0 14px;
+	padding: 0;
 }
 
 .user-row {
 	display: flex;
 	justify-content: flex-end;
-	width: 100%;
 }
 
 .message-shell {
@@ -5542,6 +5620,7 @@ body.sidebar-resizing {
 }
 
 .composer-inner {
+	position: relative;
 	max-width: 760px;
 	margin: 0 auto;
 	display: grid;
@@ -6158,6 +6237,56 @@ body.sidebar-resizing {
 	color: var(--muted);
 }
 
+.composer-queued-row {
+	position: absolute;
+	left: 14px;
+	right: 14px;
+	bottom: calc(100% + 8px);
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+	pointer-events: none;
+}
+
+.composer-queued-pill {
+	display: inline-flex;
+	align-items: center;
+	gap: 7px;
+	max-width: min(520px, 100%);
+	padding: 3px 8px;
+	border-radius: 999px;
+	border: 1px solid color-mix(in srgb, var(--border) 62%, transparent);
+	background: color-mix(in srgb, var(--bg) 78%, transparent);
+	backdrop-filter: blur(6px);
+	font-size: 10px;
+	line-height: 1.2;
+	color: var(--muted);
+}
+
+.composer-queued-label {
+	font-size: 9px;
+	font-weight: 700;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+	color: color-mix(in srgb, var(--muted-2) 85%, var(--muted));
+	flex-shrink: 0;
+}
+
+.composer-queued-text {
+	font-size: 11px;
+	color: var(--text);
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 360px;
+}
+
+.composer-queued-meta {
+	font-size: 10px;
+	color: var(--muted-2);
+	flex-shrink: 0;
+}
+
 .composer-attachments {
 	display: flex;
 	gap: 8px;
@@ -6529,8 +6658,8 @@ body.sidebar-resizing {
 	}
 
 	.chat-row {
-		width: calc(100% - 16px);
-		padding: 0 2px;
+		width: calc(100% - 24px);
+		padding: 0;
 	}
 
 	.intro-text {


### PR DESCRIPTION
## Summary
- finalize docked terminal integration polish (xterm surface, isolated command execution path, queue UX consistency)
- ship dedicated auto-rename Desktop config UX improvements (global-by-default save target, scoped save controls, lower-noise form, toggle controls)
- improve slash/runtime config-command routing and command discoverability hints
- add Desktop SDK compatibility shim extension for legacy `ctx.modelRegistry.getApiKey()` consumers
- suppress internal extension title-sync status keys (e.g. `oqto_title_changed`) so session-name sync no longer leaks as stray composer overlay text
- replace composer attach `+` with a document + paperclip icon and update tooltip copy to `Attach file`

## Issue coverage
- #67 terminal integration baseline and dock polish
- #68 auto-rename migration/config UX + compatibility hardening
- #70 slash command reliability/parity + remaining QA follow-up
- #63 umbrella UX parity slices (settings/composer/workflow polish)
- #71 attach icon polish (`+` -> file/paperclip)

## Validation
- npm run check
- npm run build:frontend