### PR TITLE
fix(terminal): add /terminal slash command and mac hotkey fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Slash palette keyboard navigation now previews the active command directly in the composer input and keeps the active row visible while traversing.
 - Command palette (`Cmd/Ctrl+K`) keyboard navigation now auto-scrolls the selected row into view for long lists.
 - Terminal UX now uses a VS Code-style bottom dock inside chat instead of opening as a standalone terminal tab/pane, with an xterm-powered shell surface and close/clear dock controls.
-- Added `Ctrl/Cmd+\`` keyboard shortcut and command-palette `terminal` action to quickly toggle the docked terminal.
+- Added fast docked-terminal toggles via keyboard (`Ctrl+\`` and `Cmd+Alt+T`), command palette (`terminal`), and slash command (`/terminal`).
 - Composer follow-up queue UX is now minimal and docked near the composer instead of injecting speculative queued bubbles into the chat timeline.
 - Welcome project dropdown now lists all projects in the current workspace and supports direct project switching (plus quick actions for add project, packages, and settings).
 - Welcome heading copy now rotates between Pi-style idle phrases for a calmer ambient experience.

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -230,6 +230,7 @@ const BUILTIN_SLASH_COMMANDS: Array<{ name: string; description: string }> = [
 	{ name: "session", description: "Append detailed session info + token stats" },
 	{ name: "changelog", description: "Show latest changelog in collapsible row (/changelog all, /changelog refresh)" },
 	{ name: "hotkeys", description: "Open keyboard shortcuts" },
+	{ name: "terminal", description: "Toggle docked terminal" },
 	{ name: "fork", description: "Open fork flow, /fork <query> pre-fills message search" },
 	{ name: "tree", description: "Open full session tree across branches, /tree <query> pre-fills search" },
 	{ name: "login", description: "Terminal-only today: /login [provider] guidance" },
@@ -1463,6 +1464,14 @@ export class ChatView {
 					this.onOpenShortcuts();
 				} else {
 					this.pushNotice("Keyboard shortcuts panel is unavailable", "info");
+				}
+				return;
+			}
+			case "terminal": {
+				if (this.onOpenTerminal) {
+					this.onOpenTerminal();
+				} else {
+					this.pushNotice("Terminal panel is unavailable", "info");
 				}
 				return;
 			}

--- a/src/components/shortcuts-panel.ts
+++ b/src/components/shortcuts-panel.ts
@@ -16,7 +16,7 @@ const SHORTCUTS: Shortcut[] = [
 	{ keys: ["Ctrl/Cmd+Shift+H"], description: "Open session history viewer", category: "Session" },
 	{ keys: ["Ctrl/Cmd+K"], description: "Open command palette", category: "Navigation" },
 	{ keys: ["/"], description: "Open command palette (when editor not focused)", category: "Navigation" },
-	{ keys: ["Ctrl/Cmd+`"], description: "Toggle terminal dock", category: "Navigation" },
+	{ keys: ["Ctrl+`", "Cmd+Alt+T"], description: "Toggle terminal dock", category: "Navigation" },
 	{ keys: ["Ctrl/Cmd+L"], description: "Focus composer", category: "Input" },
 	{ keys: ["Enter"], description: "Send message / steer when streaming", category: "Input" },
 	{ keys: ["Alt+Enter"], description: "Queue follow-up message", category: "Input" },

--- a/src/main.ts
+++ b/src/main.ts
@@ -3156,7 +3156,10 @@ function setupKeyboardShortcuts(): void {
 			return;
 		}
 
-		if (isCtrlOrMeta && !isShift && e.code === "Backquote") {
+		const terminalHotkey =
+			(isCtrlOrMeta && (e.code === "Backquote" || e.key === "`" || e.key === "Dead" || e.key === "´")) ||
+			(e.metaKey && e.altKey && e.key.toLowerCase() === "t");
+		if (terminalHotkey) {
 			e.preventDefault();
 			toggleTerminalDock();
 			return;


### PR DESCRIPTION
## Summary
- add `/terminal` as a built-in slash command in the composer slash palette
- wire `/terminal` to the same dock toggle action used by terminal UI controls
- make terminal hotkey handling more robust across keyboard layouts:
  - support dead-key/backquote variants
  - add mac fallback `Cmd+Alt+T` (since `Cmd+\`` is commonly intercepted by macOS window cycling)
- update shortcuts panel and changelog copy to match the final shortcuts

## Validation
- npm run check
- npm run build:frontend

Refs #67
