### PR TITLE
feat(commands): make /voice-notify slash description clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Packages modal now includes a dedicated auto-rename settings editor (enabled/mode/model/fallback/prefix/debug + Save/Test actions) backed by `auto-rename.json`, so extension behavior can be configured directly in Desktop.
 - Auto-rename settings now support explicit save target selection (global or project), including choosing among opened sidebar projects for project-scoped config writes.
 - Save target controls were moved next to the Save action in auto-rename settings (instead of top-of-form) for a cleaner, less noisy flow.
-- Runtime slash descriptions now include short argument hints for extension commands such as `/auto-rename` (e.g. `config`, `test`, `init`, `regen`).
+- Runtime slash descriptions now include clearer extension command guidance (including `/voice-notify` action/arg hints and `/auto-rename` subcommand hints like `config`, `test`, `init`, `regen`).
 - Expanded package capability docs now define explicit command contracts (`/<base>`, `/<base> config`, `/<base> config <args>`), safe default settings behavior, and extension SDK auth compatibility guidance (`getApiKeyAndHeaders` first, legacy fallback optional).
 
 ### Fixed

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -205,17 +205,45 @@ function runtimeCommandUsageHint(name: string): string | null {
 	if (normalized === "auto-rename" || normalized === "name-ai-config") {
 		return "Args: config, test, init, regen, <name>";
 	}
+	if (normalized === "voice-notify") {
+		return "Args: status, reload, on, off, test <idle|permission|question|error>";
+	}
+	return null;
+}
+
+function runtimeCommandDescriptionOverride(name: string, description: string): string | null {
+	const normalizedName = normalizeText(name).toLowerCase().replace(/^\/+/, "");
+	if (normalizedName === "voice-notify") {
+		return "Voice notifications: open settings UI, status, reload, on/off, test <idle|permission|question|error>";
+	}
+	const normalizedDescription = normalizeText(description);
+	if (/^configure windows smart voice notifications$/i.test(normalizedDescription)) {
+		return "Voice notifications: open settings UI, status, reload, on/off, test <idle|permission|question|error>";
+	}
 	return null;
 }
 
 function withRuntimeCommandUsageHint(name: string, description: string): string {
+	const override = runtimeCommandDescriptionOverride(name, description);
+	if (override) return override;
+	const normalizedDescription = normalizeText(description);
 	const hint = runtimeCommandUsageHint(name);
-	if (!hint) return description;
-	const normalized = normalizeText(description);
-	if (!normalized) return hint;
-	const lower = normalized.toLowerCase();
-	if (lower.includes("config") && lower.includes("test")) return normalized;
-	return `${normalized} · ${hint}`;
+	if (!hint) return normalizedDescription;
+	if (!normalizedDescription) return hint;
+	const lower = normalizedDescription.toLowerCase();
+	const normalizedName = normalizeText(name).toLowerCase().replace(/^\/+/, "");
+	if (normalizedName === "auto-rename" && lower.includes("config") && lower.includes("test")) {
+		return normalizedDescription;
+	}
+	if (
+		normalizedName === "voice-notify" &&
+		lower.includes("status") &&
+		lower.includes("reload") &&
+		lower.includes("test")
+	) {
+		return normalizedDescription;
+	}
+	return `${normalizedDescription} · ${hint}`;
 }
 
 const BUILTIN_SLASH_COMMANDS: Array<{ name: string; description: string }> = [

--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -28,6 +28,22 @@ interface BuiltinAction {
 	action: () => Promise<void> | void;
 }
 
+function normalizeCommandName(name: string): string {
+	return name.trim().toLowerCase().replace(/^\/+/, "");
+}
+
+function normalizeRuntimeCommandDescription(name: string, description: string): string {
+	const normalizedName = normalizeCommandName(name);
+	const normalizedDescription = description.trim();
+	if (normalizedName === "voice-notify") {
+		return "Voice notifications: open settings UI, status, reload, on/off, test <idle|permission|question|error>";
+	}
+	if (/^configure windows smart voice notifications$/i.test(normalizedDescription)) {
+		return "Voice notifications: open settings UI, status, reload, on/off, test <idle|permission|question|error>";
+	}
+	return normalizedDescription || `Run /${normalizedName}`;
+}
+
 export class CommandPalette {
 	private container: HTMLElement;
 	private isOpen = false;
@@ -92,7 +108,7 @@ export class CommandPalette {
 		const slashCommands: PaletteCommand[] = rpcCommands.map((cmd) => ({
 			id: `${cmd.source}:${cmd.name}`,
 			name: cmd.name,
-			description: cmd.description || `Run /${cmd.name}`,
+			description: normalizeRuntimeCommandDescription(cmd.name, cmd.description || ""),
 			source: cmd.source,
 			commandText: `/${cmd.name}`,
 		}));


### PR DESCRIPTION
## Summary
Make slash command descriptions clearer for notifications extension commands.

### Changes
- Composer slash palette (`ChatView`) now rewrites `/voice-notify` description to a user-facing action summary with explicit args:
  - `status`, `reload`, `on`, `off`, `test <idle|permission|question|error>`
- Command palette (`Cmd/Ctrl+K`) applies the same normalized runtime description for `/voice-notify`.
- Added runtime hint support for `/voice-notify` alongside existing `/auto-rename` hints.
- Changelog updated.

## Validation
- `npm run check`
- `npm run build:frontend`
