### PR TITLE
fix(notify): desktop-only flow + Pi DESK notification polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Compaction status rendering was reduced to a minimal workflow-style row with collapsed-by-default details instead of a heavy status card.
 - Auto-rename extension recommendation and desktop config bridge now target `@byteowlz/pi-auto-rename`, with dynamic command-to-package resolution for config-intent slash commands (including `/auto-rename config`) instead of hardcoded package-name routing.
 - Recommended notifications extension now defaults to `pi-smart-voice-notify`, and Packages auto-migrates legacy `pi-desktop-notify` installs by installing the new package and removing the old one.
+- Desktop now installs a lightweight capability-native notify bridge extension (`~/.pi/agent/extensions/pi-desktop-notify-bridge.ts`) and enforces non-Windows `pi-smart-voice-notify` host mode (`enableDesktopNotification: false`) so desktop delivery flows through `ctx.ui.notify`.
 - Packages modal now includes a dedicated auto-rename settings editor (enabled/mode/model/fallback/prefix/debug + Save/Test actions) backed by `auto-rename.json`, so extension behavior can be configured directly in Desktop.
 - Auto-rename settings now support explicit save target selection (global or project), including choosing among opened sidebar projects for project-scoped config writes.
 - Save target controls were moved next to the Save action in auto-rename settings (instead of top-of-form) for a cleaner, less noisy flow.
@@ -58,9 +59,9 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Fixed compaction timeline behavior so compaction rows stay anchored at the correct chronological position instead of drifting to the newest row.
 - Fixed manual `/compact` timeout failures by using an extended RPC timeout window for compaction requests, and fixed post-compaction session stats ring staleness by treating unknown backend context usage as unknown instead of reusing stale pre-compaction fallback tokens.
 - Alt+Enter in composer now surfaces explicit queued-message behavior (`followUp`) with clearer queued labeling in user bubbles.
-- Extension `notify` responses are now surfaced as in-app notices while Desktop is foregrounded, so command feedback from extension workflows (including auto-rename commands) is visible instead of appearing to no-op.
+- Extension notify delivery now stays desktop-native only (no in-app chat toasts), and notifications are emitted only when Desktop is out of focus.
 - Background desktop notifications now include workspace/session context suffixes (for example `[Workspace 1] -> [session-name]`) and carry richer per-notification targeting metadata for more deterministic deep-link focus behavior.
-- Foreground notification handling now also surfaces extension `notify` events coming from background runtimes as in-app notices, fixing missed notifications while the desktop window is focused.
+- Desktop notification copy/branding was polished (`Pi DESK` title formatting, cleaned body text, context line layout), with richer payload metadata preserved for deterministic click-to-focus routing.
 - Extension runtime errors now include better source context in chat notices, and Desktop emits an explicit compatibility hint when an extension still uses deprecated `ctx.modelRegistry.getApiKey()`.
 - Desktop now ensures a global compatibility extension (`~/.pi/agent/extensions/pi-desktop-sdk-compat.ts`) is installed to shim `modelRegistry.getApiKey()` via `getApiKeyAndHeaders()` for legacy extensions, restoring runtime compatibility for packages such as `@byteowlz/pi-auto-rename`.
 - Auto-rename settings now correctly hydrate saved `model`/`fallbackModel` values from object-form config (`{ provider, id }`) and keep those values visible in model dropdowns (including unavailable-but-saved models).

--- a/src/components/extension-ui-handler.ts
+++ b/src/components/extension-ui-handler.ts
@@ -121,6 +121,12 @@ function shouldSuppressUiStatusKey(key: string): boolean {
 	return false;
 }
 
