### PR TITLE
fix(ui): preserve rounded window corners under modal backdrops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Expanded package capability docs now define explicit command contracts (`/<base>`, `/<base> config`, `/<base> config <args>`), safe default settings behavior, and extension SDK auth compatibility guidance (`getApiKeyAndHeaders` first, legacy fallback optional).
 
 ### Fixed
+- Modal/backdrop layers now preserve window corner clipping (rounded dim/blur overlay) so opening dialogs no longer introduces square edge artifacts around the app window.
 - Bundled default Pi Desktop themes now emit full Pi CLI-compatible theme schema (all required color tokens) instead of a partial Desktop-only color set.
 - Fixed `/scoped-models` settings-open race causing Lit `ChildPart has no parentNode` errors by removing unsupported `innerHTML` mutation paths in `SettingsPanel` render/fallback lifecycle.
 - Fixed user message bubble width/wrapping regression that could squeeze short text into broken wrapping (`he j`) by correcting user-shell width constraints and wrap behavior.

--- a/src/components/login-panel.ts
+++ b/src/components/login-panel.ts
@@ -92,7 +92,7 @@ export class LoginPanel {
 		}
 
 		const template = html`
-			<div class="fixed inset-0 z-40 flex items-center justify-center bg-black/50" @click=${(e: Event) => {
+			<div class="login-panel-backdrop fixed inset-0 z-40 flex items-center justify-center bg-black/50" @click=${(e: Event) => {
 				if (e.target === e.currentTarget) this.close();
 			}}>
 				<div class="bg-background rounded-lg shadow-xl border border-border w-full max-w-md p-4">

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -33,6 +33,7 @@
 	--desktop-chrome-blur: 0px;
 	--desktop-chrome-tint-strength: 0%;
 	--desktop-contrast: 50;
+	--app-window-radius: 14px;
 }
 
 * {
@@ -59,7 +60,7 @@ samp {
 
 #app {
 	height: 100%;
-	border-radius: 14px;
+	border-radius: var(--app-window-radius);
 	overflow: hidden;
 	background: var(--bg);
 }
@@ -69,7 +70,7 @@ samp {
 	display: flex;
 	flex-direction: column;
 	background: var(--bg);
-	border-radius: 14px;
+	border-radius: var(--app-window-radius);
 	overflow: hidden;
 }
 
@@ -78,7 +79,7 @@ samp {
 	display: flex;
 	min-height: 0;
 	overflow: hidden;
-	border-radius: 0 0 14px 14px;
+	border-radius: 0 0 var(--app-window-radius) var(--app-window-radius);
 }
 
 .loading-view {
@@ -3480,6 +3481,8 @@ body.sidebar-resizing {
 	justify-content: center;
 	padding: 18px;
 	pointer-events: auto;
+	border-radius: var(--app-window-radius);
+	overflow: hidden;
 }
 
 .sidebar-space-dialog {
@@ -6791,6 +6794,14 @@ body.sidebar-resizing {
 	background: rgba(0, 0, 0, 0.48);
 	backdrop-filter: blur(4px);
 	padding: 18px;
+	border-radius: var(--app-window-radius);
+	overflow: hidden;
+}
+
+#extension-ui-overlay,
+.login-panel-backdrop {
+	border-radius: var(--app-window-radius);
+	overflow: hidden;
 }
 
 .overlay-card,
@@ -7576,6 +7587,8 @@ body.sidebar-resizing {
 	display: grid;
 	place-items: center;
 	z-index: 1200;
+	border-radius: var(--app-window-radius);
+	overflow: hidden;
 }
 
 .settings-subdialog-card {


### PR DESCRIPTION
## Summary
- introduce a shared app window radius token and reuse it on app shell surfaces
- clip full-window modal backdrops (`.overlay`, workspace-create backdrop, settings subdialog backdrop) to the same rounded window radius
- apply the same clipping treatment to extension/login full-screen overlays so dim layers remain rounded instead of showing square edges

## Validation
- npm run check
- npm run build:frontend

Closes #46
