### PR TITLE
feat(terminal): add fast toggle shortcut and command action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Slash palette keyboard navigation now previews the active command directly in the composer input and keeps the active row visible while traversing.
 - Command palette (`Cmd/Ctrl+K`) keyboard navigation now auto-scrolls the selected row into view for long lists.
 - Terminal UX now uses a VS Code-style bottom dock inside chat instead of opening as a standalone terminal tab/pane, with an xterm-powered shell surface and close/clear dock controls.
+- Added `Ctrl/Cmd+\`` keyboard shortcut and command-palette `terminal` action to quickly toggle the docked terminal.
 - Composer follow-up queue UX is now minimal and docked near the composer instead of injecting speculative queued bubbles into the chat timeline.
 - Welcome project dropdown now lists all projects in the current workspace and supports direct project switching (plus quick actions for add project, packages, and settings).
 - Welcome heading copy now rotates between Pi-style idle phrases for a calmer ambient experience.

--- a/src/components/shortcuts-panel.ts
+++ b/src/components/shortcuts-panel.ts
@@ -16,6 +16,7 @@ const SHORTCUTS: Shortcut[] = [
 	{ keys: ["Ctrl/Cmd+Shift+H"], description: "Open session history viewer", category: "Session" },
 	{ keys: ["Ctrl/Cmd+K"], description: "Open command palette", category: "Navigation" },
 	{ keys: ["/"], description: "Open command palette (when editor not focused)", category: "Navigation" },
+	{ keys: ["Ctrl/Cmd+`"], description: "Toggle terminal dock", category: "Navigation" },
 	{ keys: ["Ctrl/Cmd+L"], description: "Focus composer", category: "Input" },
 	{ keys: ["Enter"], description: "Send message / steer when streaming", category: "Input" },
 	{ keys: ["Alt+Enter"], description: "Queue follow-up message", category: "Input" },

--- a/src/main.ts
+++ b/src/main.ts
@@ -2571,14 +2571,7 @@ async function initialize(): Promise<void> {
 			}
 		});
 		chatView.setOnOpenTerminal(() => {
-			const workspace = getActiveWorkspace();
-			if (!workspace) return;
-			const shouldOpen = workspace.pane !== "chat" ? true : !workspace.terminalOpen;
-			workspace.terminalOpen = shouldOpen;
-			workspace.pane = "chat";
-			persistWorkspaces();
-			syncWorkspaceTabsBar();
-			void applyWorkspacePane(workspace);
+			toggleTerminalDock();
 		});
 		chatView.setOnAddProject(() => {
 			void sidebar?.openFolder();
@@ -2899,6 +2892,17 @@ function openPackagesPane(): void {
 	void applyWorkspacePane(workspace);
 }
 
+function toggleTerminalDock(forceOpen?: boolean): void {
+	const workspace = getActiveWorkspace();
+	if (!workspace) return;
+	const shouldOpen = typeof forceOpen === "boolean" ? forceOpen : workspace.pane !== "chat" ? true : !workspace.terminalOpen;
+	workspace.terminalOpen = shouldOpen;
+	workspace.pane = "chat";
+	persistWorkspaces();
+	syncWorkspaceTabsBar();
+	void applyWorkspacePane(workspace);
+}
+
 async function startFreshSessionTab(): Promise<void> {
 	const workspace = getActiveWorkspace();
 	if (!workspace) return;
@@ -2951,6 +2955,11 @@ function wireCommandPaletteBuiltins(): void {
 			name: "packages",
 			description: "Open packages & resources",
 			action: async () => openPackagesPane(),
+		},
+		{
+			name: "terminal",
+			description: "Toggle docked terminal",
+			action: async () => toggleTerminalDock(),
 		},
 		{
 			name: "fork",
@@ -3144,6 +3153,12 @@ function setupKeyboardShortcuts(): void {
 		if (isCtrlOrMeta && e.key === "/") {
 			e.preventDefault();
 			shortcutsPanel?.open();
+			return;
+		}
+
+		if (isCtrlOrMeta && !isShift && e.code === "Backquote") {
+			e.preventDefault();
+			toggleTerminalDock();
 			return;
 		}
 
@@ -3373,14 +3388,7 @@ function renderApp(): void {
 			);
 		});
 		contentTabsBar.setOnOpenTerminal(() => {
-			const workspace = getActiveWorkspace();
-			if (!workspace) return;
-			const shouldOpen = workspace.pane !== "chat" ? true : !workspace.terminalOpen;
-			workspace.terminalOpen = shouldOpen;
-			workspace.pane = "chat";
-			persistWorkspaces();
-			syncWorkspaceTabsBar();
-			void applyWorkspacePane(workspace);
+			toggleTerminalDock();
 		});
 		contentTabsBar.setOnRename((tabId, nextTitle) => {
 			const workspace = getActiveWorkspace();


### PR DESCRIPTION
## Summary
- add a global Ctrl/Cmd+Backquote shortcut to toggle the docked terminal
- add a command palette builtin action (`terminal`) for the same toggle behavior
- centralize terminal toggle logic in a shared helper used by chat actions, tabs action, and keyboard shortcut
- document the shortcut in the shortcuts panel and changelog

## Validation
- npm run check
- npm run build:frontend

Refs #67