+function joinFsPath(base: string, child: string): string {
+	const normalizedBase = base.replace(/\\/g, "/").replace(/\/+$/, "");
+	const normalizedChild = child.replace(/\\/g, "/").replace(/^\/+/, "");
+	return normalizedBase ? `${normalizedBase}/${normalizedChild}` : normalizedChild;
+}
+
 export interface NotificationActionTarget {
 	workspaceId?: string;
 	tabId?: string;
@@ -143,6 +149,8 @@ export class ExtensionUiHandler {
 	private lastNotificationActionTarget: NotificationActionTarget | null = null;
 	private lastDesktopNotificationKey = "";
 	private lastDesktopNotificationAt = 0;
+	private nextDesktopNotificationId = 1;
+	private desktopNotificationIconPath: string | null | undefined = undefined;
 
 	constructor() {
 		this.createContainers();
@@ -219,7 +227,70 @@ export class ExtensionUiHandler {
 		const normalizedBody = body.trim();
 		if (!normalizedBody) return contextSuffix;
 		if (normalizedBody.includes(contextSuffix)) return normalizedBody;
-		return `${normalizedBody} ${contextSuffix}`;
+		return `${normalizedBody}\n${contextSuffix}`;
+	}
+
+	private nextNotificationId(): number {
+		const current = this.nextDesktopNotificationId;
+		this.nextDesktopNotificationId = current >= 2_100_000_000 ? 1 : current + 1;
+		return current;
+	}
+
+	private sanitizeDesktopNotificationText(text: string): string {
+		return text
+			.replace(/[✅❌❓⚠️]/g, "")
+			.replace(/\bpi\s*-\s*/gi, "")
+			.replace(/\bsmart voice notify\b/gi, "")
+			.replace(/\s+/g, " ")
+			.trim();
+	}
+
+	private formatDesktopNotificationTitle(request: ExtensionUiRequest): string {
+		const cleanedTitle = this.sanitizeDesktopNotificationText(request.title?.trim() || "");
+		if (cleanedTitle) return `Pi DESK · ${cleanedTitle}`;
+		switch ((request.notifyType || "").toLowerCase()) {
+			case "error":
+				return "Pi DESK · Needs attention";
+			case "warning":
+				return "Pi DESK · Action needed";
+			default:
+				return "Pi DESK · Update";
+		}
+	}
+
+	private formatDesktopNotificationBody(request: ExtensionUiRequest, contextSuffix: string): string {
+		const cleanedMessage = this.sanitizeDesktopNotificationText(request.message?.trim() || "");
+		const cleanedTitle = this.sanitizeDesktopNotificationText(request.title?.trim() || "");
+		const base = cleanedMessage || cleanedTitle || "Agent update available.";
+		return this.appendNotificationContext(base, contextSuffix);
+	}
+
+	private async resolveDesktopNotificationIconPath(): Promise<string | undefined> {
+		if (this.desktopNotificationIconPath !== undefined) return this.desktopNotificationIconPath || undefined;
+		try {
+			const { resourceDir } = await import("@tauri-apps/api/path");
+			const { exists } = await import("@tauri-apps/plugin-fs");
+			const resourcesRoot = (await resourceDir()).replace(/\\/g, "/").replace(/\/+$/, "");
+			if (!resourcesRoot) {
+				this.desktopNotificationIconPath = null;
+				return undefined;
+			}
+			const candidates = [
+				joinFsPath(joinFsPath(resourcesRoot, "icons"), "icon.png"),
+				joinFsPath(joinFsPath(resourcesRoot, "icons"), "128x128.png"),
+				joinFsPath(joinFsPath(resourcesRoot, "icons"), "32x32.png"),
+			];
+			for (const candidate of candidates) {
+				if (await exists(candidate)) {
+					this.desktopNotificationIconPath = candidate;
+					return candidate;
+				}
+			}
+		} catch {
+			// ignore
+		}
+		this.desktopNotificationIconPath = null;
+		return undefined;
 	}
 
 	private describeNotificationContext(backgrounded: boolean): string {
@@ -631,11 +702,9 @@ export class ExtensionUiHandler {
 	}
 
 	private async showDesktopNotification(request: ExtensionUiRequest): Promise<boolean> {
-		const rawTitle = request.title?.trim() || "Pi Desktop";
-		const rawBody = request.message?.trim() || "";
 		const contextSuffix = this.formatNotificationContextSuffix(request);
-		const title = rawBody ? rawTitle : "Pi Desktop";
-		const body = this.appendNotificationContext(rawBody || rawTitle, contextSuffix);
+		const title = this.formatDesktopNotificationTitle(request);
+		const body = this.formatDesktopNotificationBody(request, contextSuffix);
 
 		let granted = await this.ensureDesktopNotificationPermission(false);
 		if (!granted) {
@@ -652,9 +721,13 @@ export class ExtensionUiHandler {
 		}
 
 		const options: DesktopNotificationOptions = {
+			id: this.nextNotificationId(),
 			title,
 			body,
-			autoCancel: true,
+			largeBody: body,
+			summary: contextSuffix || "Pi DESK",
+			group: "pi-desk-notifications",
+			autoCancel: false,
 			extra: {
 				notifyType: request.notifyType ?? "info",
 				method: request.method,
@@ -665,6 +738,10 @@ export class ExtensionUiHandler {
 				...(actionTarget?.sessionLabel ? { notifyTargetSessionLabel: actionTarget.sessionLabel } : {}),
 			},
 		};
+		const iconPath = await this.resolveDesktopNotificationIconPath();
+		if (iconPath) {
+			options.icon = iconPath;
+		}
 		const sound = this.getDesktopNotificationSound();
 		if (sound) {
 			options.sound = sound;

--- a/src/extensions/desktop-notify-bridge-extension.ts
+++ b/src/extensions/desktop-notify-bridge-extension.ts
@@ -1,0 +1,135 @@
+const DESKTOP_NOTIFY_BRIDGE_EXTENSION_FILE = "pi-desktop-notify-bridge.ts";
+const DESKTOP_NOTIFY_BRIDGE_MARKER = "pi-desktop-notify-bridge-extension/v1";
+
+const DESKTOP_NOTIFY_BRIDGE_CONTENT = `/**
+ * ${DESKTOP_NOTIFY_BRIDGE_MARKER}
+ *
+ * Minimal capability-native desktop notification bridge for Pi Desktop.
+ *
+ * Why this exists:
+ * - Extensions should use ctx.ui.notify(...) for host-native delivery.
+ * - Desktop host applies focus/background gating + deep-link metadata.
+ *
+ * This bridge emits one notify on agent_end:
+ * - success => info
+ * - run with error => error
+ */
+export default function (pi) {
+\tconst MIN_INTERVAL_MS = 2000;
+\tlet lastNotifyAt = 0;
+\tlet runHadError = false;
+
+\tconst shouldNotifyNow = () => {
+\t\tconst now = Date.now();
+\t\tif (now - lastNotifyAt < MIN_INTERVAL_MS) return false;
+\t\tlastNotifyAt = now;
+\t\treturn true;
+\t};
+
+\tconst notify = (ctx, message, kind = "info") => {
+\t\tif (!ctx || !ctx.hasUI || !ctx.ui || typeof ctx.ui.notify !== "function") return;
+\t\tif (!shouldNotifyNow()) return;
+\t\tctx.ui.notify(message, kind);
+\t};
+
+\tconst resetRunState = () => {
+\t\trunHadError = false;
+\t};
+
+\tpi.on("session_start", resetRunState);
+\tpi.on("session_switch", resetRunState);
+\tpi.on("agent_start", resetRunState);
+\tpi.on("error", () => {
+\t\trunHadError = true;
+\t});
+\tpi.on("agent_end", (_event, ctx) => {
+\t\tif (runHadError) {
+\t\t\tnotify(ctx, "Agent run ended with an error.", "error");
+\t\t} else {
+\t\t\tnotify(ctx, "Agent finished its current task.", "info");
+\t\t}
+\t\tresetRunState();
+\t});
+}
+`;
+
+function joinFsPath(base: string, child: string): string {
+	const b = base.replace(/\\/g, "/").replace(/\/+$/, "");
+	const c = child.replace(/\\/g, "/").replace(/^\/+/, "");
+	return b ? `${b}/${c}` : c;
+}
+
+async function resolveGlobalExtensionsRoot(): Promise<string | null> {
+	const { homeDir } = await import("@tauri-apps/api/path");
+	const home = (await homeDir()).replace(/\\/g, "/").replace(/\/+$/, "");
+	if (!home) return null;
+	return joinFsPath(joinFsPath(joinFsPath(home, ".pi"), "agent"), "extensions");
+}
+
+export interface DesktopNotifyBridgeInstallResult {
+	path: string;
+	created: boolean;
+	updated: boolean;
+	skipped: boolean;
+	error?: string;
+}
+
+export async function ensureDesktopNotifyBridgeExtensionInstalled(): Promise<DesktopNotifyBridgeInstallResult> {
+	const root = await resolveGlobalExtensionsRoot();
+	if (!root) {
+		return {
+			path: "",
+			created: false,
+			updated: false,
+			skipped: true,
+			error: "Could not resolve home directory",
+		};
+	}
+
+	const extensionPath = joinFsPath(root, DESKTOP_NOTIFY_BRIDGE_EXTENSION_FILE);
+
+	try {
+		const { exists, mkdir, readTextFile, writeTextFile } = await import("@tauri-apps/plugin-fs");
+		await mkdir(root, { recursive: true });
+
+		const hasExisting = await exists(extensionPath);
+		const existingContent = hasExisting ? await readTextFile(extensionPath).catch(() => "") : "";
+
+		const normalizedExisting = existingContent.replace(/\r\n/g, "\n").trim();
+		const normalizedTarget = DESKTOP_NOTIFY_BRIDGE_CONTENT.trim();
+		if (normalizedExisting === normalizedTarget) {
+			return {
+				path: extensionPath,
+				created: false,
+				updated: false,
+				skipped: false,
+			};
+		}
+
+		if (hasExisting && normalizedExisting.length > 0 && !existingContent.includes(DESKTOP_NOTIFY_BRIDGE_MARKER)) {
+			return {
+				path: extensionPath,
+				created: false,
+				updated: false,
+				skipped: true,
+				error: `Skipped writing notify bridge extension because ${DESKTOP_NOTIFY_BRIDGE_EXTENSION_FILE} is user-managed.`,
+			};
+		}
+
+		await writeTextFile(extensionPath, DESKTOP_NOTIFY_BRIDGE_CONTENT);
+		return {
+			path: extensionPath,
+			created: !hasExisting,
+			updated: hasExisting,
+			skipped: false,
+		};
+	} catch (err) {
+		return {
+			path: extensionPath,
+			created: false,
+			updated: false,
+			skipped: false,
+			error: err instanceof Error ? err.message : String(err),
+		};
+	}
+}

--- a/src/extensions/smart-voice-notify-config.ts
+++ b/src/extensions/smart-voice-notify-config.ts
@@ -1,0 +1,95 @@
+const SMART_VOICE_NOTIFY_DIR = "pi-smart-voice-notify";
+const SMART_VOICE_NOTIFY_CONFIG_FILE = "config.json";
+
+function joinFsPath(base: string, child: string): string {
+	const b = base.replace(/\\/g, "/").replace(/\/+$/, "");
+	const c = child.replace(/\\/g, "/").replace(/^\/+/, "");
+	return b ? `${b}/${c}` : c;
+}
+
+function isLikelyWindowsPlatform(): boolean {
+	if (typeof navigator === "undefined") return false;
+	const platform = `${navigator.platform} ${navigator.userAgent}`.toLowerCase();
+	return platform.includes("win");
+}
+
+function normalizeJsonRecord(value: string): Record<string, unknown> {
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+			return parsed as Record<string, unknown>;
+		}
+	} catch {
+		// fall through
+	}
+	return {};
+}
+
+export interface SmartVoiceNotifyHostModeResult {
+	path: string;
+	updated: boolean;
+	skipped: boolean;
+	reason?: string;
+	error?: string;
+}
+
+export async function ensureSmartVoiceNotifyDesktopHostMode(): Promise<SmartVoiceNotifyHostModeResult> {
+	if (isLikelyWindowsPlatform()) {
+		return {
+			path: "",
+			updated: false,
+			skipped: true,
+			reason: "windows-platform",
+		};
+	}
+
+	try {
+		const { homeDir } = await import("@tauri-apps/api/path");
+		const { exists, mkdir, readTextFile, writeTextFile } = await import("@tauri-apps/plugin-fs");
+		const home = (await homeDir()).replace(/\\/g, "/").replace(/\/+$/, "");
+		if (!home) {
+			return {
+				path: "",
+				updated: false,
+				skipped: true,
+				error: "Could not resolve home directory",
+			};
+		}
+
+		const extensionDir = joinFsPath(
+			joinFsPath(joinFsPath(joinFsPath(home, ".pi"), "agent"), "extensions"),
+			SMART_VOICE_NOTIFY_DIR,
+		);
+		const configPath = joinFsPath(extensionDir, SMART_VOICE_NOTIFY_CONFIG_FILE);
+
+		await mkdir(extensionDir, { recursive: true });
+		const hasConfig = await exists(configPath);
+		const current = hasConfig ? normalizeJsonRecord(await readTextFile(configPath).catch(() => "{}")) : {};
+		if (current.enableDesktopNotification === false) {
+			return {
+				path: configPath,
+				updated: false,
+				skipped: true,
+				reason: "already-host-mode",
+			};
+		}
+
+		const next = {
+			...current,
+			enableDesktopNotification: false,
+		};
+		await writeTextFile(configPath, `${JSON.stringify(next, null, 2)}\n`);
+		return {
+			path: configPath,
+			updated: true,
+			skipped: false,
+		};
+	} catch (err) {
+		return {
+			path: "",
+			updated: false,
+			skipped: false,
+			error: err instanceof Error ? err.message : String(err),
+		};
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,9 @@ import {
 import { syncDesktopThemeWithPiTheme } from "./theme/pi-theme-bridge.js";
 import { DESKTOP_THEME_CHANGED_EVENT, getResolvedDesktopTheme, initializeDesktopTheme, toggleDesktopTheme } from "./theme/theme-manager.js";
 import { ensureBundledThemesInstalled } from "./theme/bundled-themes.js";
+import { ensureDesktopNotifyBridgeExtensionInstalled } from "./extensions/desktop-notify-bridge-extension.js";
 import { ensureDesktopSdkCompatExtensionInstalled } from "./extensions/sdk-compat-extension.js";
+import { ensureSmartVoiceNotifyDesktopHostMode } from "./extensions/smart-voice-notify-config.js";
 import "./styles/app.css";
 
 interface WorkspaceSessionTab {
@@ -529,42 +531,6 @@ function resolveRuntimeNotifyTarget(runtime: SessionRuntime): {
 	};
 }
 
-function isDesktopForegrounded(): boolean {
-	return typeof document !== "undefined" && document.visibilityState !== "hidden" && document.hasFocus();
-}
-
-function notifyContextSuffixFromPayload(payload: Record<string, unknown>): string {
-	const workspaceLabel = typeof payload.notifyTargetWorkspaceLabel === "string" ? payload.notifyTargetWorkspaceLabel.trim() : "";
-	const sessionLabel = typeof payload.notifyTargetSessionLabel === "string" ? payload.notifyTargetSessionLabel.trim() : "";
-	if (!workspaceLabel && !sessionLabel) return "";
-	if (!workspaceLabel) return `[${sessionLabel}]`;
-	if (!sessionLabel) return `[${workspaceLabel}]`;
-	return `[${workspaceLabel}] -> [${sessionLabel}]`;
-}
-
-function notifyTextFromPayload(payload: Record<string, unknown>): string {
-	const base =
-		(typeof payload.message === "string" && payload.message.trim()) ||
-		(typeof payload.title === "string" && payload.title.trim()) ||
-		"";
-	if (!base) return "";
-	const suffix = notifyContextSuffixFromPayload(payload);
-	if (!suffix || base.includes(suffix)) return base;
-	return `${base} ${suffix}`;
-}
-
-function notifyKindFromPayload(payload: Record<string, unknown>): "info" | "error" {
-	const notifyType = typeof payload.notifyType === "string" ? payload.notifyType.trim().toLowerCase() : "info";
-	return notifyType === "error" ? "error" : "info";
-}
-
-function emitForegroundNotifyFromPayload(payload: Record<string, unknown>): void {
-	if (!isDesktopForegrounded()) return;
-	const text = notifyTextFromPayload(payload);
-	if (!text) return;
-	chatView?.notify(text, notifyKindFromPayload(payload));
-}
-
 function handleBackgroundRuntimeNotifyEvent(runtimeKey: string, event: Record<string, unknown>): void {
 	const runtime = sessionRuntimes.get(runtimeKey);
 	if (!runtime) return;
@@ -592,8 +558,6 @@ function handleBackgroundRuntimeNotifyEvent(runtimeKey: string, event: Record<st
 		);
 		markSessionAttentionTarget(target);
 	}
-
-	emitForegroundNotifyFromPayload(request);
 
 	const normalizedRequest = normalizeExtensionUiRequest(request);
 	if (!normalizedRequest) {
@@ -2727,6 +2691,14 @@ async function initialize(): Promise<void> {
 	if (compatInstall.error && !compatInstall.skipped) {
 		console.warn("Failed to install desktop compatibility extension:", compatInstall.error);
 	}
+	const notifyBridgeInstall = await ensureDesktopNotifyBridgeExtensionInstalled();
+	if (notifyBridgeInstall.error && !notifyBridgeInstall.skipped) {
+		console.warn("Failed to install desktop notify bridge extension:", notifyBridgeInstall.error);
+	}
+	const smartVoiceNotifyHostMode = await ensureSmartVoiceNotifyDesktopHostMode();
+	if (smartVoiceNotifyHostMode.error && !smartVoiceNotifyHostMode.skipped) {
+		console.warn("Failed to enforce smart voice notify desktop host mode:", smartVoiceNotifyHostMode.error);
+	}
 
 	try {
 		connectionError = null;
@@ -3087,7 +3059,6 @@ function initializeComponents(): void {
 					});
 				}
 
-				emitForegroundNotifyFromPayload(request);
 			}
 
 			const normalizedRequest = normalizeExtensionUiRequest(request);

--- a/src/recommended-packages.ts
+++ b/src/recommended-packages.ts
@@ -34,7 +34,7 @@ export const RECOMMENDED_PACKAGES: RecommendedPackageDefinition[] = [
 		publisher: "community",
 		resourcesLabel: "1 extension",
 		installSourceHint: "npm:pi-smart-voice-notify",
-		aliases: ["pi-smart-voice-notify"],
+		aliases: ["pi-smart-voice-notify", "pi-desktop-notify"],
 	},
 	{
 		id: "pi-auto-rename",


### PR DESCRIPTION
## Summary
- remove in-app notify toasts for extension `notify` payloads; desktop notifications now remain desktop-only and background-gated
- keep click-to-focus deep-link metadata flow for workspace/session targeting
- polish desktop notification presentation:
  - `Pi DESK` title formatting
  - cleaned notification body text (strip noisy prefixes/emoji patterns)
  - context rendered as a separate line (`[Workspace] -> [Session]`)
  - grouped notifications + stable id + icon lookup from app resources where available
- install a lightweight global notify bridge extension (`pi-desktop-notify-bridge.ts`) that emits capability-native `ctx.ui.notify(...)` on `agent_end`
- enforce non-Windows smart-voice host mode by writing `enableDesktopNotification: false` in `~/.pi/agent/extensions/pi-smart-voice-notify/config.json` so desktop delivery goes through host capability flow
- keep recommended package default as `pi-smart-voice-notify` and legacy alias recognition

## Validation
- npm run check
- npm run build:frontend

Follow-up to #51
