### PR TITLE
docs(terminal): clarify shortcut parity tracking scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - File split resize is now bounded to avoid overlap with the floating chat composer, while keeping the divider full-height in the chat surface.
 - Simplified content-tab trailing chrome by removing the visual divider next to the terminal button.
 - Terminal UX now uses a VS Code-style bottom dock inside chat instead of opening as a standalone terminal tab/pane, with an xterm-powered shell surface and close/clear dock controls.
-- Added fast docked-terminal toggles via keyboard (`Ctrl+\`` and `Cmd+Alt+T`), command palette (`terminal`), and slash command (`/terminal`).
+- Added fast docked-terminal toggles via command palette (`terminal`) and slash command (`/terminal`); keyboard shortcut parity across OS/layouts is being tracked in a dedicated follow-up.
 - Composer follow-up queue UX is now minimal and docked near the composer instead of injecting speculative queued bubbles into the chat timeline.
 - Welcome project dropdown now lists all projects in the current workspace and supports direct project switching (plus quick actions for add project, packages, and settings).
 - Welcome heading copy now rotates between Pi-style idle phrases for a calmer ambient experience.

--- a/issues/feature-terminal-integration.md
+++ b/issues/feature-terminal-integration.md
@@ -26,6 +26,7 @@ Status: Implemented baseline on `feat/70-slash-actions-reliability` (2026-04-06)
 
 - Legacy persisted `pane: "terminal"` state is auto-normalized back to `pane: "chat"` with terminal dock open.
 - Current implementation is single docked terminal panel (no split panes/multi-terminal tabs yet).
+- Slash/command-palette terminal toggle is stable; app-wide keyboard shortcut reliability is tracked separately in issue #84.
 
 ## Potential follow-ups
 


### PR DESCRIPTION
## Summary
- document latest QA outcome for terminal toggles:
  - `/terminal` and command palette `terminal` are stable
  - keyboard shortcut parity is deferred to dedicated follow-up
- align changelog wording with that scope boundary
- update terminal follow-up notes with explicit reference to shortcut tracking issue #84

## Validation
- npm run check

Refs #67
Refs #84
