### PR TITLE
fix(notify): bootstrap macOS permission + fallback on option validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Desktop notification copy/branding was polished (`Pi DESK` title formatting, cleaned body text, context line layout), with richer payload metadata preserved for deterministic click-to-focus routing.
 - Suppressed `smart-voice-notify` status-key output from the floating composer-status layer, so `/voice-notify reload` no longer leaves stray text near the composer.
 - Notification background detection now re-checks Tauri window focus at dispatch time, and Desktop synthesizes a host-side run-end notify fallback when no extension notify was emitted for that run.
+- Desktop notification permission now bootstraps from the next user gesture when permission is still `default`, and native notify dispatch falls back to a minimal payload if richer options fail validation on WebKit/macOS.
 - Extension runtime errors now include better source context in chat notices, and Desktop emits an explicit compatibility hint when an extension still uses deprecated `ctx.modelRegistry.getApiKey()`.
 - Desktop now ensures a global compatibility extension (`~/.pi/agent/extensions/pi-desktop-sdk-compat.ts`) is installed to shim `modelRegistry.getApiKey()` via `getApiKeyAndHeaders()` for legacy extensions, restoring runtime compatibility for packages such as `@byteowlz/pi-auto-rename`.
 - Auto-rename settings now correctly hydrate saved `model`/`fallbackModel` values from object-form config (`{ provider, id }`) and keep those values visible in model dropdowns (including unavailable-but-saved models).

--- a/src/components/extension-ui-handler.ts
+++ b/src/components/extension-ui-handler.ts
@@ -129,6 +129,13 @@ function joinFsPath(base: string, child: string): string {
 	return normalizedBase ? `${normalizedBase}/${normalizedChild}` : normalizedChild;
 }
 
+function toFileUrl(path: string): string {
+	const normalizedPath = path.replace(/\\/g, "/");
+	if (/^[a-zA-Z]+:\/\//.test(normalizedPath)) return normalizedPath;
+	if (normalizedPath.startsWith("/")) return `file://${normalizedPath}`;
+	return `file:///${normalizedPath}`;
+}
+
 interface ExtensionUiFocusTracker {
 	focused: boolean;
 	initialized: boolean;
@@ -194,6 +201,7 @@ export class ExtensionUiHandler {
 	private releaseFocusTrackerSubscription: (() => void) | null = null;
 	private notificationPermissionRequested = false;
 	private notificationActionListenerRegistered = false;
+	private releasePermissionBootstrapListeners: (() => void) | null = null;
 	private lastNotificationActionTarget: NotificationActionTarget | null = null;
 	private lastDesktopNotificationKey = "";
 	private lastDesktopNotificationAt = 0;
@@ -203,6 +211,7 @@ export class ExtensionUiHandler {
 	constructor() {
 		this.createContainers();
 		this.ensureAppFocusTracking();
+		this.ensureDesktopNotificationPermissionBootstrap();
 		this.ensureDesktopNotificationActionListener();
 	}
 
@@ -320,6 +329,7 @@ export class ExtensionUiHandler {
 		if (this.desktopNotificationIconPath !== undefined) return this.desktopNotificationIconPath || undefined;
 		try {
 			const { resourceDir } = await import("@tauri-apps/api/path");
+			const { convertFileSrc } = await import("@tauri-apps/api/core");
 			const { exists } = await import("@tauri-apps/plugin-fs");
 			const resourcesRoot = (await resourceDir()).replace(/\\/g, "/").replace(/\/+$/, "");
 			if (!resourcesRoot) {
@@ -333,8 +343,9 @@ export class ExtensionUiHandler {
 			];
 			for (const candidate of candidates) {
 				if (await exists(candidate)) {
-					this.desktopNotificationIconPath = candidate;
-					return candidate;
+					const converted = convertFileSrc(candidate);
+					this.desktopNotificationIconPath = converted || toFileUrl(candidate);
+					return this.desktopNotificationIconPath;
 				}
 			}
 		} catch {
@@ -342,6 +353,28 @@ export class ExtensionUiHandler {
 		}
 		this.desktopNotificationIconPath = null;
 		return undefined;
+	}
+
+	private ensureDesktopNotificationPermissionBootstrap(): void {
+		if (typeof window === "undefined" || typeof Notification === "undefined") return;
+		if (Notification.permission !== "default") {
+			this.notificationPermissionRequested = Notification.permission === "granted";
+			return;
+		}
+		this.releasePermissionBootstrapListeners?.();
+		const trigger = () => {
+			this.releasePermissionBootstrapListeners?.();
+			this.releasePermissionBootstrapListeners = null;
+			this.trace("notify:permission-bootstrap trigger=gesture");
+			void this.ensureDesktopNotificationPermission(true);
+		};
+		const options: AddEventListenerOptions = { capture: true, once: true };
+		window.addEventListener("pointerdown", trigger, options);
+		window.addEventListener("keydown", trigger, options);
+		this.releasePermissionBootstrapListeners = () => {
+			window.removeEventListener("pointerdown", trigger, true);
+			window.removeEventListener("keydown", trigger, true);
+		};
 	}
 
 	private describeNotificationContext(backgrounded: boolean): string {
@@ -807,7 +840,18 @@ export class ExtensionUiHandler {
 			return true;
 		} catch (err) {
 			this.trace(`notify:native-failed ${err instanceof Error ? err.message : String(err)}`);
-			return false;
+			try {
+				sendNotification({
+					title,
+					body,
+					extra: options.extra,
+				});
+				this.trace(`notify:native-dispatched fallback=minimal type=${request.notifyType ?? "info"}`);
+				return true;
+			} catch (fallbackErr) {
+				this.trace(`notify:native-failed-fallback ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}`);
+				return false;
+			}
 		}
 	}
 
@@ -917,6 +961,8 @@ export class ExtensionUiHandler {
 	destroy(): void {
 		this.releaseFocusTrackerSubscription?.();
 		this.releaseFocusTrackerSubscription = null;
+		this.releasePermissionBootstrapListeners?.();
+		this.releasePermissionBootstrapListeners = null;
 		this.overlayContainer?.remove();
 		this.statusContainer?.remove();
 		this.widgetAboveContainer?.remove();


### PR DESCRIPTION
## Summary
Additional notify reliability pass for macOS/Tauri dev where notifications still failed to appear:

- bootstrap desktop-notification permission from the next user gesture when permission is `default`
  - avoids silent non-prompt states where app never gets listed in macOS Notifications settings
- harden icon handling for WebKit Notification API
  - convert resource file path via `convertFileSrc(...)` and fallback to file URL
- add dispatch fallback path when rich Notification options fail validation
  - retry with minimal `{ title, body, extra }` payload so notifications still emit

## Validation
- `npm run check`
- `npm run build:frontend`

Follow-up to notify fixes in #88/#89.
