### PR TITLE
fix(notify): remove /voice-notify status leak + harden background delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Extension notify delivery now stays desktop-native only (no in-app chat toasts), and notifications are emitted only when Desktop is out of focus.
 - Background desktop notifications now include workspace/session context suffixes (for example `[Workspace 1] -> [session-name]`) and carry richer per-notification targeting metadata for more deterministic deep-link focus behavior.
 - Desktop notification copy/branding was polished (`Pi DESK` title formatting, cleaned body text, context line layout), with richer payload metadata preserved for deterministic click-to-focus routing.
+- Suppressed `smart-voice-notify` status-key output from the floating composer-status layer, so `/voice-notify reload` no longer leaves stray text near the composer.
+- Notification background detection now re-checks Tauri window focus at dispatch time, and Desktop synthesizes a host-side run-end notify fallback when no extension notify was emitted for that run.
 - Extension runtime errors now include better source context in chat notices, and Desktop emits an explicit compatibility hint when an extension still uses deprecated `ctx.modelRegistry.getApiKey()`.
 - Desktop now ensures a global compatibility extension (`~/.pi/agent/extensions/pi-desktop-sdk-compat.ts`) is installed to shim `modelRegistry.getApiKey()` via `getApiKeyAndHeaders()` for legacy extensions, restoring runtime compatibility for packages such as `@byteowlz/pi-auto-rename`.
 - Auto-rename settings now correctly hydrate saved `model`/`fallbackModel` values from object-form config (`{ provider, id }`) and keep those values visible in model dropdowns (including unavailable-but-saved models).

