### PR TITLE
fix(session): preserve running tab when switching sessions quickly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Suppressed `smart-voice-notify` status-key output from the floating composer-status layer, so `/voice-notify reload` no longer leaves stray text near the composer.
 - Notification background detection now re-checks Tauri window focus at dispatch time, and Desktop synthesizes a host-side run-end notify fallback when no extension notify was emitted for that run.
 - Desktop notification permission now bootstraps from the next user gesture when permission is still `default`, and native notify dispatch falls back to a minimal payload if richer options fail validation on WebKit/macOS.
+- Sidebar/session switching now avoids reusing or pruning running session tabs, preventing active runs from being interrupted when hopping to another session quickly.
 - Extension runtime errors now include better source context in chat notices, and Desktop emits an explicit compatibility hint when an extension still uses deprecated `ctx.modelRegistry.getApiKey()`.
 - Desktop now ensures a global compatibility extension (`~/.pi/agent/extensions/pi-desktop-sdk-compat.ts`) is installed to shim `modelRegistry.getApiKey()` via `getApiKeyAndHeaders()` for legacy extensions, restoring runtime compatibility for packages such as `@byteowlz/pi-auto-rename`.
 - Auto-rename settings now correctly hydrate saved `model`/`fallbackModel` values from object-form config (`{ provider, id }`) and keep those values visible in model dropdowns (including unavailable-but-saved models).

--- a/src/main.ts
+++ b/src/main.ts
@@ -987,6 +987,16 @@ function getActiveSessionTab(workspace: WorkspaceState): WorkspaceSessionTab {
 	return workspace.sessionTabs.find((tab) => tab.id === workspace.activeSessionTabId) ?? workspace.sessionTabs[0];
 }
 
+function isSessionTabRuntimeRunning(workspaceId: string, tabId: string): boolean {
+	const runtime = getRuntimeForTab(workspaceId, tabId);
+	if (!runtime) return false;
+	if (runtime.running) return true;
+	if (runtime.phase === "starting" || runtime.phase === "switching_session" || runtime.phase === "creating_session") {
+		return true;
+	}
+	return false;
+}
+
 function clearSessionAttention(tab: WorkspaceSessionTab | null | undefined): boolean {
 	if (!tab) return false;
 	if (!tab.needsAttention && !tab.attentionMessage) return false;
@@ -1099,7 +1109,27 @@ function openOrActivateSessionTab(
 		const onlyTabLooksLikeSeed =
 			Boolean(onlyTab) &&
 			["chat", "new session", ""].includes(((onlyTab?.title || "").trim().toLowerCase()));
-		const reusableTab = allowCreateTab ? null : preferredTab ?? activeTab ?? (onlyTabLooksLikeSeed ? onlyTab : null) ?? workspace.sessionTabs[0] ?? null;
+		const reusableCandidates: WorkspaceSessionTab[] = [];
+		const pushReusableCandidate = (candidate: WorkspaceSessionTab | null | undefined) => {
+			if (!candidate) return;
+			if (reusableCandidates.some((entry) => entry.id === candidate.id)) return;
+			reusableCandidates.push(candidate);
+		};
+		pushReusableCandidate(preferredTab);
+		pushReusableCandidate(onlyTabLooksLikeSeed ? onlyTab : null);
+		for (const candidate of workspace.sessionTabs) {
+			if (candidate.id === activeTab?.id) continue;
+			pushReusableCandidate(candidate);
+		}
+		pushReusableCandidate(activeTab);
+		const reusableTab = allowCreateTab
+			? null
+			: reusableCandidates.find((candidate) => !isSessionTabRuntimeRunning(workspace.id, candidate.id)) ?? null;
+		if (!allowCreateTab && !reusableTab && reusableCandidates.length > 0) {
+			recordDebugTrace(
+				`openOrActivateSessionTab:create-new avoid-running workspace=${workspace.id} target=${sessionPath}`,
+			);
+		}
 		if (reusableTab) {
 			const previousPath = reusableTab.sessionPath;
 			const shouldDiscardPreviousEphemeral =
@@ -1254,7 +1284,7 @@ function createAndActivateEmptySessionTab(
 	ensureWorkspaceContentState(workspace);
 	const forceNewTab = options.forceNewTab ?? false;
 	const activeSessionTab = workspace.sessionTabs.find((entry) => entry.id === workspace.activeSessionTabId) ?? workspace.sessionTabs[0] ?? null;
-	if (activeSessionTab && !forceNewTab) {
+	if (activeSessionTab && !forceNewTab && !isSessionTabRuntimeRunning(workspace.id, activeSessionTab.id)) {
 		if (isEphemeralSessionTab(activeSessionTab) && activeSessionTab.sessionPath && (activeSessionTab.messageCount ?? 0) <= 0) {
 			scheduleDiscardEphemeralSessionPaths([activeSessionTab.sessionPath]);
 		}
@@ -1324,7 +1354,11 @@ function pruneInactiveEphemeralSessionTabs(workspace: WorkspaceState, keepTabIds
 	ensureWorkspaceContentState(workspace);
 	const keep = new Set(keepTabIds);
 	const removedTabs = workspace.sessionTabs.filter(
-		(tab) => isEphemeralSessionTab(tab) && (tab.messageCount ?? 0) <= 0 && !keep.has(tab.id),
+		(tab) =>
+			isEphemeralSessionTab(tab) &&
+			(tab.messageCount ?? 0) <= 0 &&
+			!keep.has(tab.id) &&
+			!isSessionTabRuntimeRunning(workspace.id, tab.id),
 	);
 	if (removedTabs.length === 0) return false;
 
@@ -2960,6 +2994,11 @@ async function initialize(): Promise<void> {
 			sidebar?.setActiveProject(projectId, true);
 		});
 		chatView.setOnPromptSubmitted(() => {
+			const runtime = getActiveRuntime();
+			if (runtime) {
+				markRuntimeRunStarted(runtime.key);
+				setRuntimeRunning(runtime, true);
+			}
 			startSidebarSessionsWarmRefresh();
 		});
 		chatView.setOnRunStateChange((running) => {


### PR DESCRIPTION
## Summary
Fixes a regression where a running session could be interrupted when switching to another session shortly after start.

### What changed
- Added `isSessionTabRuntimeRunning(workspaceId, tabId)` helper.
- Session open/reuse logic now avoids reusing tabs that have running (or startup/switching) runtimes:
  - `openOrActivateSessionTab(...)`
  - `createAndActivateEmptySessionTab(...)`
- Ephemeral-tab pruning now skips tabs whose runtime is running, so active runs are not pruned away.
- On prompt submit, mark active runtime as running immediately (before stream events land), preventing early race windows where a just-started run looked idle.

### User-visible effect
Switching to another session 2–4s after starting a run no longer kills/interferes with the first run.

## Validation
- `npm run check`
- `npm run build:frontend`
