### PR TITLE
fix(compaction): prevent stale stats ring and extend compact timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Fixed workflow summary counters to report mixed outcomes correctly (complete + failed + running) instead of over-reporting failures.
 - Removed blinking assistant-body streaming cursor artifact and removed noisy composer status text beneath model controls.
 - Fixed compaction timeline behavior so compaction rows stay anchored at the correct chronological position instead of drifting to the newest row.
+- Fixed manual `/compact` timeout failures by using an extended RPC timeout window for compaction requests, and fixed post-compaction session stats ring staleness by treating unknown backend context usage as unknown instead of reusing stale pre-compaction fallback tokens.
 - Alt+Enter in composer now surfaces explicit queued-message behavior (`followUp`) with clearer queued labeling in user bubbles.
 - Extension `notify` responses are now surfaced as in-app notices while Desktop is foregrounded, so command feedback from extension workflows (including auto-rename commands) is visible instead of appearing to no-op.
 - Extension runtime errors now include better source context in chat notices, and Desktop emits an explicit compatibility hint when an extension still uses deprecated `ctx.modelRegistry.getApiKey()`.

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -2302,6 +2302,8 @@ export class ChatView {
 			const fromRaw = pickNumber(raw, [
 				"contextWindow",
 				"context_window",
+				"contextUsage.contextWindow",
+				"contextUsage.context_window",
 				"usage.contextWindow",
 				"usage.context_window",
 			]);
@@ -2397,6 +2399,27 @@ export class ChatView {
 		return null;
 	}
 
+	private markContextUsageUnknown(): void {
+		this.lastAssistantContextTokens = null;
+		this.sessionStats = {
+			...this.sessionStats,
+			tokens: null,
+			usageRatio: null,
+			updatedAt: Date.now(),
+		};
+	}
+
+	private refreshAfterCompaction(): void {
+		void (async () => {
+			try {
+				await this.refreshFromBackend();
+			} catch {
+				// ignore and still attempt stats refresh
+			}
+			await this.refreshSessionStats(true);
+		})();
+	}
+
 	private async refreshSessionStats(force = false): Promise<void> {
 		if (this.refreshingSessionStats) return;
 		if (!force && Date.now() - this.sessionStats.updatedAt < 1800) return;
@@ -2413,10 +2436,17 @@ export class ChatView {
 				"usage.tokens.total",
 				"session.totalTokens",
 			]);
+			const contextUsageRecord =
+				raw.contextUsage && typeof raw.contextUsage === "object" ? (raw.contextUsage as Record<string, unknown>) : null;
+			const contextUsageHasTokensKey = Boolean(contextUsageRecord && Object.prototype.hasOwnProperty.call(contextUsageRecord, "tokens"));
+			const contextUsageHasPercentKey = Boolean(contextUsageRecord && Object.prototype.hasOwnProperty.call(contextUsageRecord, "percent"));
+			const contextUsageTokensExplicitNull = contextUsageHasTokensKey && contextUsageRecord?.tokens === null;
+			const contextUsagePercentExplicitNull = contextUsageHasPercentKey && contextUsageRecord?.percent === null;
 			const contextTokensFromStats = pickNumber(raw, [
 				"contextTokens",
 				"context_tokens",
 				"context.tokens",
+				"contextUsage.tokens",
 				"usage.contextTokens",
 				"usage.context_tokens",
 				"usage.tokens.context",
@@ -2453,7 +2483,11 @@ export class ChatView {
 					"context_usage_percent",
 				]),
 			);
-			const contextTokens = contextTokensFromStats ?? this.lastAssistantContextTokens;
+			const contextUsageExplicitlyUnknown =
+				(contextUsageTokensExplicitNull || contextUsagePercentExplicitNull) &&
+				contextTokensFromStats === null &&
+				rawUsageRatio === null;
+			const contextTokens = contextTokensFromStats ?? (contextUsageExplicitlyUnknown ? null : this.lastAssistantContextTokens);
 			const usageRatio =
 				rawUsageRatio ??
 				(contextTokens !== null && contextWindow && contextWindow > 0
@@ -3591,7 +3625,9 @@ export class ChatView {
 						this.compactionCycle.details.push(`Context before compaction: ${Math.round(tokensBefore).toLocaleString()} tokens`);
 					}
 					this.compactionCycle.details.push("Compaction completed successfully.");
+					this.markContextUsageUnknown();
 					this.pushNotice("Auto-compaction complete", "success");
+					this.refreshAfterCompaction();
 				}
 				this.render();
 				break;
@@ -4528,6 +4564,8 @@ export class ChatView {
 				}
 				this.compactionCycle.details.push("Compaction completed successfully.");
 			}
+			this.markContextUsageUnknown();
+			this.render();
 			await this.refreshFromBackend();
 			await this.refreshSessionStats(true);
 			if (this.compactionCycle && typeof this.sessionStats.tokens === "number" && Number.isFinite(this.sessionStats.tokens)) {

--- a/src/rpc/bridge.ts
+++ b/src/rpc/bridge.ts
@@ -689,18 +689,29 @@ export class RpcBridge {
 		this.emitToListeners(data);
 	}
 
+	private timeoutMsForCommand(command: Record<string, unknown>): number {
+		const type = typeof command.type === "string" ? command.type.trim().toLowerCase() : "";
+		switch (type) {
+			case "compact":
+				return 5 * 60_000;
+			default:
+				return 35_000;
+		}
+	}
+
 	private async send(command: Record<string, unknown>): Promise<Record<string, unknown>> {
 		await this.ensureListeners();
 		const id = `req_${++this.requestId}`;
 		const fullCommand = { ...command, id };
 
 		return new Promise((resolve, reject) => {
-			traceBridge(`send instance=${this.instanceId} id=${id} command=${String(command.type)}`);
+			const timeoutMs = this.timeoutMsForCommand(command);
+			traceBridge(`send instance=${this.instanceId} id=${id} command=${String(command.type)} timeoutMs=${timeoutMs}`);
 			const timeout = setTimeout(() => {
 				this.pendingRequests.delete(id);
-				traceBridge(`timeout instance=${this.instanceId} id=${id} command=${String(command.type)}`);
+				traceBridge(`timeout instance=${this.instanceId} id=${id} command=${String(command.type)} timeoutMs=${timeoutMs}`);
 				reject(new Error(`Timeout waiting for response to ${String(command.type)}`));
-			}, 35000);
+			}, timeoutMs);
 
 			this.pendingRequests.set(id, {
 				resolve: (response) => {


### PR DESCRIPTION
## Summary
- fix stale session stats ring after compaction by handling explicit unknown context usage values (`contextUsage.tokens/percent = null`) without falling back to stale pre-compaction assistant tokens
- mark context usage as unknown immediately after compaction completion and trigger refresh pipeline (backend + stats) for both auto and manual compaction paths
- increase RPC timeout window for `compact` commands to avoid false timeout failures on larger sessions

## Validation
- npm run check
- npm run build:frontend

Closes #56