--- a/src/components/extension-ui-handler.ts
+++ b/src/components/extension-ui-handler.ts
@@ -116,6 +116,8 @@ function shouldSuppressUiStatusKey(key: string): boolean {
 	const normalized = key.trim().toLowerCase();
 	if (!normalized) return false;
 	if (normalized === "oqto_title_changed") return true;
+	if (normalized === "smart-voice-notify") return true;
+	if (normalized.includes("voice-notify")) return true;
 	if (/(^|[_.-])title([_.-])?changed($|[_.-])/.test(normalized)) return true;
 	if (normalized.includes("session.title_changed")) return true;
 	return false;
@@ -125,6 +127,50 @@ function joinFsPath(base: string, child: string): string {
 	const normalizedBase = base.replace(/\\/g, "/").replace(/\/+$/, "");
 	const normalizedChild = child.replace(/\\/g, "/").replace(/^\/+/, "");
 	return normalizedBase ? `${normalizedBase}/${normalizedChild}` : normalizedChild;
+}
+
+interface ExtensionUiFocusTracker {
+	focused: boolean;
+	initialized: boolean;
+	subscribers: Set<(focused: boolean) => void>;
+}
+
+type WindowWithExtensionUiFocusTracker = typeof window & {
+	__PI_DESKTOP_EXTENSION_UI_FOCUS_TRACKER__?: ExtensionUiFocusTracker;
+};
+
+function ensureExtensionUiFocusTrackerInitialized(): ExtensionUiFocusTracker | null {
+	if (typeof window === "undefined" || typeof document === "undefined") return null;
+	const win = window as WindowWithExtensionUiFocusTracker;
+	let tracker = win.__PI_DESKTOP_EXTENSION_UI_FOCUS_TRACKER__;
+	if (!tracker) {
+		tracker = {
+			focused: document.visibilityState !== "hidden" && document.hasFocus(),
+			initialized: false,
+			subscribers: new Set(),
+		};
+		win.__PI_DESKTOP_EXTENSION_UI_FOCUS_TRACKER__ = tracker;
+	}
+	if (!tracker.initialized) {
+		const publish = (focused: boolean) => {
+			if (tracker.focused === focused) return;
+			tracker.focused = focused;
+			for (const subscriber of tracker.subscribers) {
+				subscriber(focused);
+			}
+		};
+		window.addEventListener("focus", () => publish(true));
+		window.addEventListener("blur", () => publish(false));
+		document.addEventListener("visibilitychange", () => {
+			if (document.visibilityState === "hidden") {
+				publish(false);
+				return;
+			}
+			publish(document.hasFocus());
+		});
+		tracker.initialized = true;
+	}
+	return tracker;
 }
 
 export interface NotificationActionTarget {
@@ -144,6 +190,8 @@ export class ExtensionUiHandler {
 	private onTrace: ((message: string) => void) | null = null;
 	private onNotificationActionTarget: ((target: NotificationActionTarget) => void) | null = null;
 	private appWindowFocused = typeof document !== "undefined" ? document.hasFocus() : true;
+	private lastKnownTauriWindowFocus: boolean | null = null;
+	private releaseFocusTrackerSubscription: (() => void) | null = null;
 	private notificationPermissionRequested = false;
 	private notificationActionListenerRegistered = false;
 	private lastNotificationActionTarget: NotificationActionTarget | null = null;
@@ -179,30 +227,33 @@ export class ExtensionUiHandler {
 		console.debug(`[extension-ui] ${message}`);
 	}
 
-	private isAppBackgrounded(): boolean {
+	private async isAppBackgrounded(): Promise<boolean> {
 		if (typeof document === "undefined") return false;
-		return document.visibilityState === "hidden" || !this.appWindowFocused || !document.hasFocus();
+		const visibilityHidden = document.visibilityState === "hidden";
+		const domFocused = document.hasFocus();
+		let windowFocused = this.appWindowFocused;
+		try {
+			windowFocused = await getCurrentWindow().isFocused();
+			this.lastKnownTauriWindowFocus = windowFocused;
+			this.appWindowFocused = windowFocused;
+		} catch {
+			this.lastKnownTauriWindowFocus = null;
+		}
+		return visibilityHidden || !domFocused || !windowFocused;
 	}
 
 	private ensureAppFocusTracking(): void {
-		if (typeof window === "undefined" || typeof document === "undefined") return;
-		if ((window as typeof window & { __PI_DESKTOP_EXTENSION_UI_FOCUS_TRACKING__?: boolean }).__PI_DESKTOP_EXTENSION_UI_FOCUS_TRACKING__) {
-			return;
-		}
-		(window as typeof window & { __PI_DESKTOP_EXTENSION_UI_FOCUS_TRACKING__?: boolean }).__PI_DESKTOP_EXTENSION_UI_FOCUS_TRACKING__ = true;
-		window.addEventListener("focus", () => {
-			this.appWindowFocused = true;
-		});
-		window.addEventListener("blur", () => {
-			this.appWindowFocused = false;
-		});
-		document.addEventListener("visibilitychange", () => {
-			if (document.visibilityState === "hidden") {
-				this.appWindowFocused = false;
-			} else if (document.hasFocus()) {
-				this.appWindowFocused = true;
-			}
-		});
+		const tracker = ensureExtensionUiFocusTrackerInitialized();
+		if (!tracker) return;
+		this.releaseFocusTrackerSubscription?.();
+		this.appWindowFocused = tracker.focused;
+		const subscriber = (focused: boolean) => {
+			this.appWindowFocused = focused;
+		};
+		tracker.subscribers.add(subscriber);
+		this.releaseFocusTrackerSubscription = () => {
+			tracker.subscribers.delete(subscriber);
+		};
 	}
 
 	private getDesktopNotificationSound(): string | undefined {
@@ -296,7 +347,8 @@ export class ExtensionUiHandler {
 	private describeNotificationContext(backgrounded: boolean): string {
 		const visibility = typeof document !== "undefined" ? document.visibilityState : "unknown";
 		const domFocused = typeof document !== "undefined" ? document.hasFocus() : false;
-		return `backgrounded=${backgrounded ? "yes" : "no"} visibility=${visibility} domFocus=${domFocused ? "yes" : "no"} appFocus=${this.appWindowFocused ? "yes" : "no"}`;
+		const tauriFocused = this.lastKnownTauriWindowFocus;
+		return `backgrounded=${backgrounded ? "yes" : "no"} visibility=${visibility} domFocus=${domFocused ? "yes" : "no"} appFocus=${this.appWindowFocused ? "yes" : "no"} tauriFocus=${tauriFocused === null ? "unknown" : tauriFocused ? "yes" : "no"}`;
 	}
 
 	private notificationDedupKey(request: ExtensionUiRequest): string {
@@ -381,7 +433,7 @@ export class ExtensionUiHandler {
 
 	private async primeDesktopNotificationPermission(): Promise<void> {
 		if (this.notificationPermissionRequested) return;
-		if (this.isAppBackgrounded()) {
+		if (await this.isAppBackgrounded()) {
 			this.trace("notify:prime-skipped backgrounded=yes");
 			return;
 		}
@@ -760,7 +812,7 @@ export class ExtensionUiHandler {
 	}
 
 	private async showNotification(request: ExtensionUiRequest): Promise<void> {
-		const backgrounded = this.isAppBackgrounded();
+		const backgrounded = await this.isAppBackgrounded();
 		this.trace(`notify:request type=${request.notifyType ?? "info"} ${this.describeNotificationContext(backgrounded)}`);
 		if (!backgrounded) {
 			this.trace("notify:skipped foreground");
@@ -863,6 +915,8 @@ export class ExtensionUiHandler {
 	}
 
 	destroy(): void {
+		this.releaseFocusTrackerSubscription?.();
+		this.releaseFocusTrackerSubscription = null;
 		this.overlayContainer?.remove();
 		this.statusContainer?.remove();
 		this.widgetAboveContainer?.remove();

--- a/src/main.ts
+++ b/src/main.ts
@@ -171,6 +171,9 @@ let runningSessionPollInFlight = false;
 let debugOverlayInterval: ReturnType<typeof setInterval> | null = null;
 let debugTraceLines: string[] = [];
 let notificationAttentionListenersBound = false;
+let runtimeRunHadError = new Map<string, boolean>();
+let runtimeRunNotifyObserved = new Map<string, boolean>();
+let syntheticRuntimeNotifyCounter = 0;
 
 function recordDebugTrace(message: string): void {
 	const stamp = new Date().toISOString().slice(11, 23);
@@ -531,15 +534,101 @@ function resolveRuntimeNotifyTarget(runtime: SessionRuntime): {
 	};
 }
 
+function markRuntimeRunStarted(runtimeKey: string): void {
+	runtimeRunHadError.set(runtimeKey, false);
+	runtimeRunNotifyObserved.set(runtimeKey, false);
+}
+
+function markRuntimeRunErrored(runtimeKey: string): void {
+	runtimeRunHadError.set(runtimeKey, true);
+}
+
+function markRuntimeRunNotifyObserved(runtimeKey: string): void {
+	runtimeRunNotifyObserved.set(runtimeKey, true);
+}
+
+function consumeRuntimeRunState(runtimeKey: string): { hadError: boolean; hadNotify: boolean } {
+	const hadError = runtimeRunHadError.get(runtimeKey) === true;
+	const hadNotify = runtimeRunNotifyObserved.get(runtimeKey) === true;
+	runtimeRunHadError.delete(runtimeKey);
+	runtimeRunNotifyObserved.delete(runtimeKey);
+	return { hadError, hadNotify };
+}
+
+function clearRuntimeRunState(runtimeKey: string): void {
+	runtimeRunHadError.delete(runtimeKey);
+	runtimeRunNotifyObserved.delete(runtimeKey);
+}
+
+function nextSyntheticRuntimeNotifyRequestId(runtimeKey: string): string {
+	syntheticRuntimeNotifyCounter = syntheticRuntimeNotifyCounter >= 2_100_000_000 ? 1 : syntheticRuntimeNotifyCounter + 1;
+	const normalizedRuntimeKey = runtimeKey.replace(/[^a-zA-Z0-9_-]/g, "_");
+	return `desktop_notify_${normalizedRuntimeKey}_${Date.now()}_${syntheticRuntimeNotifyCounter}`;
+}
+
+function attachNotifyTargetToRequest(
+	request: Record<string, unknown>,
+	target: ReturnType<typeof resolveRuntimeNotifyTarget>,
+	source: "active" | "background",
+	runtime: SessionRuntime,
+): void {
+	if (!target.workspaceId && !target.tabId && !target.sessionPath) return;
+	request.notifyTargetWorkspaceId = target.workspaceId;
+	request.notifyTargetTabId = target.tabId;
+	request.notifyTargetSessionPath = target.sessionPath;
+	request.notifyTargetWorkspaceLabel = target.workspaceLabel;
+	request.notifyTargetSessionLabel = target.sessionLabel;
+	recordDebugTrace(
+		`notify-target workspace=${target.workspaceId ?? "-"} tab=${target.tabId ?? "-"} session=${target.sessionPath ?? "-"} source=${source} runtime=${runtime.instanceId}`,
+	);
+	markSessionAttentionTarget(target);
+}
+
+function dispatchSyntheticRunEndNotify(runtime: SessionRuntime, source: "active" | "background"): void {
+	const state = consumeRuntimeRunState(runtime.key);
+	if (state.hadNotify) return;
+
+	const request: Record<string, unknown> = {
+		id: nextSyntheticRuntimeNotifyRequestId(runtime.key),
+		method: "notify",
+		notifyType: state.hadError ? "error" : "info",
+		title: state.hadError ? "Run ended with an error" : "Task finished",
+		message: state.hadError ? "Agent run ended with an error." : "Agent finished its current task.",
+	};
+	const target = resolveRuntimeNotifyTarget(runtime);
+	attachNotifyTargetToRequest(request, target, source, runtime);
+	recordDebugTrace(
+		`notify:synthetic-run-end type=${state.hadError ? "error" : "info"} source=${source} runtime=${runtime.instanceId}`,
+	);
+	const normalizedRequest = normalizeExtensionUiRequest(request);
+	if (!normalizedRequest) return;
+	void extensionUiHandler?.handleRequest(normalizedRequest);
+}
+
 function handleBackgroundRuntimeNotifyEvent(runtimeKey: string, event: Record<string, unknown>): void {
 	const runtime = sessionRuntimes.get(runtimeKey);
 	if (!runtime) return;
 	if (runtime.key === activeSessionRuntimeKey) return;
 
 	const type = typeof event.type === "string" ? event.type : "unknown";
+	if (type === "agent_start") {
+		markRuntimeRunStarted(runtime.key);
+		return;
+	}
+	if (type === "error") {
+		markRuntimeRunErrored(runtime.key);
+		return;
+	}
+	if (type === "agent_end") {
+		setTimeout(() => {
+			dispatchSyntheticRunEndNotify(runtime, "background");
+		}, 0);
+		return;
+	}
 	if (type !== "extension_ui_request") return;
 	const method = typeof event.method === "string" ? event.method : "unknown";
 	if (method !== "notify") return;
+	markRuntimeRunNotifyObserved(runtime.key);
 
 	const message = typeof event.message === "string" ? event.message : "";
 	recordDebugTrace(`rpc:event type=${type} source=background runtime=${runtime.instanceId}`);
@@ -547,17 +636,7 @@ function handleBackgroundRuntimeNotifyEvent(runtimeKey: string, event: Record<st
 
 	const request = { ...(event as Record<string, unknown>) };
 	const target = resolveRuntimeNotifyTarget(runtime);
-	if (target.workspaceId || target.tabId || target.sessionPath) {
-		request.notifyTargetWorkspaceId = target.workspaceId;
-		request.notifyTargetTabId = target.tabId;
-		request.notifyTargetSessionPath = target.sessionPath;
-		request.notifyTargetWorkspaceLabel = target.workspaceLabel;
-		request.notifyTargetSessionLabel = target.sessionLabel;
-		recordDebugTrace(
-			`notify-target workspace=${target.workspaceId ?? "-"} tab=${target.tabId ?? "-"} session=${target.sessionPath ?? "-"} source=background`,
-		);
-		markSessionAttentionTarget(target);
-	}
+	attachNotifyTargetToRequest(request, target, "background", runtime);
 
 	const normalizedRequest = normalizeExtensionUiRequest(request);
 	if (!normalizedRequest) {
@@ -682,6 +761,7 @@ function removeRuntimeByKey(runtimeKey: string): void {
 	runtime.eventUnlisten?.();
 	runtime.eventUnlisten = null;
 	sessionRuntimes.delete(runtimeKey);
+	clearRuntimeRunState(runtimeKey);
 	if (activeSessionRuntimeKey === runtimeKey) {
 		setActiveRuntime(null);
 	}
@@ -3027,6 +3107,20 @@ function initializeComponents(): void {
 		if (type === "agent_start" || type === "agent_end" || type === "error" || type === "extension_ui_request") {
 			recordDebugTrace(`rpc:event type=${type}`);
 		}
+
+		const runtime = getActiveRuntime();
+		if (runtime) {
+			if (type === "agent_start") {
+				markRuntimeRunStarted(runtime.key);
+			} else if (type === "error") {
+				markRuntimeRunErrored(runtime.key);
+			} else if (type === "agent_end") {
+				setTimeout(() => {
+					dispatchSyntheticRunEndNotify(runtime, "active");
+				}, 0);
+			}
+		}
+
 		if (type === "extension_ui_request") {
 			const method = typeof event.method === "string" ? event.method : "unknown";
 			const message = typeof event.message === "string" ? event.message : "";
@@ -3034,31 +3128,34 @@ function initializeComponents(): void {
 
 			const request = { ...(event as Record<string, unknown>) } as Record<string, unknown>;
 			if (method === "notify") {
-				const runtime = getActiveRuntime();
-				const workspace = runtime ? workspaces.find((entry) => entry.id === runtime.workspaceId) ?? null : getActiveWorkspace();
-				const activeTab = workspace ? getActiveSessionTab(workspace) : null;
-				const targetWorkspaceId = runtime?.workspaceId ?? workspace?.id ?? undefined;
-				const targetTabId = runtime?.tabId ?? activeTab?.id ?? undefined;
-				const targetSessionPath = runtime?.lastKnownSessionPath ?? activeTab?.sessionPath ?? undefined;
-				const targetWorkspaceLabel = workspace?.title?.trim() || undefined;
-				const targetSessionLabel = activeTab?.title?.trim() || (targetSessionPath ? baseName(targetSessionPath) : undefined);
-
-				if (targetWorkspaceId || targetTabId || targetSessionPath) {
-					request.notifyTargetWorkspaceId = targetWorkspaceId;
-					request.notifyTargetTabId = targetTabId;
-					request.notifyTargetSessionPath = targetSessionPath;
-					request.notifyTargetWorkspaceLabel = targetWorkspaceLabel;
-					request.notifyTargetSessionLabel = targetSessionLabel;
-					recordDebugTrace(
-						`notify-target workspace=${targetWorkspaceId ?? "-"} tab=${targetTabId ?? "-"} session=${targetSessionPath ?? "-"}`,
-					);
-					markSessionAttentionTarget({
-						workspaceId: targetWorkspaceId,
-						tabId: targetTabId,
-						sessionPath: targetSessionPath,
-					});
+				if (runtime) {
+					markRuntimeRunNotifyObserved(runtime.key);
+					const target = resolveRuntimeNotifyTarget(runtime);
+					attachNotifyTargetToRequest(request, target, "active", runtime);
+				} else {
+					const workspace = getActiveWorkspace();
+					const activeTab = workspace ? getActiveSessionTab(workspace) : null;
+					const targetWorkspaceId = workspace?.id ?? undefined;
+					const targetTabId = activeTab?.id ?? undefined;
+					const targetSessionPath = activeTab?.sessionPath ?? undefined;
+					const targetWorkspaceLabel = workspace?.title?.trim() || undefined;
+					const targetSessionLabel = activeTab?.title?.trim() || (targetSessionPath ? baseName(targetSessionPath) : undefined);
+					if (targetWorkspaceId || targetTabId || targetSessionPath) {
+						request.notifyTargetWorkspaceId = targetWorkspaceId;
+						request.notifyTargetTabId = targetTabId;
+						request.notifyTargetSessionPath = targetSessionPath;
+						request.notifyTargetWorkspaceLabel = targetWorkspaceLabel;
+						request.notifyTargetSessionLabel = targetSessionLabel;
+						recordDebugTrace(
+							`notify-target workspace=${targetWorkspaceId ?? "-"} tab=${targetTabId ?? "-"} session=${targetSessionPath ?? "-"} source=active runtime=-`,
+						);
+						markSessionAttentionTarget({
+							workspaceId: targetWorkspaceId,
+							tabId: targetTabId,
+							sessionPath: targetSessionPath,
+						});
+					}
 				}
-
 			}
 
 			const normalizedRequest = normalizeExtensionUiRequest(request);


### PR DESCRIPTION
## Summary
Follow-up notify reliability/polish pass based on `/voice-notify reload` + background-delivery regressions reported in `tauri dev`:

- suppress `smart-voice-notify` status-key output in Desktop composer status layer
  - fixes stray `voice:sound-first snd tts no-toast` text near composer after `/voice-notify reload`
- harden background focus detection for desktop notifications
  - re-check Tauri window focus (`getCurrentWindow().isFocused()`) at notify dispatch time
  - keep focus tracking robust across dev/HMR lifecycle by using shared focus tracker subscriptions
- add host-side synthetic run-end notification fallback
  - track per-runtime `agent_start` / `error` / `notify` activity
  - on `agent_end`, emit a host notify only when no extension notify was observed for that run
  - preserves target metadata/deep-link routing (workspace/session/tab)
  - works for active + background runtimes
- clear per-runtime notify/error tracking state on runtime teardown
- changelog updated

## Validation
- `npm run check`
- `npm run build:frontend`

## Manual QA checklist
- Run `/voice-notify reload` and verify no floating composer status text appears.
- Start a prompt, move app to background, verify completion notification appears.
- Click notification and verify focus routing into target workspace/session/tab.
