### PR TITLE
feat(voice-notify): no-arg slash opens extension settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Packages modal now includes a dedicated auto-rename settings editor (enabled/mode/model/fallback/prefix/debug + Save/Test actions) backed by `auto-rename.json`, so extension behavior can be configured directly in Desktop.
 - Auto-rename settings now support explicit save target selection (global or project), including choosing among opened sidebar projects for project-scoped config writes.
 - Save target controls were moved next to the Save action in auto-rename settings (instead of top-of-form) for a cleaner, less noisy flow.
-- Runtime slash descriptions now include clearer extension command guidance (including `/voice-notify` action/arg hints and `/auto-rename` subcommand hints like `config`, `test`, `init`, `regen`).
+- Runtime slash descriptions now include clearer extension command guidance (including `/voice-notify` action/arg hints and `/auto-rename` subcommand hints like `config`, `test`, `init`, `regen`), and `/voice-notify` with no args now opens extension settings in Desktop.
 - Expanded package capability docs now define explicit command contracts (`/<base>`, `/<base> config`, `/<base> config <args>`), safe default settings behavior, and extension SDK auth compatibility guidance (`getApiKeyAndHeaders` first, legacy fallback optional).
 
 ### Fixed

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -206,7 +206,7 @@ function runtimeCommandUsageHint(name: string): string | null {
 		return "Args: config, test, init, regen, <name>";
 	}
 	if (normalized === "voice-notify") {
-		return "Args: status, reload, on, off, test <idle|permission|question|error>";
+		return "No arg opens extension settings; args: status, reload, on, off, test <idle|permission|question|error>";
 	}
 	return null;
 }
@@ -214,11 +214,11 @@ function runtimeCommandUsageHint(name: string): string | null {
 function runtimeCommandDescriptionOverride(name: string, description: string): string | null {
 	const normalizedName = normalizeText(name).toLowerCase().replace(/^\/+/, "");
 	if (normalizedName === "voice-notify") {
-		return "Voice notifications: open settings UI, status, reload, on/off, test <idle|permission|question|error>";
+		return "Voice notifications: no arg opens extension settings, or use status/reload/on/off/test";
 	}
 	const normalizedDescription = normalizeText(description);
 	if (/^configure windows smart voice notifications$/i.test(normalizedDescription)) {
-		return "Voice notifications: open settings UI, status, reload, on/off, test <idle|permission|question|error>";
+		return "Voice notifications: no arg opens extension settings, or use status/reload/on/off/test";
 	}
 	return null;
 }
@@ -1221,7 +1221,9 @@ export class ChatView {
 		if (source === "extension" && this.onOpenExtensionConfig) {
 			const normalizedName = commandName.trim().toLowerCase();
 			const normalizedArgs = args.trim().toLowerCase();
+			const defaultSettingsIntent = normalizedName === "voice-notify" && normalizedArgs.length === 0;
 			const configIntent =
+				defaultSettingsIntent ||
 				normalizedName.endsWith("config") ||
 				normalizedArgs === "config" ||
 				normalizedArgs.startsWith("config ");

--- a/src/components/command-palette.ts
+++ b/src/components/command-palette.ts
@@ -36,10 +36,10 @@ function normalizeRuntimeCommandDescription(name: string, description: string): 
 	const normalizedName = normalizeCommandName(name);
 	const normalizedDescription = description.trim();
 	if (normalizedName === "voice-notify") {
-		return "Voice notifications: open settings UI, status, reload, on/off, test <idle|permission|question|error>";
+		return "Voice notifications: no arg opens extension settings, or use status/reload/on/off/test";
 	}
 	if (/^configure windows smart voice notifications$/i.test(normalizedDescription)) {
-		return "Voice notifications: open settings UI, status, reload, on/off, test <idle|permission|question|error>";
+		return "Voice notifications: no arg opens extension settings, or use status/reload/on/off/test";
 	}
 	return normalizedDescription || `Run /${normalizedName}`;
 }

--- a/src/components/packages-view.ts
+++ b/src/components/packages-view.ts
@@ -1903,7 +1903,9 @@ export class PackagesView {
 		if (!normalizedCommand) return false;
 
 		const normalizedArgs = args.trim().toLowerCase();
+		const defaultSettingsIntent = normalizedCommand === "voice-notify" && normalizedArgs.length === 0;
 		const configIntent =
+			defaultSettingsIntent ||
 			normalizedCommand.endsWith("config") ||
 			normalizedArgs === "config" ||
 			normalizedArgs.startsWith("config ");

--- a/src/main.ts
+++ b/src/main.ts
@@ -2912,7 +2912,9 @@ async function initialize(): Promise<void> {
 		chatView.setOnOpenExtensionConfig(async (commandName, args) => {
 			const normalizedName = commandName.trim().toLowerCase().replace(/^\/+/, "");
 			const normalizedArgs = args.trim().toLowerCase();
+			const defaultSettingsIntent = normalizedName === "voice-notify" && normalizedArgs.length === 0;
 			const configIntent =
+				defaultSettingsIntent ||
 				normalizedName.endsWith("config") ||
 				normalizedArgs === "config" ||
 				normalizedArgs.startsWith("config ");


### PR DESCRIPTION
## Summary
Make `/voice-notify` behavior match Desktop UX expectations.

### Changes
- `/voice-notify` with no args now opens extension settings in Desktop (Packages config surface), instead of appearing to no-op.
- Keeps existing config-intent behavior (`config`, `config ...`, `<name>-config`).
- Updates slash descriptions in both composer slash menu and command palette to explain:
  - no-arg opens settings
  - available args: `status`, `reload`, `on`, `off`, `test <idle|permission|question|error>`

### Files
- `src/components/chat-view.ts`
- `src/main.ts`
- `src/components/packages-view.ts`
- `src/components/command-palette.ts`
- `CHANGELOG.md`

## Validation
- `npm run check`
- `npm run build:frontend`
