### PR TITLE
feat(model-picker): inline provider auth actions + unauth provider states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Package settings now include explicit `/voice-notify` argument guidance (status/reload/on/off/test) directly in the settings card so command usage is visible without leaving Desktop.
 - Model picker now shows provider-level auth state (including unauthenticated providers), greys out providers that still need setup, and exposes inline per-provider Login/Logout actions directly in the flyout.
 - Expanded package capability docs now define explicit command contracts (`/<base>`, `/<base> config`, `/<base> config <args>`), safe default settings behavior, and extension SDK auth compatibility guidance (`getApiKeyAndHeaders` first, legacy fallback optional).
+- Provider auth discovery in Desktop now uses a CLI-aligned OAuth provider catalog (built-ins + package-registered OAuth providers), so model picker and account diagnostics stay consistent with `/login` behavior.
+- Settings → Account was refocused to a WIP account/product direction with lightweight diagnostics, while provider login/setup remains centered in model picker + Packages flows.
+- Packages recommendations now include `pi-cursor-provider` and `pi-kilocode` as first-class recommended provider extensions.
+- Packages discover-row `+` action now opens package details first (modal-driven install flow) instead of starting immediate background install.
 
 ### Fixed
 - Modal/backdrop layers now preserve window corner clipping (rounded dim/blur overlay) so opening dialogs no longer introduces square edge artifacts around the app window.
@@ -73,6 +77,8 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Auto-rename settings now correctly hydrate saved `model`/`fallbackModel` values from object-form config (`{ provider, id }`) and keep those values visible in model dropdowns (including unavailable-but-saved models).
 - Suppressed internal extension status-key events (for example `oqto_title_changed`) from rendering as floating composer status text, fixing stray session-title overlays above the attach/model row.
 - Git branch picker now includes both local and remote-tracking branches, supports remote-branch checkout as local tracking branches, prevents accidental new-branch creation when a matching remote exists, and adds an inline `Fetch` action for refreshing remotes.
+- Fixed Packages-page horizontal overflow during long install/output status updates by constraining x-overflow and wrapping diagnostics/banner text.
+- Uninstalling an extension from its package modal now closes the modal immediately to avoid stale-context interaction during background removal.
 
 ## [0.1.8] - 2026-03-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 - Save target controls were moved next to the Save action in auto-rename settings (instead of top-of-form) for a cleaner, less noisy flow.
 - Runtime slash descriptions now include clearer extension command guidance (including `/voice-notify` action/arg hints and `/auto-rename` subcommand hints like `config`, `test`, `init`, `regen`), and `/voice-notify` with no args now opens extension settings in Desktop.
 - Package settings now include explicit `/voice-notify` argument guidance (status/reload/on/off/test) directly in the settings card so command usage is visible without leaving Desktop.
+- Model picker now shows provider-level auth state (including unauthenticated providers), greys out providers that still need setup, and exposes inline per-provider Login/Logout actions directly in the flyout.
 - Expanded package capability docs now define explicit command contracts (`/<base>`, `/<base> config`, `/<base> config <args>`), safe default settings behavior, and extension SDK auth compatibility guidance (`getApiKeyAndHeaders` first, legacy fallback optional).
 
 ### Fixed

--- a/TODO.md
+++ b/TODO.md
@@ -251,6 +251,9 @@ These should be packages/extensions/skills unless there is a very strong reason 
   - [x] simplify the Packages pane into a more minimalist list/row layout with less repeated chrome/text
   - [x] remove manual source install bar from the top-level flow; keep install action on package rows
   - [x] diagnostics/load errors where possible
+  - [x] prevent packages-page horizontal overflow from long command/status output
+  - [x] make discover-row `+` action open details modal first (no silent background install)
+  - [x] close extension modal immediately on uninstall action
 - [ ] Add proper per-resource enable/disable UX
   - [ ] do **not** shell users into the interactive `pi config` TUI
   - [ ] prefer direct config/settings-driven desktop UX

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,35 @@
 # TODO — V1/V1.1 release cleanup plan
 
+## Session update (2026-04-10) — Terminal architecture reset (#48 auth/login follow-up)
+
+Status: **In progress (stabilization first, architecture decision next)**
+
+### Root-cause notes from investigation
+- [x] Confirmed `@tauri-apps/plugin-shell` is **process I/O**, not a full terminal emulator/PTY host by itself.
+- [x] Confirmed plugin-shell default streamed events are line-delimited; raw mode returns byte payloads and needs explicit decoding.
+- [x] Confirmed our regression came from raw payload shape mismatch in desktop runtime (`number[]`/raw payload rendered as textified numbers).
+- [x] Confirmed dedicated terminal examples (`tauri-terminal`, `Terminaux`) use **portable-pty + xterm.js** architecture, not line-mode shell streaming.
+
+### Stabilization plan (current branch)
+- [x] Hotfix raw byte decoding for interactive mode (`pi`, `pi login`) so TUI escape stream is decoded correctly.
+- [x] Restore safe xterm newline handling and viewport rendering guards (remove diagonal numeric rendering artifacts).
+- [ ] Re-run manual QA matrix for terminal dock:
+  - [ ] plain shell commands (`ls`, `pwd`, `cd`, clear)
+  - [ ] `pi` interactive render + keyboard controls
+  - [ ] `pi login <provider>` bridge => `/login` picker path
+  - [ ] clear/abort behavior (no duplicate prompt)
+  - [ ] resize behavior (no bottom clipping/black strip)
+
+### Next architecture step (after stabilization)
+- [ ] Decide terminal backend direction explicitly:
+  - [ ] **A:** keep `script` bridge (quick, minimal, known limitations)
+  - [ ] **B:** implement native Rust PTY bridge (`portable-pty`) with resize/write/read events (recommended)
+- [ ] If path **B** chosen, create dedicated implementation issue + phased rollout:
+  - [ ] Rust PTY session manager (spawn, write, resize, kill)
+  - [ ] Tauri commands/events for binary-safe stream transport
+  - [ ] xterm integration with deterministic lifecycle per workspace tab
+  - [ ] login/auth flows reused on top of PTY primitive (no one-off hacks)
+
 ## Session update (2026-04-04) — Issue #70
 
 Status: **In progress, near completion**

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -27,7 +27,6 @@
 		"shell:default",
 		"shell:allow-open",
 		"shell:allow-kill",
-		"shell:allow-spawn",
 		"fs:default",
 		{
 			"identifier": "fs:allow-home-read-recursive",
@@ -50,6 +49,66 @@
 		"notification:default",
 		{
 			"identifier": "shell:allow-execute",
+			"allow": [
+				{
+					"name": "binaries/pi",
+					"sidecar": true,
+					"args": true
+				},
+				{
+					"name": "terminal-zsh-path",
+					"cmd": "/bin/zsh",
+					"args": true
+				},
+				{
+					"name": "terminal-zsh",
+					"cmd": "zsh",
+					"args": true
+				},
+				{
+					"name": "terminal-bash-path",
+					"cmd": "/bin/bash",
+					"args": true
+				},
+				{
+					"name": "terminal-bash",
+					"cmd": "bash",
+					"args": true
+				},
+				{
+					"name": "terminal-sh-path",
+					"cmd": "/bin/sh",
+					"args": true
+				},
+				{
+					"name": "terminal-sh",
+					"cmd": "sh",
+					"args": true
+				},
+				{
+					"name": "terminal-pwsh-exe",
+					"cmd": "pwsh.exe",
+					"args": true
+				},
+				{
+					"name": "terminal-pwsh",
+					"cmd": "pwsh",
+					"args": true
+				},
+				{
+					"name": "terminal-cmd-exe",
+					"cmd": "cmd.exe",
+					"args": true
+				},
+				{
+					"name": "terminal-cmd",
+					"cmd": "cmd",
+					"args": true
+				}
+			]
+		},
+		{
+			"identifier": "shell:allow-spawn",
 			"allow": [
 				{
 					"name": "binaries/pi",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -166,6 +166,66 @@
 					"args": true
 				}
 			]
+		},
+		{
+			"identifier": "shell:allow-stdin-write",
+			"allow": [
+				{
+					"name": "binaries/pi",
+					"sidecar": true,
+					"args": true
+				},
+				{
+					"name": "terminal-zsh-path",
+					"cmd": "/bin/zsh",
+					"args": true
+				},
+				{
+					"name": "terminal-zsh",
+					"cmd": "zsh",
+					"args": true
+				},
+				{
+					"name": "terminal-bash-path",
+					"cmd": "/bin/bash",
+					"args": true
+				},
+				{
+					"name": "terminal-bash",
+					"cmd": "bash",
+					"args": true
+				},
+				{
+					"name": "terminal-sh-path",
+					"cmd": "/bin/sh",
+					"args": true
+				},
+				{
+					"name": "terminal-sh",
+					"cmd": "sh",
+					"args": true
+				},
+				{
+					"name": "terminal-pwsh-exe",
+					"cmd": "pwsh.exe",
+					"args": true
+				},
+				{
+					"name": "terminal-pwsh",
+					"cmd": "pwsh",
+					"args": true
+				},
+				{
+					"name": "terminal-cmd-exe",
+					"cmd": "cmd.exe",
+					"args": true
+				},
+				{
+					"name": "terminal-cmd",
+					"cmd": "cmd",
+					"args": true
+				}
+			]
 		}
 	]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -27,6 +27,7 @@
 		"shell:default",
 		"shell:allow-open",
 		"shell:allow-kill",
+		"shell:allow-spawn",
 		"fs:default",
 		{
 			"identifier": "fs:allow-home-read-recursive",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1166,6 +1166,324 @@ async fn clear_pi_provider_auth(provider: String) -> Result<PiProviderAuthClearR
     })
 }
 
+#[derive(Debug, Serialize, Clone)]
+struct PiOAuthProviderInfo {
+    id: String,
+    name: String,
+    source: String,
+}
+
+fn builtin_oauth_provider_info() -> Vec<PiOAuthProviderInfo> {
+    vec![
+        PiOAuthProviderInfo {
+            id: "anthropic".to_string(),
+            name: "Anthropic".to_string(),
+            source: "built_in".to_string(),
+        },
+        PiOAuthProviderInfo {
+            id: "github-copilot".to_string(),
+            name: "GitHub Copilot".to_string(),
+            source: "built_in".to_string(),
+        },
+        PiOAuthProviderInfo {
+            id: "google-gemini-cli".to_string(),
+            name: "Google Gemini CLI".to_string(),
+            source: "built_in".to_string(),
+        },
+        PiOAuthProviderInfo {
+            id: "google-antigravity".to_string(),
+            name: "Google Antigravity".to_string(),
+            source: "built_in".to_string(),
+        },
+        PiOAuthProviderInfo {
+            id: "openai-codex".to_string(),
+            name: "OpenAI Codex".to_string(),
+            source: "built_in".to_string(),
+        },
+    ]
+}
+
+fn humanize_provider_id(provider_id: &str) -> String {
+    provider_id
+        .split(|ch: char| ch == '-' || ch == '_' || ch.is_whitespace())
+        .filter(|part| !part.trim().is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            match chars.next() {
+                Some(first) => format!("{}{}", first.to_uppercase(), chars.as_str()),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<String>>()
+        .join(" ")
+}
+
+fn parse_package_paths_from_pi_list_output(output: &str) -> Vec<PathBuf> {
+    let mut paths: Vec<PathBuf> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let candidate = PathBuf::from(trimmed);
+        if !candidate.is_absolute() || !candidate.exists() || !candidate.is_dir() {
+            continue;
+        }
+
+        let key = candidate.to_string_lossy().to_string();
+        if seen.insert(key) {
+            paths.push(candidate);
+        }
+    }
+
+    paths
+}
+
+fn package_extension_entry_files(package_root: &Path) -> Vec<PathBuf> {
+    let mut files: Vec<PathBuf> = Vec::new();
+
+    let package_json_path = package_root.join("package.json");
+    if package_json_path.is_file() {
+        if let Ok(content) = fs::read_to_string(&package_json_path) {
+            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&content) {
+                if let Some(extensions) = parsed
+                    .get("pi")
+                    .and_then(|pi| pi.get("extensions"))
+                    .and_then(|value| value.as_array())
+                {
+                    for entry in extensions {
+                        let Some(raw) = entry.as_str() else {
+                            continue;
+                        };
+                        let normalized = raw.trim().trim_start_matches("./").trim_start_matches(".\\");
+                        if normalized.is_empty() {
+                            continue;
+                        }
+                        let candidate = package_root.join(normalized);
+                        if candidate.is_file() {
+                            files.push(candidate);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if files.is_empty() {
+        for fallback in ["index.ts", "index.js", "src/index.ts", "src/index.js", "src/index.mjs", "index.mjs"] {
+            let candidate = package_root.join(fallback);
+            if candidate.is_file() {
+                files.push(candidate);
+            }
+        }
+    }
+
+    files
+}
+
+fn parse_quoted_string(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut index = 0usize;
+
+    while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+        index += 1;
+    }
+    if index >= bytes.len() {
+        return None;
+    }
+
+    let quote = bytes[index];
+    if quote != b'"' && quote != b'\'' {
+        return None;
+    }
+    index += 1;
+    let start = index;
+
+    while index < bytes.len() {
+        if bytes[index] == quote {
+            return Some(value[start..index].to_string());
+        }
+        index += 1;
+    }
+
+    None
+}
+
+fn extract_oauth_name_from_segment(segment: &str, provider_id: &str) -> String {
+    let oauth_pos = segment.find("oauth").unwrap_or(0);
+    let oauth_segment = &segment[oauth_pos..];
+
+    if let Some(name_pos) = oauth_segment.find("name") {
+        let tail = &oauth_segment[name_pos + "name".len()..];
+        if let Some(colon_pos) = tail.find(':') {
+            let candidate = &tail[colon_pos + 1..];
+            if let Some(name) = parse_quoted_string(candidate) {
+                let trimmed = name.trim();
+                if !trimmed.is_empty() {
+                    return trimmed.to_string();
+                }
+            }
+        }
+    }
+
+    humanize_provider_id(provider_id)
+}
+
+fn extract_oauth_providers_from_source(source: &str) -> Vec<(String, String)> {
+    let mut providers: Vec<(String, String)> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    let needle = "registerProvider(";
+    let mut cursor = 0usize;
+
+    while cursor < source.len() {
+        let Some(rel) = source[cursor..].find(needle) else {
+            break;
+        };
+        let start = cursor + rel;
+        let mut index = start + needle.len();
+        let bytes = source.as_bytes();
+
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        if index >= bytes.len() {
+            break;
+        }
+
+        let quote = bytes[index];
+        if quote != b'"' && quote != b'\'' {
+            cursor = index.saturating_add(1);
+            continue;
+        }
+
+        index += 1;
+        let provider_start = index;
+        while index < bytes.len() && bytes[index] != quote {
+            index += 1;
+        }
+        if index >= bytes.len() {
+            break;
+        }
+
+        let provider_id = source[provider_start..index].trim().to_lowercase();
+        if provider_id.is_empty() {
+            cursor = index.saturating_add(1);
+            continue;
+        }
+
+        let segment_start = index;
+        let mut scan_limit = (segment_start + 9000).min(source.len());
+        while scan_limit > segment_start && !source.is_char_boundary(scan_limit) {
+            scan_limit -= 1;
+        }
+        let segment_end = source[segment_start..scan_limit]
+            .find(needle)
+            .map(|next_rel| segment_start + next_rel)
+            .unwrap_or(scan_limit);
+
+        let segment = &source[segment_start..segment_end];
+        if !segment.contains("oauth") {
+            cursor = index.saturating_add(1);
+            continue;
+        }
+
+        if seen.insert(provider_id.clone()) {
+            let provider_name = extract_oauth_name_from_segment(segment, &provider_id);
+            providers.push((provider_id, provider_name));
+        }
+
+        cursor = index.saturating_add(1);
+    }
+
+    providers
+}
+
+fn extract_oauth_providers_from_package(package_root: &Path) -> Vec<PiOAuthProviderInfo> {
+    let mut providers: Vec<PiOAuthProviderInfo> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    for file in package_extension_entry_files(package_root) {
+        let Ok(content) = fs::read_to_string(&file) else {
+            continue;
+        };
+        for (id, name) in extract_oauth_providers_from_source(&content) {
+            if !seen.insert(id.clone()) {
+                continue;
+            }
+            providers.push(PiOAuthProviderInfo {
+                id,
+                name,
+                source: "package".to_string(),
+            });
+        }
+    }
+
+    providers
+}
+
+/// Discover OAuth providers the same way users see in CLI /login:
+/// built-ins + package-registered OAuth providers.
+#[tauri::command]
+async fn get_pi_oauth_providers(app: AppHandle) -> Result<Vec<PiOAuthProviderInfo>, String> {
+    let mut providers = builtin_oauth_provider_info();
+    let mut seen: HashSet<String> = providers.iter().map(|provider| provider.id.clone()).collect();
+
+    let discovery_opts = RpcStartOptions {
+        cli_path: None,
+        cwd: ".".to_string(),
+        provider: None,
+        model: None,
+        env: None,
+    };
+
+    let Ok(pi) = discover_pi(&app, &discovery_opts) else {
+        return Ok(providers);
+    };
+
+    let list_opts = PiCliCommandOptions {
+        args: vec!["list".to_string()],
+        cwd: Some(".".to_string()),
+        env: None,
+        cli_path: None,
+    };
+
+    let output = match build_plain_command(&pi, &list_opts).output() {
+        Ok(output) => output,
+        Err(_) => return Ok(providers),
+    };
+
+    if !output.status.success() {
+        return Ok(providers);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let package_paths = parse_package_paths_from_pi_list_output(&stdout);
+    let mut custom_providers: Vec<PiOAuthProviderInfo> = Vec::new();
+
+    for package_path in package_paths {
+        for provider in extract_oauth_providers_from_package(&package_path) {
+            if !seen.insert(provider.id.clone()) {
+                continue;
+            }
+            custom_providers.push(provider);
+        }
+    }
+
+    custom_providers.sort_by(|a, b| {
+        let name_cmp = a.name.to_lowercase().cmp(&b.name.to_lowercase());
+        if name_cmp != std::cmp::Ordering::Equal {
+            return name_cmp;
+        }
+        a.id.cmp(&b.id)
+    });
+
+    providers.extend(custom_providers);
+    Ok(providers)
+}
+
 /// Settings structure
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
@@ -2022,6 +2340,7 @@ pub fn run() {
             list_sessions,
             get_session_content,
             get_pi_auth_status,
+            get_pi_oauth_providers,
             clear_pi_provider_auth,
             save_settings,
             load_settings,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -991,6 +991,43 @@ struct PiAuthStatus {
     configured_providers: Vec<PiAuthProviderStatus>,
 }
 
+fn provider_env_var_map() -> [(&'static str, &'static str); 16] {
+    [
+        ("anthropic", "ANTHROPIC_API_KEY"),
+        ("azure-openai-responses", "AZURE_OPENAI_API_KEY"),
+        ("openai", "OPENAI_API_KEY"),
+        ("google", "GEMINI_API_KEY"),
+        ("mistral", "MISTRAL_API_KEY"),
+        ("groq", "GROQ_API_KEY"),
+        ("cerebras", "CEREBRAS_API_KEY"),
+        ("xai", "XAI_API_KEY"),
+        ("openrouter", "OPENROUTER_API_KEY"),
+        ("vercel-ai-gateway", "AI_GATEWAY_API_KEY"),
+        ("zai", "ZAI_API_KEY"),
+        ("opencode", "OPENCODE_API_KEY"),
+        ("huggingface", "HF_TOKEN"),
+        ("kimi-coding", "KIMI_API_KEY"),
+        ("minimax", "MINIMAX_API_KEY"),
+        ("minimax-cn", "MINIMAX_CN_API_KEY"),
+    ]
+}
+
+fn provider_env_var(provider: &str) -> Option<&'static str> {
+    for (name, env_key) in provider_env_var_map() {
+        if name == provider {
+            return Some(env_key);
+        }
+    }
+    None
+}
+
+fn provider_env_var_is_set(provider: &str) -> bool {
+    provider_env_var(provider)
+        .and_then(|env_key| std::env::var_os(env_key))
+        .map(|value| !value.is_empty())
+        .unwrap_or(false)
+}
+
 /// Inspect PI auth configuration from auth.json + environment variables.
 #[tauri::command]
 async fn get_pi_auth_status() -> Result<PiAuthStatus, String> {
@@ -1035,26 +1072,7 @@ async fn get_pi_auth_status() -> Result<PiAuthStatus, String> {
     }
 
     // Known provider env var mapping from docs/providers.md (core API key providers)
-    let provider_env_map = [
-        ("anthropic", "ANTHROPIC_API_KEY"),
-        ("azure-openai-responses", "AZURE_OPENAI_API_KEY"),
-        ("openai", "OPENAI_API_KEY"),
-        ("google", "GEMINI_API_KEY"),
-        ("mistral", "MISTRAL_API_KEY"),
-        ("groq", "GROQ_API_KEY"),
-        ("cerebras", "CEREBRAS_API_KEY"),
-        ("xai", "XAI_API_KEY"),
-        ("openrouter", "OPENROUTER_API_KEY"),
-        ("vercel-ai-gateway", "AI_GATEWAY_API_KEY"),
-        ("zai", "ZAI_API_KEY"),
-        ("opencode", "OPENCODE_API_KEY"),
-        ("huggingface", "HF_TOKEN"),
-        ("kimi-coding", "KIMI_API_KEY"),
-        ("minimax", "MINIMAX_API_KEY"),
-        ("minimax-cn", "MINIMAX_CN_API_KEY"),
-    ];
-
-    for (provider, env_key) in provider_env_map {
+    for (provider, env_key) in provider_env_var_map() {
         let env_present = std::env::var_os(env_key)
             .map(|v| !v.is_empty())
             .unwrap_or(false);
@@ -1081,6 +1099,70 @@ async fn get_pi_auth_status() -> Result<PiAuthStatus, String> {
         auth_file: auth_file_path.map(|p| p.to_string_lossy().to_string()),
         auth_file_exists,
         configured_providers,
+    })
+}
+
+#[derive(Debug, Serialize)]
+struct PiProviderAuthClearResult {
+    provider: String,
+    removed: bool,
+    source: String,
+}
+
+/// Remove provider credentials from ~/.pi/agent/auth.json when present.
+#[tauri::command]
+async fn clear_pi_provider_auth(provider: String) -> Result<PiProviderAuthClearResult, String> {
+    let normalized = provider.trim().to_lowercase();
+    if normalized.is_empty() {
+        return Err("Provider cannot be empty".to_string());
+    }
+
+    let agent_dir = get_pi_agent_dir();
+    let auth_file_path = agent_dir.as_ref().map(|dir| dir.join("auth.json"));
+    let mut removed = false;
+
+    if let Some(path) = &auth_file_path {
+        if path.exists() && path.is_file() {
+            let content = fs::read_to_string(path)
+                .map_err(|e| format!("Failed to read auth file: {}", e))?;
+            let mut parsed = serde_json::from_str::<serde_json::Value>(&content)
+                .unwrap_or_else(|_| serde_json::json!({}));
+
+            if !parsed.is_object() {
+                parsed = serde_json::json!({});
+            }
+
+            if let Some(map) = parsed.as_object_mut() {
+                if map.remove(&normalized).is_some() {
+                    removed = true;
+                    let serialized = serde_json::to_string_pretty(&parsed)
+                        .map_err(|e| format!("Failed to serialize auth file: {}", e))?;
+                    fs::write(path, format!("{}\n", serialized))
+                        .map_err(|e| format!("Failed to write auth file: {}", e))?;
+
+                    #[cfg(unix)]
+                    {
+                        use std::os::unix::fs::PermissionsExt;
+                        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+                    }
+                }
+            }
+        }
+    }
+
+    let source = if removed {
+        "auth_file"
+    } else if provider_env_var_is_set(&normalized) {
+        "environment"
+    } else {
+        "missing"
+    }
+    .to_string();
+
+    Ok(PiProviderAuthClearResult {
+        provider: normalized,
+        removed,
+        source,
     })
 }
 
@@ -1940,6 +2022,7 @@ pub fn run() {
             list_sessions,
             get_session_content,
             get_pi_auth_status,
+            clear_pi_provider_auth,
             save_settings,
             load_settings,
             open_file_dialog,

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -6469,7 +6469,6 @@ export class ChatView {
 																}}
 															>
 																<span class="model-picker-provider-label">${group.providerLabel}</span>
-																<span class="model-picker-provider-caret" aria-hidden="true">›</span>
 															</button>
 															<button
 																type="button"

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -1335,12 +1335,13 @@ export class ChatView {
 		try {
 			if (action === "login") {
 				if (DEFAULT_OAUTH_PROVIDER_SET.has(providerKey)) {
+					const loginCommand = `pi login ${providerKey}`;
 					if (this.onOpenTerminal) {
-						await this.onOpenTerminal("pi");
-						this.pushNotice(`Opened terminal. In Pi, type /login and select ${providerLabel}.`, "info");
+						await this.onOpenTerminal(loginCommand);
+						this.pushNotice(`Opened terminal and started /login for ${providerLabel}.`, "info");
 						return;
 					}
-					this.pushNotice(`Open terminal, run pi, then type /login and select ${providerLabel}.`, "info");
+					this.pushNotice(`Open terminal and run: ${loginCommand}`, "info");
 					return;
 				}
 				const openedPackageConfig = await this.openProviderSetup(providerKey);
@@ -6532,7 +6533,7 @@ export class ChatView {
 															? "Configured from environment variable"
 															: `Logout from ${group.providerLabel}`
 														: group.isDefaultOAuthProvider
-															? `Open terminal login for ${group.providerLabel} (run pi, then /login)`
+															? `Open terminal login for ${group.providerLabel} (starts /login automatically)`
 															: `Set up ${group.providerLabel}`;
 													return html`
 														<div class="model-picker-provider-row ${group.providerKey === resolvedActiveProvider ? "active" : ""} ${group.authConfigured ? "" : "unauth"}">
@@ -6587,14 +6588,14 @@ export class ChatView {
 																			? "Connected, but no models are available right now. Try /reload after login changes."
 																			: "Connected, but no models are loaded for this provider. Install/enable its package in Packages, then run /reload."
 																		: activeProviderGroup.isDefaultOAuthProvider
-																								? "Not connected yet. Click Login, then in terminal run pi and type /login."
+																								? "Not connected yet. Click Login to open terminal and start /login automatically."
 																								: "Not connected yet. Use Login to set up this provider."}
 																</div>
 															`
 															: html`
 																${!activeProviderGroup.authConfigured
 																	? html`<div class="model-picker-auth-hint">${activeProviderGroup.isDefaultOAuthProvider
-																							? "Not connected yet. Click Login, then in terminal run pi and type /login."
+																							? "Not connected yet. Click Login to open terminal and start /login automatically."
 																							: "Not connected yet. Use Login to set up this provider."}</div>`
 																	: nothing}
 																${activeProviderGroup.models.map((model) => {

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -599,6 +599,7 @@ export class ChatView {
 	private providerAuthLoadedAt = 0;
 	private providerAuthById = new Map<string, Pick<PiAuthProviderStatus, "source" | "kind">>();
 	private providerAuthConfigured = new Set<string>();
+	private providerAuthForcedLoggedOut = new Set<string>();
 	private lastBackendRefreshError: string | null = null;
 	private lastModelLoadError: string | null = null;
 	private lastBackendSessionFile: string | null = null;
@@ -851,6 +852,7 @@ export class ChatView {
 			this.modelCatalog = [];
 			this.providerAuthById.clear();
 			this.providerAuthConfigured.clear();
+			this.providerAuthForcedLoggedOut.clear();
 			this.providerAuthLoadedAt = 0;
 			this.runHasAssistantText = false;
 			this.runSawToolActivity = false;
@@ -885,6 +887,7 @@ export class ChatView {
 		this.compactionCycle = null;
 		this.compactionInsertIndex = null;
 		this.runningProviderAuthAction = null;
+		this.providerAuthForcedLoggedOut.clear();
 		this.runHasAssistantText = false;
 		this.runSawToolActivity = false;
 		this.keepWorkflowExpandedUntilAssistantText = false;
@@ -1183,14 +1186,9 @@ export class ChatView {
 	private recomputeProviderAuthConfigured(): void {
 		const next = new Set<string>();
 		for (const provider of this.providerAuthById.keys()) {
+			if (this.providerAuthForcedLoggedOut.has(provider)) continue;
 			next.add(provider);
 		}
-		for (const model of this.availableModels) {
-			const key = this.providerKey(model.provider);
-			if (key) next.add(key);
-		}
-		const currentProvider = this.providerKey(this.state?.model?.provider ?? "");
-		if (currentProvider) next.add(currentProvider);
 		this.providerAuthConfigured = next;
 	}
 
@@ -1218,6 +1216,9 @@ export class ChatView {
 			}
 			this.providerAuthById = next;
 			this.providerAuthLoadedAt = Date.now();
+			for (const provider of next.keys()) {
+				this.providerAuthForcedLoggedOut.delete(provider);
+			}
 			this.recomputeProviderAuthConfigured();
 		} catch (err) {
 			console.error("Failed to load provider auth status:", err);
@@ -1329,10 +1330,16 @@ export class ChatView {
 
 			const result = await rpcBridge.clearPiProviderAuth(providerKey);
 			if (result.removed) {
+				this.providerAuthForcedLoggedOut.add(providerKey);
+				this.providerAuthById.delete(providerKey);
+				this.recomputeProviderAuthConfigured();
 				this.pushNotice(`Logged out of ${providerLabel}`, "success");
 			} else if (result.source === "environment") {
 				this.pushNotice(`${providerLabel} is configured via environment variable; remove env var to fully log out.`, "info");
 			} else {
+				this.providerAuthForcedLoggedOut.add(providerKey);
+				this.providerAuthById.delete(providerKey);
+				this.recomputeProviderAuthConfigured();
 				this.pushNotice(`No stored auth.json credentials found for ${providerLabel}`, "info");
 			}
 			await Promise.all([
@@ -6331,8 +6338,9 @@ export class ChatView {
 				const authKey = this.providerKey(group.providerKey);
 				const hasSelectableModel = group.models.some((model) => model.selectable);
 				const authInfo = this.providerAuthById.get(authKey);
-				const authConfigured = this.providerAuthConfigured.has(authKey) || hasSelectableModel;
-				const authSource = authInfo?.source ?? (hasSelectableModel ? "runtime" : "missing");
+				const forcedLoggedOut = this.providerAuthForcedLoggedOut.has(authKey);
+				const authConfigured = !forcedLoggedOut && (this.providerAuthConfigured.has(authKey) || hasSelectableModel);
+				const authSource = forcedLoggedOut ? "missing" : (authInfo?.source ?? (hasSelectableModel ? "runtime" : "missing"));
 				return {
 					...group,
 					authConfigured,
@@ -6497,7 +6505,7 @@ export class ChatView {
 														${activeProviderGroup.models.map((model) => {
 															const nextValue = `${model.provider}::${model.id}`;
 															const isActive = model.provider === currentProvider && model.id === currentModelId;
-															const isDisabled = !model.selectable;
+															const isDisabled = !model.selectable || !activeProviderGroup.authConfigured;
 															return html`
 																<button
 																	type="button"

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -6,6 +6,7 @@ import "@mariozechner/mini-lit/dist/CodeBlock.js";
 import "@mariozechner/mini-lit/dist/MarkdownBlock.js";
 import { html, nothing, render, type TemplateResult } from "lit";
 import {
+	type PiAuthProviderStatus,
 	type RpcImageInput,
 	type RpcSessionState,
 	type ThinkingLevel,
@@ -261,14 +262,17 @@ const BUILTIN_SLASH_COMMANDS: Array<{ name: string; description: string }> = [
 	{ name: "terminal", description: "Toggle docked terminal" },
 	{ name: "fork", description: "Open fork flow, /fork <query> pre-fills message search" },
 	{ name: "tree", description: "Open full session tree across branches, /tree <query> pre-fills search" },
-	{ name: "login", description: "Terminal-only today: /login [provider] guidance" },
-	{ name: "logout", description: "Terminal-only today: /logout [provider] guidance" },
+	{ name: "login", description: "No arg opens model picker auth actions; /login <provider> opens setup" },
+	{ name: "logout", description: "No arg opens model picker auth actions; /logout <provider> clears auth.json credentials" },
 	{ name: "new", description: "Start fresh session tab" },
 	{ name: "compact", description: "Manually compact context, /compact <instructions> optional" },
 	{ name: "resume", description: "Open session browser, /resume <query> pre-fills search" },
 	{ name: "reload", description: "Reload runtime (bridge restart + state/models/commands refresh)" },
 	{ name: "quit", description: "Quit Desktop app" },
 ];
+
+const MODEL_PICKER_AUTH_CACHE_MS = 15_000;
+const MODEL_PICKER_CATALOG_CACHE_MS = 60_000;
 
 function uid(prefix = "id"): string {
 	return `${prefix}_${Math.random().toString(36).slice(2, 8)}_${Date.now().toString(36)}`;
@@ -445,6 +449,53 @@ function formatModelDisplayName(modelId: string): string {
 		.join(" ");
 }
 
+function parseListModelsContextWindow(raw: string): number | undefined {
+	const token = normalizeText(raw).toLowerCase();
+	if (!token) return undefined;
+	const match = token.match(/^(\d+(?:\.\d+)?)([km])?$/i);
+	if (!match) return undefined;
+	const base = Number(match[1]);
+	if (!Number.isFinite(base) || base <= 0) return undefined;
+	const unit = match[2]?.toLowerCase();
+	if (unit === "k") return Math.round(base * 1_000);
+	if (unit === "m") return Math.round(base * 1_000_000);
+	return Math.round(base);
+}
+
+function parseListModelsCatalog(output: string): ModelOption[] {
+	const mapped: ModelOption[] = [];
+	const seen = new Set<string>();
+	for (const rawLine of output.split(/\r?\n/)) {
+		const trimmed = rawLine.trim();
+		if (!trimmed) continue;
+		if (/^provider\s+/i.test(trimmed)) continue;
+		if (/^[\-=]{3,}/.test(trimmed)) continue;
+		const cols = trimmed.split(/\s+/);
+		if (cols.length < 2) continue;
+		const provider = cols[0]?.trim();
+		const id = cols[1]?.trim();
+		if (!provider || !id) continue;
+		const key = `${provider.toLowerCase()}::${id.toLowerCase()}`;
+		if (seen.has(key)) continue;
+		seen.add(key);
+		mapped.push({
+			provider,
+			id,
+			label: `${provider}/${id}`,
+			reasoning: (cols[4] || "").toLowerCase() === "yes",
+			contextWindow: parseListModelsContextWindow(cols[2] || ""),
+		});
+	}
+	mapped.sort((a, b) => {
+		const providerCompare = formatProviderDisplayName(a.provider).localeCompare(formatProviderDisplayName(b.provider), undefined, {
+			sensitivity: "base",
+		});
+		if (providerCompare !== 0) return providerCompare;
+		return formatModelDisplayName(a.id).localeCompare(formatModelDisplayName(b.id), undefined, { sensitivity: "base" });
+	});
+	return mapped;
+}
+
 function formatThinkingDisplayName(level: ThinkingLevel): string {
 	switch (level) {
 		case "off":
@@ -527,6 +578,7 @@ export class ChatView {
 	private onOpenSettings: ((sectionId?: string) => void) | null = null;
 	private onOpenPackages: (() => void) | null = null;
 	private onOpenExtensionConfig: ((commandName: string, args: string) => boolean | Promise<boolean>) | null = null;
+	private onOpenProviderConfig: ((provider: string) => boolean | Promise<boolean>) | null = null;
 	private onBeginRenameCurrentSession: (() => boolean | Promise<boolean>) | null = null;
 	private onRenameCurrentSession: ((nextName: string) => boolean | Promise<boolean>) | null = null;
 	private onCreateFreshSession: (() => boolean | Promise<boolean>) | null = null;
@@ -538,8 +590,15 @@ export class ChatView {
 	private onPromptSubmitted: (() => void) | null = null;
 	private onRunStateChange: ((running: boolean) => void) | null = null;
 	private availableModels: ModelOption[] = [];
+	private modelCatalog: ModelOption[] = [];
 	private loadingModels = false;
+	private loadingModelCatalog = false;
+	private loadingProviderAuth = false;
 	private modelLoadRequestSeq = 0;
+	private modelCatalogLoadedAt = 0;
+	private providerAuthLoadedAt = 0;
+	private providerAuthById = new Map<string, Pick<PiAuthProviderStatus, "source" | "kind">>();
+	private providerAuthConfigured = new Set<string>();
 	private lastBackendRefreshError: string | null = null;
 	private lastModelLoadError: string | null = null;
 	private lastBackendSessionFile: string | null = null;
@@ -549,6 +608,7 @@ export class ChatView {
 	private modelPickerOpen = false;
 	private modelPickerActiveProvider = "";
 	private modelPickerGlobalListenersBound = false;
+	private runningProviderAuthAction: { provider: string; action: "login" | "logout" } | null = null;
 	private sendingPrompt = false;
 	private pendingImages: PendingImage[] = [];
 	private notices: Notice[] = [];
@@ -703,6 +763,10 @@ export class ChatView {
 		this.onOpenExtensionConfig = cb;
 	}
 
+	setOnOpenProviderConfig(cb: (provider: string) => boolean | Promise<boolean>): void {
+		this.onOpenProviderConfig = cb;
+	}
+
 	setOnBeginRenameCurrentSession(cb: () => boolean | Promise<boolean>): void {
 		this.onBeginRenameCurrentSession = cb;
 	}
@@ -775,11 +839,19 @@ export class ChatView {
 		this.compactionCycle = null;
 		this.compactionInsertIndex = null;
 		this.keepWorkflowExpandedUntilAssistantText = false;
+		this.runningProviderAuthAction = null;
+		this.modelCatalogLoadedAt = 0;
 		if (!path) {
 			this.bindingStatusText = null;
 			this.welcomeHeadlineIndex = (this.welcomeHeadlineIndex + 1) % this.welcomeHeadlines.length;
 			this.modelLoadRequestSeq += 1;
 			this.loadingModels = false;
+			this.loadingModelCatalog = false;
+			this.loadingProviderAuth = false;
+			this.modelCatalog = [];
+			this.providerAuthById.clear();
+			this.providerAuthConfigured.clear();
+			this.providerAuthLoadedAt = 0;
 			this.runHasAssistantText = false;
 			this.runSawToolActivity = false;
 			this.clearWorkingStatusTimer(true);
@@ -812,6 +884,7 @@ export class ChatView {
 		this.collapsedAutoWorkflowIds.clear();
 		this.compactionCycle = null;
 		this.compactionInsertIndex = null;
+		this.runningProviderAuthAction = null;
 		this.runHasAssistantText = false;
 		this.runSawToolActivity = false;
 		this.keepWorkflowExpandedUntilAssistantText = false;
@@ -1103,14 +1176,177 @@ export class ChatView {
 		return provider;
 	}
 
-	private showTerminalOnlyAuthGuidance(action: "login" | "logout", rawArgs: string): void {
-		const provider = this.normalizedAuthProviderArg(rawArgs);
-		const command = `/${action}${provider ? ` ${provider}` : ""}`;
-		this.appendSystemMessage(`Run in terminal: \`pi\` then \`${command}\``, {
-			label: "auth",
-			markdown: true,
-		});
-		this.pushNotice("OAuth commands are terminal-only in Desktop for now", "info");
+	private providerKey(provider: string): string {
+		return normalizeText(provider).toLowerCase();
+	}
+
+	private recomputeProviderAuthConfigured(): void {
+		const next = new Set<string>();
+		for (const provider of this.providerAuthById.keys()) {
+			next.add(provider);
+		}
+		for (const model of this.availableModels) {
+			const key = this.providerKey(model.provider);
+			if (key) next.add(key);
+		}
+		const currentProvider = this.providerKey(this.state?.model?.provider ?? "");
+		if (currentProvider) next.add(currentProvider);
+		this.providerAuthConfigured = next;
+	}
+
+	private async loadProviderAuthStatus(force = false): Promise<void> {
+		if (this.loadingProviderAuth) return;
+		const stale = Date.now() - this.providerAuthLoadedAt > MODEL_PICKER_AUTH_CACHE_MS;
+		if (!force && this.providerAuthLoadedAt > 0 && !stale) return;
+		this.loadingProviderAuth = true;
+		try {
+			const raw = await rpcBridge.getPiAuthStatus();
+			const next = new Map<string, Pick<PiAuthProviderStatus, "source" | "kind">>();
+			const providers = Array.isArray(raw?.configured_providers) ? raw.configured_providers : [];
+			for (const entry of providers) {
+				const provider = this.providerKey(typeof entry?.provider === "string" ? entry.provider : "");
+				if (!provider) continue;
+				const source = entry?.source;
+				const kind = entry?.kind;
+				next.set(provider, {
+					source:
+						source === "environment" || source === "auth_file_api_key" || source === "auth_file_oauth"
+							? source
+							: "auth_file_api_key",
+					kind: kind === "api_key" || kind === "oauth" || kind === "unknown" ? kind : "unknown",
+				});
+			}
+			this.providerAuthById = next;
+			this.providerAuthLoadedAt = Date.now();
+			this.recomputeProviderAuthConfigured();
+		} catch (err) {
+			console.error("Failed to load provider auth status:", err);
+			if (this.providerAuthLoadedAt === 0) {
+				this.providerAuthById = new Map();
+			}
+			this.recomputeProviderAuthConfigured();
+		} finally {
+			this.loadingProviderAuth = false;
+			this.render();
+		}
+	}
+
+	private async loadModelCatalog(force = false): Promise<void> {
+		if (this.loadingModelCatalog) return;
+		const stale = Date.now() - this.modelCatalogLoadedAt > MODEL_PICKER_CATALOG_CACHE_MS;
+		if (!force && this.modelCatalogLoadedAt > 0 && !stale) return;
+		this.loadingModelCatalog = true;
+		try {
+			const result = await rpcBridge.runPiCliCommand(["--list-models"], {
+				cwd: this.projectPath || ".",
+			});
+			if (result.exit_code !== 0) {
+				throw new Error(result.stderr || result.stdout || `pi --list-models failed with exit ${result.exit_code}`);
+			}
+			const parsed = parseListModelsCatalog(result.stdout || "");
+			if (parsed.length > 0) {
+				this.modelCatalog = parsed;
+				this.modelCatalogLoadedAt = Date.now();
+			}
+		} catch (err) {
+			console.error("Failed to load model catalog:", err);
+		} finally {
+			this.loadingModelCatalog = false;
+			this.render();
+		}
+	}
+
+	private resolveProviderSetupCommand(provider: string): string | null {
+		const providerKey = this.providerKey(provider);
+		if (!providerKey) return null;
+		const providerTokens = providerKey.split(/[-_.]+/).filter(Boolean);
+		let best: { name: string; score: number } | null = null;
+		for (const command of this.slashRuntimeCommands) {
+			if (command.source !== "extension") continue;
+			const name = normalizeText(command.name).toLowerCase().replace(/^\/+/, "");
+			if (!name) continue;
+			const description = normalizeText(command.description).toLowerCase();
+			const haystack = `${name} ${description}`;
+			let score = 0;
+			if (haystack.includes(providerKey)) score += 9;
+			score += providerTokens.filter((token) => token.length > 2 && haystack.includes(token)).length * 2;
+			if (/\b(config|setup|settings|auth|login)\b/.test(haystack)) score += 3;
+			if (/config/.test(name)) score += 2;
+			if (score <= 0) continue;
+			if (!best || score > best.score) {
+				best = { name, score };
+			}
+		}
+		return best?.name ?? null;
+	}
+
+	private async openProviderSetup(provider: string): Promise<boolean> {
+		const providerKey = this.providerKey(provider);
+		if (!providerKey) return false;
+		if (this.onOpenProviderConfig) {
+			try {
+				const handled = await this.onOpenProviderConfig(providerKey);
+				if (handled) return true;
+			} catch {
+				// ignore and continue fallback flow
+			}
+		}
+		await this.ensureSlashCommandsLoaded();
+		const setupCommand = this.resolveProviderSetupCommand(providerKey);
+		if (setupCommand && this.onOpenExtensionConfig) {
+			const handled = await this.onOpenExtensionConfig(setupCommand, "config");
+			if (handled) return true;
+		}
+		return false;
+	}
+
+	private async handleProviderAuthAction(provider: string, action: "login" | "logout"): Promise<void> {
+		const providerKey = this.providerKey(provider);
+		if (!providerKey) return;
+		if (this.runningProviderAuthAction) return;
+
+		this.runningProviderAuthAction = { provider: providerKey, action };
+		this.render();
+		const providerLabel = formatProviderDisplayName(providerKey);
+
+		try {
+			if (action === "login") {
+				const openedPackageConfig = await this.openProviderSetup(providerKey);
+				if (openedPackageConfig) {
+					this.pushNotice(`Opened ${providerLabel} setup`, "info");
+					return;
+				}
+				if (this.onOpenSettings) {
+					this.onOpenSettings("account");
+				}
+				this.appendSystemMessage(
+					`Open setup for **${providerLabel}** in Packages. For built-in OAuth providers, run \`pi\` in terminal and use \`/login\`.`,
+					{ label: "auth", markdown: true },
+				);
+				this.pushNotice(`Opened account setup for ${providerLabel}`, "info");
+				return;
+			}
+
+			const result = await rpcBridge.clearPiProviderAuth(providerKey);
+			if (result.removed) {
+				this.pushNotice(`Logged out of ${providerLabel}`, "success");
+			} else if (result.source === "environment") {
+				this.pushNotice(`${providerLabel} is configured via environment variable; remove env var to fully log out.`, "info");
+			} else {
+				this.pushNotice(`No stored auth.json credentials found for ${providerLabel}`, "info");
+			}
+			await Promise.all([
+				this.loadProviderAuthStatus(true),
+				this.loadAvailableModels(),
+				this.loadModelCatalog(true),
+			]);
+		} catch (err) {
+			console.error(`Provider auth action failed (${action}:${providerKey}):`, err);
+			this.pushNotice(err instanceof Error ? err.message : "Provider auth action failed", "error");
+		} finally {
+			this.runningProviderAuthAction = null;
+			this.render();
+		}
 	}
 
 	private async pickSessionImportPathFromDialog(): Promise<string | null> {
@@ -1241,13 +1477,20 @@ export class ChatView {
 		if (!this.loadingModels && this.availableModels.length === 0) {
 			void this.loadAvailableModels();
 		}
+		if (!this.loadingProviderAuth) {
+			void this.loadProviderAuthStatus();
+		}
+		if (!this.loadingModelCatalog && this.modelCatalog.length === 0) {
+			void this.loadModelCatalog();
+		}
 		const preferred = normalizeText(options.preferredProvider).toLowerCase();
 		if (preferred) {
-			const exact = this.availableModels.find((model) => model.provider.toLowerCase() === preferred)?.provider;
+			const providerPool = [...this.availableModels, ...this.modelCatalog];
+			const exact = providerPool.find((model) => model.provider.toLowerCase() === preferred)?.provider;
 			if (exact) {
 				this.modelPickerActiveProvider = exact;
 			} else {
-				const partial = this.availableModels.find((model) => model.provider.toLowerCase().includes(preferred))?.provider;
+				const partial = providerPool.find((model) => model.provider.toLowerCase().includes(preferred))?.provider;
 				if (partial) this.modelPickerActiveProvider = partial;
 			}
 		}
@@ -1269,13 +1512,14 @@ export class ChatView {
 		const token = byDelim.trim().toLowerCase();
 		if (!token) return null;
 
-		const providers = [...new Set(this.availableModels.map((model) => model.provider))];
+		const providerPool = [...this.availableModels, ...this.modelCatalog];
+		const providers = [...new Set(providerPool.map((model) => model.provider))];
 		const exact = providers.find((provider) => provider.toLowerCase() === token);
 		if (exact) return exact;
 		const partial = providers.find((provider) => provider.toLowerCase().includes(token));
 		if (partial) return partial;
 
-		const fuzzy = this.availableModels.filter((model) => `${model.provider}/${model.id}`.toLowerCase().includes(token));
+		const fuzzy = providerPool.filter((model) => `${model.provider}/${model.id}`.toLowerCase().includes(token));
 		if (fuzzy.length > 0) {
 			const uniqueProviders = [...new Set(fuzzy.map((model) => model.provider))];
 			if (uniqueProviders.length === 1) return uniqueProviders[0];
@@ -1518,11 +1762,21 @@ export class ChatView {
 				return;
 			}
 			case "login": {
-				this.showTerminalOnlyAuthGuidance("login", args);
+				const provider = this.normalizedAuthProviderArg(args);
+				if (!provider) {
+					this.openModelPicker();
+					return;
+				}
+				await this.handleProviderAuthAction(provider, "login");
 				return;
 			}
 			case "logout": {
-				this.showTerminalOnlyAuthGuidance("logout", args);
+				const provider = this.normalizedAuthProviderArg(args);
+				if (!provider) {
+					this.openModelPicker();
+					return;
+				}
+				await this.handleProviderAuthAction(provider, "logout");
 				return;
 			}
 			case "new": {
@@ -1550,13 +1804,21 @@ export class ChatView {
 					const handled = await this.onReloadRuntime();
 					if (handled) {
 						await this.ensureSlashCommandsLoaded(true);
+						await Promise.all([
+							this.loadProviderAuthStatus(true),
+							this.loadModelCatalog(true),
+						]);
 						this.pushNotice("Reloaded runtime state", "success");
 						return;
 					}
 				}
 				await this.ensureSlashCommandsLoaded(true);
 				await this.refreshFromBackend();
-				await this.loadAvailableModels();
+				await Promise.all([
+					this.loadAvailableModels(),
+					this.loadProviderAuthStatus(true),
+					this.loadModelCatalog(true),
+				]);
 				this.pushNotice("Reloaded runtime state", "success");
 				return;
 			}
@@ -1690,6 +1952,8 @@ export class ChatView {
 		if (!this.isConnected) return;
 		void this.refreshFromBackend();
 		void this.loadAvailableModels();
+		void this.loadProviderAuthStatus();
+		void this.loadModelCatalog();
 	}
 
 	disconnect(): void {
@@ -1731,6 +1995,7 @@ export class ChatView {
 			const currentSessionFile = state.sessionFile ?? null;
 			this.state = state;
 			this.syncComposerQueueFromState(state);
+			this.recomputeProviderAuthConfigured();
 			this.lastBackendSessionFile = currentSessionFile;
 			if ((previousSessionFile ?? "") !== (currentSessionFile ?? "")) {
 				this.sessionStats = {
@@ -1807,6 +2072,12 @@ export class ChatView {
 			if (!this.loadingModels && this.availableModels.length === 0) {
 				void this.loadAvailableModels();
 			}
+			if (!this.loadingProviderAuth && this.providerAuthLoadedAt === 0) {
+				void this.loadProviderAuthStatus();
+			}
+			if (!this.loadingModelCatalog && this.modelCatalog.length === 0) {
+				void this.loadModelCatalog();
+			}
 			push?.(`chat:refreshFromBackend ok session=${state.sessionFile ?? "-"} messages=${backendMessages.length}`);
 		} catch (err) {
 			console.error("Failed to refresh chat state:", err);
@@ -1819,7 +2090,11 @@ export class ChatView {
 	}
 
 	async refreshModels(): Promise<void> {
-		await this.loadAvailableModels();
+		await Promise.all([
+			this.loadAvailableModels(),
+			this.loadProviderAuthStatus(true),
+			this.loadModelCatalog(true),
+		]);
 	}
 
 	private mapBackendMessages(backendMessages: Array<Record<string, unknown>>): UiMessage[] {
@@ -2181,16 +2456,15 @@ export class ChatView {
 					label: `${provider}/${id}`,
 				});
 			}
-			if (mapped.length > 0) {
-				mapped.sort((a, b) => {
-					const providerCompare = formatProviderDisplayName(a.provider).localeCompare(formatProviderDisplayName(b.provider), undefined, {
-						sensitivity: "base",
-					});
-					if (providerCompare !== 0) return providerCompare;
-					return formatModelDisplayName(a.id).localeCompare(formatModelDisplayName(b.id), undefined, { sensitivity: "base" });
+			mapped.sort((a, b) => {
+				const providerCompare = formatProviderDisplayName(a.provider).localeCompare(formatProviderDisplayName(b.provider), undefined, {
+					sensitivity: "base",
 				});
-				this.availableModels = mapped;
-			}
+				if (providerCompare !== 0) return providerCompare;
+				return formatModelDisplayName(a.id).localeCompare(formatModelDisplayName(b.id), undefined, { sensitivity: "base" });
+			});
+			this.availableModels = mapped;
+			this.recomputeProviderAuthConfigured();
 			this.lastModelLoadError = null;
 			push?.(`chat:loadModels ok count=${mapped.length}`);
 		} catch (err) {
@@ -2216,6 +2490,7 @@ export class ChatView {
 			await rpcBridge.setModel(provider, modelId);
 			this.state = await rpcBridge.getState();
 			this.syncComposerQueueFromState(this.state);
+			this.recomputeProviderAuthConfigured();
 			if (this.state) this.onStateChange?.(this.state);
 			void this.refreshSessionStats(true);
 			this.pushNotice(`Switched to ${provider}/${modelId}`, "success");
@@ -6003,46 +6278,71 @@ export class ChatView {
 		const thinkingValue = (this.state?.thinkingLevel ?? "off") as ThinkingLevel;
 		const thinkingLabel = formatThinkingDisplayName(thinkingValue);
 
-		const groupedByProvider = new Map<string, { providerKey: string; providerLabel: string; models: ModelOption[] }>();
+		const availableByKey = new Map<string, ModelOption>();
 		for (const model of this.availableModels) {
-			const providerKey = model.provider;
-			const existing = groupedByProvider.get(providerKey);
-			if (existing) {
-				existing.models.push(model);
-			} else {
-				groupedByProvider.set(providerKey, {
-					providerKey,
-					providerLabel: formatProviderDisplayName(providerKey),
-					models: [model],
+			availableByKey.set(`${model.provider}::${model.id}`.toLowerCase(), model);
+		}
+
+		const catalogSeed = this.modelCatalog.length > 0 ? this.modelCatalog : this.availableModels;
+		const combinedByKey = new Map<string, ModelOption>();
+		for (const model of catalogSeed) {
+			const key = `${model.provider}::${model.id}`.toLowerCase();
+			if (!combinedByKey.has(key)) combinedByKey.set(key, model);
+		}
+		for (const model of this.availableModels) {
+			const key = `${model.provider}::${model.id}`.toLowerCase();
+			if (!combinedByKey.has(key)) combinedByKey.set(key, model);
+		}
+
+		if (currentProvider && currentModelId) {
+			const currentKey = `${currentProvider}::${currentModelId}`.toLowerCase();
+			if (!combinedByKey.has(currentKey)) {
+				combinedByKey.set(currentKey, {
+					provider: currentProvider,
+					id: currentModelId,
+					label: `${currentProvider}/${currentModelId}`,
+					reasoning: false,
 				});
 			}
 		}
 
-		if (currentProvider && currentModelId && !this.availableModels.some((m) => m.provider === currentProvider && m.id === currentModelId)) {
-			const existing = groupedByProvider.get(currentProvider);
-			const fallbackModel: ModelOption = {
-				provider: currentProvider,
-				id: currentModelId,
-				label: `${currentProvider}/${currentModelId}`,
-				reasoning: false,
-			};
-			if (existing) existing.models.unshift(fallbackModel);
-			else {
-				groupedByProvider.set(currentProvider, {
-					providerKey: currentProvider,
-					providerLabel: formatProviderDisplayName(currentProvider),
-					models: [fallbackModel],
+		const groupedByProvider = new Map<
+			string,
+			{ providerKey: string; providerLabel: string; models: Array<ModelOption & { selectable: boolean }> }
+		>();
+		for (const model of combinedByKey.values()) {
+			const providerKey = model.provider;
+			const modelKey = `${model.provider}::${model.id}`.toLowerCase();
+			const selectable = availableByKey.has(modelKey) || (model.provider === currentProvider && model.id === currentModelId);
+			const existing = groupedByProvider.get(providerKey);
+			if (existing) {
+				existing.models.push({ ...model, selectable });
+			} else {
+				groupedByProvider.set(providerKey, {
+					providerKey,
+					providerLabel: formatProviderDisplayName(providerKey),
+					models: [{ ...model, selectable }],
 				});
 			}
 		}
 
 		const providerGroups = Array.from(groupedByProvider.values())
-			.map((group) => ({
-				...group,
-				models: [...group.models].sort((a, b) =>
-					formatModelDisplayName(a.id).localeCompare(formatModelDisplayName(b.id), undefined, { sensitivity: "base" }),
-				),
-			}))
+			.map((group) => {
+				const authKey = this.providerKey(group.providerKey);
+				const hasSelectableModel = group.models.some((model) => model.selectable);
+				const authInfo = this.providerAuthById.get(authKey);
+				const authConfigured = this.providerAuthConfigured.has(authKey) || hasSelectableModel;
+				const authSource = authInfo?.source ?? (hasSelectableModel ? "runtime" : "missing");
+				return {
+					...group,
+					authConfigured,
+					authSource,
+					authKind: authInfo?.kind ?? "unknown",
+					models: [...group.models].sort((a, b) =>
+						formatModelDisplayName(a.id).localeCompare(formatModelDisplayName(b.id), undefined, { sensitivity: "base" }),
+					),
+				};
+			})
 			.sort((a, b) => a.providerLabel.localeCompare(b.providerLabel, undefined, { sensitivity: "base" }));
 
 		const resolvedActiveProvider = providerGroups.some((g) => g.providerKey === this.modelPickerActiveProvider)
@@ -6093,11 +6393,17 @@ export class ChatView {
 							type="button"
 							class="model-picker-trigger"
 							title=${currentModelTitle}
-							?disabled=${interactionLocked || this.loadingModels || this.settingModel}
+							?disabled=${interactionLocked || this.settingModel}
 							@click=${() => {
 								if (interactionLocked || this.settingModel) return;
 								if (!this.loadingModels && this.availableModels.length === 0) {
 									void this.loadAvailableModels();
+								}
+								if (!this.loadingProviderAuth) {
+									void this.loadProviderAuthStatus();
+								}
+								if (!this.loadingModelCatalog && this.modelCatalog.length === 0) {
+									void this.loadModelCatalog();
 								}
 								if (this.modelPickerOpen) {
 									this.modelPickerOpen = false;
@@ -6116,17 +6422,35 @@ export class ChatView {
 						${this.modelPickerOpen
 							? html`
 								<div class="model-picker-popover" role="listbox" aria-label="Available models">
-									${this.loadingModels
-										? html`<div class="model-picker-empty">Loading models…</div>`
-										: providerGroups.length === 0
-											? html`<div class="model-picker-empty">No models available</div>`
-											: html`
-												<div class="model-picker-providers">
-													${providerGroups.map(
-														(group) => html`
+									${providerGroups.length === 0
+										? html`<div class="model-picker-empty">${this.loadingModels || this.loadingModelCatalog ? "Loading models…" : "No models available"}</div>`
+										: html`
+											<div class="model-picker-providers">
+												${providerGroups.map((group) => {
+													const authKey = this.providerKey(group.providerKey);
+													const isActionBusy = this.runningProviderAuthAction?.provider === authKey;
+													const canLogout = group.authConfigured && group.authSource !== "environment";
+													const action = canLogout ? ("logout" as const) : ("login" as const);
+													const actionLabel = group.authConfigured
+														? group.authSource === "environment"
+															? "Env"
+															: "Logout"
+														: "Login";
+													const actionDisabled =
+														interactionLocked ||
+														this.settingModel ||
+														isActionBusy ||
+														(group.authConfigured && group.authSource === "environment");
+													const actionTitle = group.authConfigured
+														? group.authSource === "environment"
+															? "Configured from environment variable"
+															: `Logout from ${group.providerLabel}`
+														: `Set up ${group.providerLabel}`;
+													return html`
+														<div class="model-picker-provider-row ${group.providerKey === resolvedActiveProvider ? "active" : ""} ${group.authConfigured ? "" : "unauth"}">
 															<button
 																type="button"
-																class="model-picker-provider ${group.providerKey === resolvedActiveProvider ? "active" : ""}"
+																class="model-picker-provider ${group.providerKey === resolvedActiveProvider ? "active" : ""} ${group.authConfigured ? "" : "unauth"}"
 																@mouseenter=${() => {
 																	if (this.modelPickerActiveProvider === group.providerKey) return;
 																	this.modelPickerActiveProvider = group.providerKey;
@@ -6144,21 +6468,47 @@ export class ChatView {
 																}}
 															>
 																<span class="model-picker-provider-label">${group.providerLabel}</span>
+																<span class="model-picker-provider-state">${group.authConfigured ? "connected" : "setup"}</span>
 																<span class="model-picker-provider-caret" aria-hidden="true">›</span>
 															</button>
-														`,
-													)}
-												</div>
-												<div class="model-picker-models">
-													${activeProviderGroup
-														? activeProviderGroup.models.map(
-															(model) => html`
+															<button
+																type="button"
+																class="model-picker-provider-auth ${group.authConfigured ? "connected" : ""}"
+																title=${actionTitle}
+																?disabled=${actionDisabled}
+																@click=${(event: MouseEvent) => {
+																	event.preventDefault();
+																	event.stopPropagation();
+																	if (actionDisabled) return;
+																	void this.handleProviderAuthAction(group.providerKey, action);
+																}}
+															>
+																${isActionBusy ? "…" : actionLabel}
+															</button>
+														</div>
+													`;
+												})}
+											</div>
+											<div class="model-picker-models">
+												${activeProviderGroup
+													? html`
+														${!activeProviderGroup.authConfigured
+															? html`<div class="model-picker-auth-hint">Not connected yet. Use Login to set up this provider.</div>`
+															: nothing}
+														${activeProviderGroup.models.map((model) => {
+															const nextValue = `${model.provider}::${model.id}`;
+															const isActive = model.provider === currentProvider && model.id === currentModelId;
+															const isDisabled = !model.selectable;
+															return html`
 																<button
 																	type="button"
-																	class="model-picker-model ${model.provider === currentProvider && model.id === currentModelId ? "active" : ""}"
-																	title=${`${formatProviderDisplayName(model.provider)} / ${model.id}`}
+																	class="model-picker-model ${isActive ? "active" : ""} ${isDisabled ? "disabled" : ""}"
+																	title=${isDisabled
+																		? `${formatProviderDisplayName(model.provider)} / ${model.id} (setup required)`
+																		: `${formatProviderDisplayName(model.provider)} / ${model.id}`}
+																	?disabled=${interactionLocked || this.settingModel || isDisabled}
 																	@click=${() => {
-																		const nextValue = `${model.provider}::${model.id}`;
+																		if (isDisabled) return;
 																		this.modelPickerOpen = false;
 																		this.render();
 																		if (nextValue === currentModelValue) return;
@@ -6167,11 +6517,12 @@ export class ChatView {
 																>
 																	<span>${formatModelDisplayName(model.id)}</span>
 																</button>
-															`,
-														)
-														: html`<div class="model-picker-empty">No models</div>`}
-												</div>
-											`}
+															`;
+														})}
+													`
+													: html`<div class="model-picker-empty">No models</div>`}
+											</div>
+										`}
 								</div>
 							`
 							: nothing}

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -1342,11 +1342,22 @@ export class ChatView {
 				this.recomputeProviderAuthConfigured();
 				this.pushNotice(`No stored auth.json credentials found for ${providerLabel}`, "info");
 			}
+
+			if (this.onReloadRuntime) {
+				try {
+					await this.onReloadRuntime();
+				} catch {
+					// best-effort reload only
+				}
+			}
+
 			await Promise.all([
+				this.refreshFromBackend(),
 				this.loadProviderAuthStatus(true),
 				this.loadAvailableModels(),
 				this.loadModelCatalog(true),
 			]);
+			await this.switchAwayFromLoggedOutProvider(providerKey);
 		} catch (err) {
 			console.error(`Provider auth action failed (${action}:${providerKey}):`, err);
 			this.pushNotice(err instanceof Error ? err.message : "Provider auth action failed", "error");
@@ -1354,6 +1365,17 @@ export class ChatView {
 			this.runningProviderAuthAction = null;
 			this.render();
 		}
+	}
+
+	private async switchAwayFromLoggedOutProvider(providerKey: string): Promise<void> {
+		const currentProvider = this.providerKey(this.state?.model?.provider ?? "");
+		if (!currentProvider || currentProvider !== providerKey) return;
+		const fallback = this.availableModels.find((model) => this.providerKey(model.provider) !== providerKey) ?? null;
+		if (!fallback) {
+			this.pushNotice("No other authenticated models available. Log in to another provider.", "info");
+			return;
+		}
+		await this.setModel(fallback.provider, fallback.id);
 	}
 
 	private async pickSessionImportPathFromDialog(): Promise<string | null> {
@@ -6331,6 +6353,14 @@ export class ChatView {
 					models: [{ ...model, selectable }],
 				});
 			}
+		}
+		for (const forcedLoggedOutProvider of this.providerAuthForcedLoggedOut) {
+			if (groupedByProvider.has(forcedLoggedOutProvider)) continue;
+			groupedByProvider.set(forcedLoggedOutProvider, {
+				providerKey: forcedLoggedOutProvider,
+				providerLabel: formatProviderDisplayName(forcedLoggedOutProvider),
+				models: [],
+			});
 		}
 
 		const providerGroups = Array.from(groupedByProvider.values())

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -274,6 +274,16 @@ const BUILTIN_SLASH_COMMANDS: Array<{ name: string; description: string }> = [
 const MODEL_PICKER_AUTH_CACHE_MS = 15_000;
 const MODEL_PICKER_CATALOG_CACHE_MS = 60_000;
 
+// Mirrors built-in OAuth providers from @mariozechner/pi-ai/oauth.
+const DEFAULT_OAUTH_PROVIDER_IDS = [
+	"anthropic",
+	"github-copilot",
+	"google-gemini-cli",
+	"google-antigravity",
+	"openai-codex",
+] as const;
+const DEFAULT_OAUTH_PROVIDER_SET = new Set<string>(DEFAULT_OAUTH_PROVIDER_IDS);
+
 function uid(prefix = "id"): string {
 	return `${prefix}_${Math.random().toString(36).slice(2, 8)}_${Date.now().toString(36)}`;
 }
@@ -399,12 +409,20 @@ function formatProviderDisplayName(provider: string): string {
 	switch (normalized) {
 		case "openai":
 			return "OpenAI";
+		case "openai-codex":
+			return "OpenAI Codex";
 		case "anthropic":
 			return "Anthropic";
 		case "google":
 		case "googleai":
 		case "gemini":
 			return "Google";
+		case "google-gemini-cli":
+			return "Google Gemini CLI";
+		case "google-antigravity":
+			return "Google Antigravity";
+		case "github-copilot":
+			return "GitHub Copilot";
 		case "xai":
 			return "xAI";
 		case "openrouter":
@@ -413,6 +431,10 @@ function formatProviderDisplayName(provider: string): string {
 			return "Ollama";
 		case "lmstudio":
 			return "LM Studio";
+		case "cursor-agent":
+			return "Cursor";
+		case "kilo":
+			return "Kilo";
 		default:
 			return normalized
 				.split(/[-_\s]+/)
@@ -1245,10 +1267,8 @@ export class ChatView {
 				throw new Error(result.stderr || result.stdout || `pi --list-models failed with exit ${result.exit_code}`);
 			}
 			const parsed = parseListModelsCatalog(result.stdout || "");
-			if (parsed.length > 0) {
-				this.modelCatalog = parsed;
-				this.modelCatalogLoadedAt = Date.now();
-			}
+			this.modelCatalog = parsed;
+			this.modelCatalogLoadedAt = Date.now();
 		} catch (err) {
 			console.error("Failed to load model catalog:", err);
 		} finally {
@@ -6354,6 +6374,22 @@ export class ChatView {
 				});
 			}
 		}
+		for (const provider of this.providerAuthById.keys()) {
+			if (groupedByProvider.has(provider)) continue;
+			groupedByProvider.set(provider, {
+				providerKey: provider,
+				providerLabel: formatProviderDisplayName(provider),
+				models: [],
+			});
+		}
+		for (const provider of DEFAULT_OAUTH_PROVIDER_IDS) {
+			if (groupedByProvider.has(provider)) continue;
+			groupedByProvider.set(provider, {
+				providerKey: provider,
+				providerLabel: formatProviderDisplayName(provider),
+				models: [],
+			});
+		}
 		for (const forcedLoggedOutProvider of this.providerAuthForcedLoggedOut) {
 			if (groupedByProvider.has(forcedLoggedOutProvider)) continue;
 			groupedByProvider.set(forcedLoggedOutProvider, {
@@ -6376,6 +6412,7 @@ export class ChatView {
 					authConfigured,
 					authSource,
 					authKind: authInfo?.kind ?? "unknown",
+					isDefaultOAuthProvider: DEFAULT_OAUTH_PROVIDER_SET.has(authKey),
 					models: [...group.models].sort((a, b) =>
 						formatModelDisplayName(a.id).localeCompare(formatModelDisplayName(b.id), undefined, { sensitivity: "base" }),
 					),
@@ -6529,33 +6566,45 @@ export class ChatView {
 											<div class="model-picker-models">
 												${activeProviderGroup
 													? html`
-														${!activeProviderGroup.authConfigured
-															? html`<div class="model-picker-auth-hint">Not connected yet. Use Login to set up this provider.</div>`
-															: nothing}
-														${activeProviderGroup.models.map((model) => {
-															const nextValue = `${model.provider}::${model.id}`;
-															const isActive = model.provider === currentProvider && model.id === currentModelId;
-															const isDisabled = !model.selectable || !activeProviderGroup.authConfigured;
-															return html`
-																<button
-																	type="button"
-																	class="model-picker-model ${isActive ? "active" : ""} ${isDisabled ? "disabled" : ""}"
-																	title=${isDisabled
-																		? `${formatProviderDisplayName(model.provider)} / ${model.id} (setup required)`
-																		: `${formatProviderDisplayName(model.provider)} / ${model.id}`}
-																	?disabled=${interactionLocked || this.settingModel || isDisabled}
-																	@click=${() => {
-																		if (isDisabled) return;
-																		this.modelPickerOpen = false;
-																		this.render();
-																		if (nextValue === currentModelValue) return;
-																		void this.setModel(model.provider, model.id);
-																	}}
-																>
-																	<span>${formatModelDisplayName(model.id)}</span>
-																</button>
-															`;
-														})}
+														${activeProviderGroup.models.length === 0
+															? html`
+																<div class="model-picker-auth-hint">
+																	${activeProviderGroup.authConfigured
+																		? activeProviderGroup.isDefaultOAuthProvider
+																			? "Connected, but no models are available right now. Try /reload after login changes."
+																			: "Connected, but no models are loaded for this provider. Install/enable its package in Packages, then run /reload."
+																		: "Not connected yet. Use Login to set up this provider."}
+																</div>
+															`
+															: html`
+																${!activeProviderGroup.authConfigured
+																	? html`<div class="model-picker-auth-hint">Not connected yet. Use Login to set up this provider.</div>`
+																	: nothing}
+																${activeProviderGroup.models.map((model) => {
+																	const nextValue = `${model.provider}::${model.id}`;
+																	const isActive = model.provider === currentProvider && model.id === currentModelId;
+																	const isDisabled = !model.selectable || !activeProviderGroup.authConfigured;
+																	return html`
+																		<button
+																			type="button"
+																			class="model-picker-model ${isActive ? "active" : ""} ${isDisabled ? "disabled" : ""}"
+																			title=${isDisabled
+																				? `${formatProviderDisplayName(model.provider)} / ${model.id} (setup required)`
+																				: `${formatProviderDisplayName(model.provider)} / ${model.id}`}
+																			?disabled=${interactionLocked || this.settingModel || isDisabled}
+																			@click=${() => {
+																				if (isDisabled) return;
+																				this.modelPickerOpen = false;
+																				this.render();
+																				if (nextValue === currentModelValue) return;
+																				void this.setModel(model.provider, model.id);
+																			}}
+																		>
+																			<span>${formatModelDisplayName(model.id)}</span>
+																		</button>
+																	`;
+																})}
+															`}
 													`
 													: html`<div class="model-picker-empty">No models</div>`}
 											</div>

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -6451,6 +6451,7 @@ export class ChatView {
 															<button
 																type="button"
 																class="model-picker-provider ${group.providerKey === resolvedActiveProvider ? "active" : ""} ${group.authConfigured ? "" : "unauth"}"
+																title=${group.authConfigured ? `${group.providerLabel} connected` : `${group.providerLabel} needs setup`}
 																@mouseenter=${() => {
 																	if (this.modelPickerActiveProvider === group.providerKey) return;
 																	this.modelPickerActiveProvider = group.providerKey;
@@ -6468,12 +6469,11 @@ export class ChatView {
 																}}
 															>
 																<span class="model-picker-provider-label">${group.providerLabel}</span>
-																<span class="model-picker-provider-state">${group.authConfigured ? "connected" : "setup"}</span>
 																<span class="model-picker-provider-caret" aria-hidden="true">›</span>
 															</button>
 															<button
 																type="button"
-																class="model-picker-provider-auth ${group.authConfigured ? "connected" : ""}"
+																class="model-picker-provider-auth ${group.authConfigured ? "connected" : ""} ${isActionBusy ? "busy" : ""}"
 																title=${actionTitle}
 																?disabled=${actionDisabled}
 																@click=${(event: MouseEvent) => {

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -7,6 +7,7 @@ import "@mariozechner/mini-lit/dist/MarkdownBlock.js";
 import { html, nothing, render, type TemplateResult } from "lit";
 import {
 	type PiAuthProviderStatus,
+	type PiOAuthProviderInfo,
 	type RpcImageInput,
 	type RpcSessionState,
 	type ThinkingLevel,
@@ -283,6 +284,13 @@ const DEFAULT_OAUTH_PROVIDER_IDS = [
 	"openai-codex",
 ] as const;
 const DEFAULT_OAUTH_PROVIDER_SET = new Set<string>(DEFAULT_OAUTH_PROVIDER_IDS);
+const DEFAULT_OAUTH_PROVIDER_NAME_BY_ID = new Map<string, string>([
+	["anthropic", "Anthropic"],
+	["github-copilot", "GitHub Copilot"],
+	["google-gemini-cli", "Google Gemini CLI"],
+	["google-antigravity", "Google Antigravity"],
+	["openai-codex", "OpenAI Codex"],
+]);
 
 function uid(prefix = "id"): string {
 	return `${prefix}_${Math.random().toString(36).slice(2, 8)}_${Date.now().toString(36)}`;
@@ -432,9 +440,11 @@ function formatProviderDisplayName(provider: string): string {
 		case "lmstudio":
 			return "LM Studio";
 		case "cursor-agent":
+		case "cursor":
 			return "Cursor";
 		case "kilo":
-			return "Kilo";
+		case "kilocode":
+			return "Kilo Code";
 		default:
 			return normalized
 				.split(/[-_\s]+/)
@@ -622,6 +632,9 @@ export class ChatView {
 	private providerAuthById = new Map<string, Pick<PiAuthProviderStatus, "source" | "kind">>();
 	private providerAuthConfigured = new Set<string>();
 	private providerAuthForcedLoggedOut = new Set<string>();
+	private oauthProviderCatalogLoadedAt = 0;
+	private oauthProviderCatalogLoading = false;
+	private oauthProviderCatalog = new Map<string, { name: string; source: "built_in" | "package" }>();
 	private lastBackendRefreshError: string | null = null;
 	private lastModelLoadError: string | null = null;
 	private lastBackendSessionFile: string | null = null;
@@ -1205,6 +1218,66 @@ export class ChatView {
 		return normalizeText(provider).toLowerCase();
 	}
 
+	private isOAuthProviderId(provider: string): boolean {
+		const key = this.providerKey(provider);
+		return DEFAULT_OAUTH_PROVIDER_SET.has(key) || this.oauthProviderCatalog.has(key);
+	}
+
+	private displayProviderLabel(provider: string): string {
+		const key = this.providerKey(provider);
+		const catalogName = this.oauthProviderCatalog.get(key)?.name;
+		if (catalogName) return catalogName;
+		const defaultName = DEFAULT_OAUTH_PROVIDER_NAME_BY_ID.get(key);
+		if (defaultName) return defaultName;
+		return formatProviderDisplayName(key);
+	}
+
+	private async loadOAuthProviderCatalog(force = false): Promise<void> {
+		if (this.oauthProviderCatalogLoading) return;
+		const stale = Date.now() - this.oauthProviderCatalogLoadedAt > MODEL_PICKER_AUTH_CACHE_MS;
+		if (!force && this.oauthProviderCatalogLoadedAt > 0 && !stale) return;
+		this.oauthProviderCatalogLoading = true;
+		try {
+			const raw = await rpcBridge.getPiOAuthProviders();
+			const next = new Map<string, { name: string; source: "built_in" | "package" }>();
+			const entries = Array.isArray(raw) ? raw : [];
+			for (const entry of entries) {
+				const providerId = this.providerKey(typeof entry?.id === "string" ? entry.id : "");
+				if (!providerId) continue;
+				const nameRaw = typeof entry?.name === "string" ? entry.name.trim() : "";
+				const sourceRaw = entry?.source;
+				next.set(providerId, {
+					name: nameRaw || this.displayProviderLabel(providerId),
+					source: sourceRaw === "package" ? "package" : "built_in",
+				});
+			}
+			for (const providerId of DEFAULT_OAUTH_PROVIDER_IDS) {
+				if (next.has(providerId)) continue;
+				next.set(providerId, {
+					name: DEFAULT_OAUTH_PROVIDER_NAME_BY_ID.get(providerId) ?? formatProviderDisplayName(providerId),
+					source: "built_in",
+				});
+			}
+			this.oauthProviderCatalog = next;
+			this.oauthProviderCatalogLoadedAt = Date.now();
+		} catch (err) {
+			console.error("Failed to load OAuth provider catalog:", err);
+			if (this.oauthProviderCatalogLoadedAt === 0) {
+				const defaults = new Map<string, { name: string; source: "built_in" | "package" }>();
+				for (const providerId of DEFAULT_OAUTH_PROVIDER_IDS) {
+					defaults.set(providerId, {
+						name: DEFAULT_OAUTH_PROVIDER_NAME_BY_ID.get(providerId) ?? formatProviderDisplayName(providerId),
+						source: "built_in",
+					});
+				}
+				this.oauthProviderCatalog = defaults;
+			}
+		} finally {
+			this.oauthProviderCatalogLoading = false;
+			this.render();
+		}
+	}
+
 	private recomputeProviderAuthConfigured(): void {
 		const next = new Set<string>();
 		for (const provider of this.providerAuthById.keys()) {
@@ -1330,11 +1403,14 @@ export class ChatView {
 
 		this.runningProviderAuthAction = { provider: providerKey, action };
 		this.render();
-		const providerLabel = formatProviderDisplayName(providerKey);
+		const providerLabel = this.displayProviderLabel(providerKey);
 
 		try {
 			if (action === "login") {
-				if (DEFAULT_OAUTH_PROVIDER_SET.has(providerKey)) {
+				if (!this.isOAuthProviderId(providerKey)) {
+					await this.loadOAuthProviderCatalog(true);
+				}
+				if (this.isOAuthProviderId(providerKey)) {
 					const loginCommand = `pi login ${providerKey}`;
 					if (this.onOpenTerminal) {
 						await this.onOpenTerminal(loginCommand);
@@ -1386,6 +1462,7 @@ export class ChatView {
 			await Promise.all([
 				this.refreshFromBackend(),
 				this.loadProviderAuthStatus(true),
+				this.loadOAuthProviderCatalog(true),
 				this.loadAvailableModels(),
 				this.loadModelCatalog(true),
 			]);
@@ -1540,6 +1617,9 @@ export class ChatView {
 		}
 		if (!this.loadingProviderAuth) {
 			void this.loadProviderAuthStatus();
+		}
+		if (!this.oauthProviderCatalogLoading) {
+			void this.loadOAuthProviderCatalog();
 		}
 		if (!this.loadingModelCatalog && this.modelCatalog.length === 0) {
 			void this.loadModelCatalog();
@@ -1867,6 +1947,7 @@ export class ChatView {
 						await this.ensureSlashCommandsLoaded(true);
 						await Promise.all([
 							this.loadProviderAuthStatus(true),
+							this.loadOAuthProviderCatalog(true),
 							this.loadModelCatalog(true),
 						]);
 						this.pushNotice("Reloaded runtime state", "success");
@@ -1878,6 +1959,7 @@ export class ChatView {
 				await Promise.all([
 					this.loadAvailableModels(),
 					this.loadProviderAuthStatus(true),
+					this.loadOAuthProviderCatalog(true),
 					this.loadModelCatalog(true),
 				]);
 				this.pushNotice("Reloaded runtime state", "success");
@@ -2014,6 +2096,7 @@ export class ChatView {
 		void this.refreshFromBackend();
 		void this.loadAvailableModels();
 		void this.loadProviderAuthStatus();
+		void this.loadOAuthProviderCatalog();
 		void this.loadModelCatalog();
 	}
 
@@ -2136,6 +2219,9 @@ export class ChatView {
 			if (!this.loadingProviderAuth && this.providerAuthLoadedAt === 0) {
 				void this.loadProviderAuthStatus();
 			}
+			if (!this.oauthProviderCatalogLoading && this.oauthProviderCatalogLoadedAt === 0) {
+				void this.loadOAuthProviderCatalog();
+			}
 			if (!this.loadingModelCatalog && this.modelCatalog.length === 0) {
 				void this.loadModelCatalog();
 			}
@@ -2154,6 +2240,7 @@ export class ChatView {
 		await Promise.all([
 			this.loadAvailableModels(),
 			this.loadProviderAuthStatus(true),
+			this.loadOAuthProviderCatalog(true),
 			this.loadModelCatalog(true),
 		]);
 	}
@@ -6334,7 +6421,7 @@ export class ChatView {
 		const currentModelId = normalizeText(this.state?.model?.id);
 		const currentModelValue = currentProvider && currentModelId ? `${currentProvider}::${currentModelId}` : "";
 		const currentModelDisplay = currentModelId ? formatModelDisplayName(currentModelId) : "Select model";
-		const currentProviderDisplay = currentProvider ? formatProviderDisplayName(currentProvider) : "";
+		const currentProviderDisplay = currentProvider ? this.displayProviderLabel(currentProvider) : "";
 		const currentModelTitle = currentProvider && currentModelId ? `${currentProviderDisplay} / ${currentModelId}` : "Select model";
 		const thinkingValue = (this.state?.thinkingLevel ?? "off") as ThinkingLevel;
 		const thinkingLabel = formatThinkingDisplayName(thinkingValue);
@@ -6381,7 +6468,7 @@ export class ChatView {
 			} else {
 				groupedByProvider.set(providerKey, {
 					providerKey,
-					providerLabel: formatProviderDisplayName(providerKey),
+					providerLabel: this.displayProviderLabel(providerKey),
 					models: [{ ...model, selectable }],
 				});
 			}
@@ -6390,7 +6477,15 @@ export class ChatView {
 			if (groupedByProvider.has(provider)) continue;
 			groupedByProvider.set(provider, {
 				providerKey: provider,
-				providerLabel: formatProviderDisplayName(provider),
+				providerLabel: this.displayProviderLabel(provider),
+				models: [],
+			});
+		}
+		for (const provider of this.oauthProviderCatalog.keys()) {
+			if (groupedByProvider.has(provider)) continue;
+			groupedByProvider.set(provider, {
+				providerKey: provider,
+				providerLabel: this.displayProviderLabel(provider),
 				models: [],
 			});
 		}
@@ -6398,7 +6493,7 @@ export class ChatView {
 			if (groupedByProvider.has(provider)) continue;
 			groupedByProvider.set(provider, {
 				providerKey: provider,
-				providerLabel: formatProviderDisplayName(provider),
+				providerLabel: this.displayProviderLabel(provider),
 				models: [],
 			});
 		}
@@ -6406,7 +6501,7 @@ export class ChatView {
 			if (groupedByProvider.has(forcedLoggedOutProvider)) continue;
 			groupedByProvider.set(forcedLoggedOutProvider, {
 				providerKey: forcedLoggedOutProvider,
-				providerLabel: formatProviderDisplayName(forcedLoggedOutProvider),
+				providerLabel: this.displayProviderLabel(forcedLoggedOutProvider),
 				models: [],
 			});
 		}
@@ -6417,14 +6512,17 @@ export class ChatView {
 				const hasSelectableModel = group.models.some((model) => model.selectable);
 				const authInfo = this.providerAuthById.get(authKey);
 				const forcedLoggedOut = this.providerAuthForcedLoggedOut.has(authKey);
-				const authConfigured = !forcedLoggedOut && (this.providerAuthConfigured.has(authKey) || hasSelectableModel);
-				const authSource = forcedLoggedOut ? "missing" : (authInfo?.source ?? (hasSelectableModel ? "runtime" : "missing"));
+				const isOAuthProvider = this.isOAuthProviderId(authKey);
+				const authConfigured = !forcedLoggedOut && (this.providerAuthConfigured.has(authKey) || (!isOAuthProvider && hasSelectableModel));
+				const authSource = forcedLoggedOut
+					? "missing"
+					: (authInfo?.source ?? (!isOAuthProvider && hasSelectableModel ? "runtime" : "missing"));
 				return {
 					...group,
 					authConfigured,
 					authSource,
 					authKind: authInfo?.kind ?? "unknown",
-					isDefaultOAuthProvider: DEFAULT_OAUTH_PROVIDER_SET.has(authKey),
+					isDefaultOAuthProvider: isOAuthProvider,
 					models: [...group.models].sort((a, b) =>
 						formatModelDisplayName(a.id).localeCompare(formatModelDisplayName(b.id), undefined, { sensitivity: "base" }),
 					),
@@ -6488,6 +6586,9 @@ export class ChatView {
 								}
 								if (!this.loadingProviderAuth) {
 									void this.loadProviderAuthStatus();
+								}
+								if (!this.oauthProviderCatalogLoading) {
+									void this.loadOAuthProviderCatalog();
 								}
 								if (!this.loadingModelCatalog && this.modelCatalog.length === 0) {
 									void this.loadModelCatalog();

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -262,7 +262,7 @@ const BUILTIN_SLASH_COMMANDS: Array<{ name: string; description: string }> = [
 	{ name: "terminal", description: "Toggle docked terminal" },
 	{ name: "fork", description: "Open fork flow, /fork <query> pre-fills message search" },
 	{ name: "tree", description: "Open full session tree across branches, /tree <query> pre-fills search" },
-	{ name: "login", description: "No arg opens model picker auth actions; /login <provider> opens setup" },
+	{ name: "login", description: "No arg opens model picker auth actions; /login <provider> opens provider login guidance/setup" },
 	{ name: "logout", description: "No arg opens model picker auth actions; /logout <provider> clears auth.json credentials" },
 	{ name: "new", description: "Start fresh session tab" },
 	{ name: "compact", description: "Manually compact context, /compact <instructions> optional" },
@@ -1280,7 +1280,7 @@ export class ChatView {
 	private resolveProviderSetupCommand(provider: string): string | null {
 		const providerKey = this.providerKey(provider);
 		if (!providerKey) return null;
-		const providerTokens = providerKey.split(/[-_.]+/).filter(Boolean);
+		const providerTokens = providerKey.split(/[-_.]+/).filter((token) => token.length > 2);
 		let best: { name: string; score: number } | null = null;
 		for (const command of this.slashRuntimeCommands) {
 			if (command.source !== "extension") continue;
@@ -1288,12 +1288,14 @@ export class ChatView {
 			if (!name) continue;
 			const description = normalizeText(command.description).toLowerCase();
 			const haystack = `${name} ${description}`;
+			const tokenHits = providerTokens.filter((token) => haystack.includes(token)).length;
+			const hasProviderMatch = haystack.includes(providerKey) || tokenHits > 0;
+			if (!hasProviderMatch) continue;
 			let score = 0;
-			if (haystack.includes(providerKey)) score += 9;
-			score += providerTokens.filter((token) => token.length > 2 && haystack.includes(token)).length * 2;
-			if (/\b(config|setup|settings|auth|login)\b/.test(haystack)) score += 3;
-			if (/config/.test(name)) score += 2;
-			if (score <= 0) continue;
+			if (haystack.includes(providerKey)) score += 8;
+			score += tokenHits * 3;
+			if (/\b(config|setup|settings|auth|login)\b/.test(haystack)) score += 2;
+			if (/config/.test(name)) score += 1;
 			if (!best || score > best.score) {
 				best = { name, score };
 			}
@@ -1332,6 +1334,15 @@ export class ChatView {
 
 		try {
 			if (action === "login") {
+				if (DEFAULT_OAUTH_PROVIDER_SET.has(providerKey)) {
+					this.onOpenTerminal?.();
+					this.appendSystemMessage(
+						`To log in to **${providerLabel}**, run \`pi\` in terminal, then run \`/login\` and choose **${providerLabel}** in the OAuth picker.`,
+						{ label: "auth", markdown: true },
+					);
+					this.pushNotice(`Open terminal and run pi → /login to connect ${providerLabel}`, "info");
+					return;
+				}
 				const openedPackageConfig = await this.openProviderSetup(providerKey);
 				if (openedPackageConfig) {
 					this.pushNotice(`Opened ${providerLabel} setup`, "info");
@@ -1341,7 +1352,7 @@ export class ChatView {
 					this.onOpenSettings("account");
 				}
 				this.appendSystemMessage(
-					`Open setup for **${providerLabel}** in Packages. For built-in OAuth providers, run \`pi\` in terminal and use \`/login\`.`,
+					`Open setup for **${providerLabel}** in Packages. If this provider supports OAuth, use \`pi\` in terminal and run \`/login\` to authorize.`,
 					{ label: "auth", markdown: true },
 				);
 				this.pushNotice(`Opened account setup for ${providerLabel}`, "info");

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -595,7 +595,7 @@ export class ChatView {
 	private lastDropSignature = "";
 	private lastDropAt = 0;
 	private onStateChange: ((state: RpcSessionState) => void) | null = null;
-	private onOpenTerminal: (() => void) | null = null;
+	private onOpenTerminal: ((command?: string) => void | Promise<void>) | null = null;
 	private onAddProject: (() => void) | null = null;
 	private onOpenSettings: ((sectionId?: string) => void) | null = null;
 	private onOpenPackages: (() => void) | null = null;
@@ -766,7 +766,7 @@ export class ChatView {
 		this.onStateChange = cb;
 	}
 
-	setOnOpenTerminal(cb: () => void): void {
+	setOnOpenTerminal(cb: (command?: string) => void | Promise<void>): void {
 		this.onOpenTerminal = cb;
 	}
 
@@ -1335,12 +1335,13 @@ export class ChatView {
 		try {
 			if (action === "login") {
 				if (DEFAULT_OAUTH_PROVIDER_SET.has(providerKey)) {
-					this.onOpenTerminal?.();
-					this.appendSystemMessage(
-						`To log in to **${providerLabel}**, run \`pi\` in terminal, then run \`/login\` and choose **${providerLabel}** in the OAuth picker.`,
-						{ label: "auth", markdown: true },
-					);
-					this.pushNotice(`Open terminal and run pi → /login to connect ${providerLabel}`, "info");
+					const loginCommand = `pi login ${providerKey}`;
+					if (this.onOpenTerminal) {
+						await this.onOpenTerminal(loginCommand);
+						this.pushNotice(`Opened terminal and started OAuth login helper for ${providerLabel}`, "info");
+						return;
+					}
+					this.pushNotice(`Open terminal and run: ${loginCommand}`, "info");
 					return;
 				}
 				const openedPackageConfig = await this.openProviderSetup(providerKey);
@@ -1803,7 +1804,7 @@ export class ChatView {
 			}
 			case "terminal": {
 				if (this.onOpenTerminal) {
-					this.onOpenTerminal();
+					await this.onOpenTerminal();
 				} else {
 					this.pushNotice("Terminal panel is unavailable", "info");
 				}

--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -1335,13 +1335,12 @@ export class ChatView {
 		try {
 			if (action === "login") {
 				if (DEFAULT_OAUTH_PROVIDER_SET.has(providerKey)) {
-					const loginCommand = `pi login ${providerKey}`;
 					if (this.onOpenTerminal) {
-						await this.onOpenTerminal(loginCommand);
-						this.pushNotice(`Opened terminal and started OAuth login helper for ${providerLabel}`, "info");
+						await this.onOpenTerminal("pi");
+						this.pushNotice(`Opened terminal. In Pi, type /login and select ${providerLabel}.`, "info");
 						return;
 					}
-					this.pushNotice(`Open terminal and run: ${loginCommand}`, "info");
+					this.pushNotice(`Open terminal, run pi, then type /login and select ${providerLabel}.`, "info");
 					return;
 				}
 				const openedPackageConfig = await this.openProviderSetup(providerKey);
@@ -6532,7 +6531,9 @@ export class ChatView {
 														? group.authSource === "environment"
 															? "Configured from environment variable"
 															: `Logout from ${group.providerLabel}`
-														: `Set up ${group.providerLabel}`;
+														: group.isDefaultOAuthProvider
+															? `Open terminal login for ${group.providerLabel} (run pi, then /login)`
+															: `Set up ${group.providerLabel}`;
 													return html`
 														<div class="model-picker-provider-row ${group.providerKey === resolvedActiveProvider ? "active" : ""} ${group.authConfigured ? "" : "unauth"}">
 															<button
@@ -6585,12 +6586,16 @@ export class ChatView {
 																		? activeProviderGroup.isDefaultOAuthProvider
 																			? "Connected, but no models are available right now. Try /reload after login changes."
 																			: "Connected, but no models are loaded for this provider. Install/enable its package in Packages, then run /reload."
-																		: "Not connected yet. Use Login to set up this provider."}
+																		: activeProviderGroup.isDefaultOAuthProvider
+																								? "Not connected yet. Click Login, then in terminal run pi and type /login."
+																								: "Not connected yet. Use Login to set up this provider."}
 																</div>
 															`
 															: html`
 																${!activeProviderGroup.authConfigured
-																	? html`<div class="model-picker-auth-hint">Not connected yet. Use Login to set up this provider.</div>`
+																	? html`<div class="model-picker-auth-hint">${activeProviderGroup.isDefaultOAuthProvider
+																							? "Not connected yet. Click Login, then in terminal run pi and type /login."
+																							: "Not connected yet. Use Login to set up this provider."}</div>`
 																	: nothing}
 																${activeProviderGroup.models.map((model) => {
 																	const nextValue = `${model.provider}::${model.id}`;

--- a/src/components/packages-view.ts
+++ b/src/components/packages-view.ts
@@ -134,6 +134,15 @@ const SMART_NOTIFY_COMMAND_NAMES = new Set(["voice-notify"]);
 const SMART_NOTIFY_PRIMARY_SOURCE = normalizeRecommendedSource("npm:pi-smart-voice-notify");
 const SMART_NOTIFY_LEGACY_SOURCE = normalizeRecommendedSource("npm:pi-desktop-notify");
 const SMART_NOTIFY_INSTALL_SOURCE = "npm:pi-smart-voice-notify";
+const BUILTIN_OAUTH_PROVIDER_IDS = new Set(["anthropic", "github-copilot", "google-gemini-cli", "google-antigravity", "openai-codex"]);
+const PROVIDER_AUTH_CLEANUP_HINTS = new Map<string, string[]>([
+	["pi-cursor-agent", ["cursor-agent"]],
+	["cursor-agent", ["cursor-agent"]],
+	["pi-kilocode", ["kilo"]],
+	["kilocode", ["kilo"]],
+	["kilo-pi-provider", ["kilo"]],
+	["pi-kilo", ["kilo"]],
+]);
 
 function defaultAutoRenameConfigDraft(): AutoRenameConfigDraft {
 	return {
@@ -3030,6 +3039,87 @@ export class PackagesView {
 		}
 	}
 
+	private inferRemovedPackageAuthProviderCandidates(source: string): string[] {
+		const normalized = normalizeRecommendedSource(source);
+		if (!normalized.startsWith("npm:")) return [];
+		const packageName = normalized.slice(4);
+		if (!packageName) return [];
+		const packageTail = packageName.split("/").filter(Boolean).pop() || packageName;
+		const candidates = new Set<string>();
+		const hinted = [...(PROVIDER_AUTH_CLEANUP_HINTS.get(packageName) ?? []), ...(PROVIDER_AUTH_CLEANUP_HINTS.get(packageTail) ?? [])];
+		for (const provider of hinted) {
+			const normalizedProvider = provider.trim().toLowerCase();
+			if (normalizedProvider) candidates.add(normalizedProvider);
+		}
+		if (packageName.includes("cursor") || packageTail.includes("cursor")) {
+			candidates.add("cursor-agent");
+		}
+		if (packageName.includes("kilo") || packageTail.includes("kilo")) {
+			candidates.add("kilo");
+		}
+		const withoutPiPrefix = packageTail.startsWith("pi-") ? packageTail.slice(3) : packageTail;
+		if (withoutPiPrefix) {
+			candidates.add(withoutPiPrefix);
+			if (withoutPiPrefix.endsWith("-provider")) {
+				candidates.add(withoutPiPrefix.slice(0, -"-provider".length));
+			}
+		}
+		return [...candidates].filter(Boolean);
+	}
+
+	private async cleanupProviderAuthForRemovedPackage(source: string): Promise<string[]> {
+		const candidates = this.inferRemovedPackageAuthProviderCandidates(source);
+		if (candidates.length === 0) return [];
+		let authProviders: Array<{ provider: string; source: string; kind: string }> = [];
+		try {
+			const status = await rpcBridge.getPiAuthStatus();
+			authProviders = Array.isArray(status?.configured_providers)
+				? status.configured_providers.map((item) => ({
+					provider: String(item.provider || "").trim().toLowerCase(),
+					source: String(item.source || "").trim().toLowerCase(),
+					kind: String(item.kind || "").trim().toLowerCase(),
+				})).filter((item) => item.provider.length > 0)
+				: [];
+		} catch {
+			return [];
+		}
+
+		const packageTokens = normalizeRecommendedSource(source)
+			.replace(/^npm:/, "")
+			.split(/[\/_-]+/)
+			.map((token) => token.trim().toLowerCase())
+			.filter((token) => token.length >= 4 && token !== "provider" && token !== "package");
+
+		const targets = new Set<string>();
+		for (const auth of authProviders) {
+			if (auth.source === "environment") continue;
+			if (auth.kind !== "oauth") continue;
+			if (BUILTIN_OAUTH_PROVIDER_IDS.has(auth.provider)) continue;
+			const directMatch = candidates.some((candidate) => auth.provider === candidate || auth.provider.includes(candidate) || candidate.includes(auth.provider));
+			const tokenMatch = packageTokens.some((token) => auth.provider.includes(token));
+			if (directMatch || tokenMatch) {
+				targets.add(auth.provider);
+			}
+		}
+
+		if (targets.size === 0) return [];
+		const removed: string[] = [];
+		for (const provider of targets) {
+			try {
+				const result = await rpcBridge.clearPiProviderAuth(provider);
+				if (result.removed) {
+					removed.push(provider);
+				}
+			} catch {
+				// best-effort cleanup
+			}
+		}
+		if (removed.length > 0) {
+			this.commandOutput = `${this.commandOutput ? `${this.commandOutput}\n` : ""}[auth-cleanup] removed oauth credentials for: ${removed.join(", ")}\n`;
+		}
+		return removed;
+	}
+
 	private async removePackage(source: string, scope: "global" | "local"): Promise<void> {
 		const trimmed = source.trim();
 		if (!trimmed) return;
@@ -3041,7 +3131,12 @@ export class PackagesView {
 			refreshOnSuccess: true,
 		});
 		if (success) {
-			this.commandStatus = `Removed: ${trimmed}`;
+			const removedProviders = await this.cleanupProviderAuthForRemovedPackage(trimmed);
+			if (removedProviders.length > 0) {
+				this.commandStatus = `Removed: ${trimmed} · Cleared auth for ${removedProviders.join(", ")}`;
+			} else {
+				this.commandStatus = `Removed: ${trimmed}`;
+			}
 		}
 	}
 

--- a/src/components/packages-view.ts
+++ b/src/components/packages-view.ts
@@ -1954,6 +1954,48 @@ export class PackagesView {
 		return false;
 	}
 
+	async openExtensionConfigByProvider(provider: string): Promise<boolean> {
+		const providerToken = normalizeCommandNameForMatch(provider);
+		if (!providerToken) return false;
+		await this.refreshPackageConfigCommands();
+
+		const tokenParts = providerToken.split(/[-_.]/).filter((part) => part.length > 1);
+		const scoreText = (value: string): number => {
+			const haystack = value.toLowerCase();
+			let score = 0;
+			if (haystack.includes(providerToken)) score += 6;
+			for (const part of tokenParts) {
+				if (haystack.includes(part)) score += 1;
+			}
+			return score;
+		};
+
+		let bestSource: string | null = null;
+		let bestScore = 0;
+		for (const item of this.getInstalledItems(false)) {
+			const normalizedSource = normalizeRecommendedSource(item.source);
+			const sourceName = normalizedSource.startsWith("npm:") ? normalizedSource.slice(4) : normalizedSource;
+			const sourceTail = sourceName.split("/").filter(Boolean).pop() || sourceName;
+			const commands = this.packageConfigCommands.get(normalizedSource) ?? [];
+			let score = 0;
+			score += scoreText(item.displayName);
+			score += scoreText(sourceName);
+			score += scoreText(sourceTail);
+			for (const command of commands) {
+				score += scoreText(command.name) * 2;
+				score += scoreText(command.description);
+			}
+			if (commands.length > 0) score += 1;
+			if (score > bestScore) {
+				bestScore = score;
+				bestSource = normalizedSource;
+			}
+		}
+
+		if (!bestSource || bestScore <= 0) return false;
+		return await this.openExtensionConfigBySource(bestSource);
+	}
+
 	private closeActivePackageConfig(): void {
 		this.activePackageConfigSource = null;
 		this.activePackageConfigLabel = "";

--- a/src/components/packages-view.ts
+++ b/src/components/packages-view.ts
@@ -4154,8 +4154,9 @@ Execute the required file creation/edits directly, then summarize exactly which 
 	}
 
 	private async uninstallExtensionItem(item: ExtensionSurfaceItem): Promise<void> {
+		if (this.runningCommand || this.runningConfigCommand) return;
+		this.closePackagesItemModal();
 		if (normalizeRecommendedSource(item.source) === DESKTOP_THEMES_PACKAGE_SOURCE) {
-			if (this.runningCommand || this.runningConfigCommand) return;
 			this.runningCommand = true;
 			this.commandStatus = "Uninstalling Pi Desktop Themes…";
 			this.render();
@@ -4635,8 +4636,8 @@ Execute the required file creation/edits directly, then summarize exactly which 
 					<button
 						class="packages-row-install add"
 						?disabled=${this.runningCommand}
-						title="Install"
-						@click=${() => void this.installExtensionItem(item)}
+						title="Open"
+						@click=${() => void this.openPackagesItemModal({ kind: "extension", item })}
 					>
 						+
 					</button>
@@ -4657,8 +4658,8 @@ Execute the required file creation/edits directly, then summarize exactly which 
 					<button
 						class="packages-row-install add"
 						?disabled=${this.runningCommand}
-						title="Install"
-						@click=${() => void this.installExtensionItem(item)}
+						title="Open"
+						@click=${() => void this.openPackagesItemModal({ kind: "extension", item })}
 					>
 						+
 					</button>
@@ -4678,8 +4679,8 @@ Execute the required file creation/edits directly, then summarize exactly which 
 					<button
 						class="packages-row-install add"
 						?disabled=${this.runningCommand}
-						title="Install"
-						@click=${() => void this.installExtensionItem(item)}
+						title="Open"
+						@click=${() => void this.openPackagesItemModal({ kind: "extension", item })}
 					>
 						+
 					</button>

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -918,7 +918,7 @@ export class SettingsPanel {
 			this.refreshDesktopStatus(),
 			this.refreshCliStatus(),
 			this.refreshThemeCatalog(),
-			this.refreshAuthStatus(),
+			this.refreshAccountStatus(),
 			this.refreshCompatibilityStatus(),
 			this.refreshScopedModels(),
 		]);
@@ -956,6 +956,10 @@ export class SettingsPanel {
 			this.authLoading = false;
 			this.render();
 		}
+	}
+
+	private async refreshAccountStatus(): Promise<void> {
+		await this.refreshAuthStatus();
 	}
 
 	private async refreshDesktopStatus(): Promise<void> {
@@ -1881,61 +1885,67 @@ export class SettingsPanel {
 		hasProjectContext: boolean,
 		authProviders: PiAuthStatus["configured_providers"],
 	): TemplateResult {
-		if (!runtimeControlsEnabled) {
-			const runtimeMessage = hasProjectContext
-				? "Runtime is still starting for this project. Account diagnostics unlock when runtime is ready."
-				: "Open a project to inspect provider auth and runtime-linked account details.";
-			return html`
-				<div class="settings-view-grid">
-					<section class="settings-group settings-group-full">
-						<div class="settings-section">
-							<div class="settings-section-title">Account</div>
-							<div class="settings-desc">${runtimeMessage}</div>
-						</div>
-					</section>
-				</div>
-			`;
+		const runtimeMessage = hasProjectContext
+			? "Runtime is still starting for this project. Account diagnostics unlock when runtime is ready."
+			: "Open a project to inspect account diagnostics.";
+
+		const uniqueAuthProviders = new Map<string, PiAuthStatus["configured_providers"][number]>();
+		for (const entry of authProviders) {
+			const key = (entry?.provider ?? "").trim().toLowerCase();
+			if (!key) continue;
+			const existing = uniqueAuthProviders.get(key);
+			const score = entry.source === "environment" ? 2 : 1;
+			const existingScore = existing ? (existing.source === "environment" ? 2 : 1) : -1;
+			if (!existing || score >= existingScore) {
+				uniqueAuthProviders.set(key, entry);
+			}
 		}
+		const connectedProviders = Array.from(uniqueAuthProviders.values()).sort((a, b) => a.provider.localeCompare(b.provider));
 
 		return html`
 			<div class="settings-view-grid">
 				<section class="settings-group">
 					<div class="settings-section">
-						<div class="settings-section-title">Account</div>
-						${this.authLoading
-							? html`<div class="settings-desc">Checking account status…</div>`
-							: html`
-								<div class="settings-desc">
-									${authProviders.length > 0 ? `Connected providers: ${authProviders.length}` : "No provider connected yet."}
-								</div>
-								<div class="settings-actions">
-									<button class="ghost-btn" @click=${() => this.refreshAuthStatus()}>Refresh account status</button>
-								</div>
-								${authProviders.length > 0
-									? html`
-										<div class="account-chips">
-											${authProviders.map((p) => html`<span class="account-chip">${p.provider} · ${p.source === "environment" ? "env" : p.kind}</span>`) }
-										</div>
-									`
-									: null}
-								<div class="settings-desc">Tip: run <code>/login</code> in terminal once, then restart desktop.</div>
-								${this.authStatus?.auth_file
-									? html`
-										<details class="settings-advanced">
-											<summary>Advanced account details</summary>
-											<div class="settings-desc">Auth file: <code>${this.authStatus.auth_file}</code></div>
-										</details>
-									`
-									: null}
-							`}
+						<div class="settings-section-title">Account (work in progress)</div>
+						<div class="settings-desc">This section is being redesigned for real account features instead of model/provider login controls.</div>
+						<div class="settings-desc">Planned direction: GitHub/Google sign-in, profile/avatar in the app sidebar, and optional cloud sync for preferences.</div>
+						<div class="settings-desc">Model/provider login/logout is handled from the model picker.</div>
+						<div class="settings-desc">Package install + provider setup flows stay in <strong>Packages</strong>.</div>
 					</div>
 				</section>
 
 				<section class="settings-group">
 					<div class="settings-section">
-						<div class="settings-section-title">Package configuration</div>
-						<div class="settings-desc">Package-specific settings are managed in <strong>Packages</strong> (gear icon on installed packages).</div>
-						<div class="settings-desc">Desktop stays capability-driven: packages can expose config commands, and those run via the normal chat/runtime flow.</div>
+						<div class="settings-section-title">Current account diagnostics</div>
+						${!runtimeControlsEnabled
+							? html`<div class="settings-desc">${runtimeMessage}</div>`
+							: this.authLoading
+								? html`<div class="settings-desc">Checking account diagnostics…</div>`
+								: html`
+									<div class="settings-desc">
+										${connectedProviders.length > 0
+											? `Connected providers detected: ${connectedProviders.length}`
+											: "No provider credentials detected."}
+									</div>
+									<div class="settings-actions">
+										<button class="ghost-btn" @click=${() => this.refreshAccountStatus()}>Refresh diagnostics</button>
+									</div>
+									${connectedProviders.length > 0
+										? html`
+											<div class="account-chips">
+												${connectedProviders.map((provider) => html`<span class="account-chip">${provider.provider} · ${provider.source === "environment" ? "env" : provider.kind}</span>`) }
+											</div>
+										`
+										: null}
+									${this.authStatus?.auth_file
+										? html`
+											<details class="settings-advanced">
+												<summary>Advanced details</summary>
+												<div class="settings-desc">Auth file: <code>${this.authStatus.auth_file}</code></div>
+											</details>
+										`
+										: null}
+								`}
 					</div>
 				</section>
 			</div>

--- a/src/components/terminal-panel.ts
+++ b/src/components/terminal-panel.ts
@@ -480,14 +480,14 @@ export class TerminalPanel {
 			if (loginMatch) {
 				const requestedProvider = (loginMatch[1] ?? "").trim().toLowerCase();
 				const infoText = requestedProvider
-					? `Running Pi in interactive mode. Type /login and select ${requestedProvider} in the provider picker.`
-					: "Running Pi in interactive mode. Type /login in the terminal picker.";
+					? `Running Pi in interactive mode. Starting /login automatically; then select ${requestedProvider} in the provider picker.`
+					: "Running Pi in interactive mode. Starting /login automatically.";
 				return {
 					shellCommand: piCommand,
 					infoText,
 					interactive: true,
-					initialInput: [],
-					initialInputStartDelayMs: 0,
+					initialInput: ["/login\r"],
+					initialInputStartDelayMs: 1000,
 					initialInputInterChunkDelayMs: 0,
 				};
 			}

--- a/src/components/terminal-panel.ts
+++ b/src/components/terminal-panel.ts
@@ -223,7 +223,7 @@ export class TerminalPanel {
 				domEvent.preventDefault();
 				if (this.runningInteractive && this.runningChild) {
 					if (domEvent.key === "Enter") {
-						this.writeToRunningChild("\n");
+						this.writeToRunningChild("\r");
 						return;
 					}
 					if (domEvent.key === "Backspace") {
@@ -480,15 +480,31 @@ export class TerminalPanel {
 			if (loginMatch) {
 				const requestedProvider = (loginMatch[1] ?? "").trim().toLowerCase();
 				const infoText = requestedProvider
-					? `Running Pi OAuth helper. Use /login and select ${requestedProvider} in the provider picker.`
-					: "Running Pi OAuth helper. Use /login in the terminal picker.";
+					? `Running Pi in interactive mode. Type /login and select ${requestedProvider} in the provider picker.`
+					: "Running Pi in interactive mode. Type /login in the terminal picker.";
 				return {
 					shellCommand: piCommand,
 					infoText,
 					interactive: true,
-					initialInput: ["/login\n"],
-					initialInputStartDelayMs: 1000,
-					initialInputInterChunkDelayMs: 220,
+					initialInput: [],
+					initialInputStartDelayMs: 0,
+					initialInputInterChunkDelayMs: 0,
+				};
+			}
+
+			const logoutMatch = trimmed.match(/^pi\s+logout(?:\s+([a-z0-9._-]+))?$/i);
+			if (logoutMatch) {
+				const requestedProvider = (logoutMatch[1] ?? "").trim().toLowerCase();
+				const infoText = requestedProvider
+					? `Running Pi in interactive mode. Type /logout and select ${requestedProvider} in the provider picker.`
+					: "Running Pi in interactive mode. Type /logout in the terminal picker.";
+				return {
+					shellCommand: piCommand,
+					infoText,
+					interactive: true,
+					initialInput: [],
+					initialInputStartDelayMs: 0,
+					initialInputInterChunkDelayMs: 0,
 				};
 			}
 		}

--- a/src/components/terminal-panel.ts
+++ b/src/components/terminal-panel.ts
@@ -428,6 +428,29 @@ export class TerminalPanel {
 		}
 	}
 
+	private isSpawnScopeError(error: unknown): boolean {
+		const message = normalizeText(error).toLowerCase();
+		return message.includes("allow-spawn") || message.includes("configured shell scope") || message.includes("program not allowed");
+	}
+
+	private async executeShellViaExecute(profile: ShellProfile, command: string, streamOutput: boolean): Promise<TerminalExecResult> {
+		const output = await Command.create(profile.name, this.buildShellArgs(profile, command), {
+			cwd: this.cwd || undefined,
+		}).execute();
+		const stdout = normalizeText(output.stdout);
+		const stderr = normalizeText(output.stderr);
+		if (streamOutput) {
+			if (stdout) this.writeStdOut(stdout);
+			if (stderr) this.writeStdErr(stderr);
+		}
+		return {
+			code: output.code,
+			signal: output.signal,
+			stdout,
+			stderr,
+		};
+	}
+
 	private async executeShell(command: string, options: { streamOutput?: boolean } = {}): Promise<TerminalExecResult> {
 		const profile = await this.ensureShellProfile();
 		const streamOutput = options.streamOutput !== false;
@@ -440,6 +463,7 @@ export class TerminalPanel {
 			let stderr = "";
 			let settled = false;
 			let spawnedChild: Child | null = null;
+			let fallbackStarted = false;
 
 			const cleanup = () => {
 				shellCommand.stdout.off("data", onStdout);
@@ -465,6 +489,13 @@ export class TerminalPanel {
 				reject(error instanceof Error ? error : new Error(normalizeText(error)));
 			};
 
+			const attemptExecuteFallback = () => {
+				if (fallbackStarted) return;
+				fallbackStarted = true;
+				this.writeInfo("Spawn unavailable; falling back to execute mode.");
+				void this.executeShellViaExecute(profile, command, streamOutput).then(settleWithResult).catch(settleWithError);
+			};
+
 			const onStdout = (payload: string) => {
 				const text = normalizeText(payload);
 				if (!text) return;
@@ -486,6 +517,10 @@ export class TerminalPanel {
 				});
 			};
 			const onError = (message: string) => {
+				if (!spawnedChild && this.isSpawnScopeError(message)) {
+					attemptExecuteFallback();
+					return;
+				}
 				settleWithError(new Error(message || "Shell command failed"));
 			};
 
@@ -501,6 +536,10 @@ export class TerminalPanel {
 					this.runningChild = child;
 				})
 				.catch((error) => {
+					if (this.isSpawnScopeError(error)) {
+						attemptExecuteFallback();
+						return;
+					}
 					settleWithError(error);
 				});
 		});

--- a/src/components/terminal-panel.ts
+++ b/src/components/terminal-panel.ts
@@ -132,6 +132,7 @@ export class TerminalPanel {
 	private runningInteractive = false;
 	private suppressPromptOnce = false;
 	private queuedCommands: string[] = [];
+	private clipboardEventHandlersInstalled = false;
 
 	constructor(container: HTMLElement) {
 		this.container = container;
@@ -210,6 +211,7 @@ export class TerminalPanel {
 			this.xterm.open(viewport);
 			this.fitAddon.fit();
 			this.installKeyboardBindings();
+			this.installClipboardEventHandlers(this.container);
 			this.printPrompt();
 		}
 
@@ -288,6 +290,23 @@ export class TerminalPanel {
 		}
 	}
 
+	private installClipboardEventHandlers(target: HTMLElement): void {
+		if (this.clipboardEventHandlersInstalled) return;
+		target.addEventListener("paste", (event: ClipboardEvent) => {
+			const text = event.clipboardData?.getData("text") ?? "";
+			if (!text) return;
+			event.preventDefault();
+			this.handlePastedText(text);
+		});
+		target.addEventListener("copy", (event: ClipboardEvent) => {
+			const selection = this.xterm?.getSelection() ?? "";
+			if (!selection) return;
+			event.clipboardData?.setData("text/plain", selection);
+			event.preventDefault();
+		});
+		this.clipboardEventHandlersInstalled = true;
+	}
+
 	private installKeyboardBindings(): void {
 		if (!this.xterm) return;
 		this.xterm.onKey(({ key, domEvent }) => {
@@ -298,6 +317,10 @@ export class TerminalPanel {
 			}
 
 			if (this.isPasteShortcut(domEvent)) {
+				if (this.isMacPlatform() && domEvent.metaKey) {
+					void this.pasteFromClipboard();
+					return;
+				}
 				domEvent.preventDefault();
 				void this.pasteFromClipboard();
 				return;
@@ -471,8 +494,7 @@ export class TerminalPanel {
 		if (!this.xterm) return;
 		this.commandHistoryIndex = -1;
 		this.commandHistoryDraft = "";
-		const pathLabel = compactPath(this.cwd);
-		this.xterm.write(`\x1b[34m${pathLabel}\x1b[0m $ `);
+		this.xterm.write("\x1b[34m$\x1b[0m ");
 		this.scrollTerminalToBottom();
 	}
 

--- a/src/components/terminal-panel.ts
+++ b/src/components/terminal-panel.ts
@@ -31,6 +31,12 @@ interface TerminalCommandResolution {
 	initialInputInterChunkDelayMs: number;
 }
 
+interface TerminalCommandCompleteEvent {
+	command: string;
+	interactive: boolean;
+	result: TerminalExecResult | null;
+}
+
 function normalizeText(value: unknown): string {
 	if (typeof value === "string") return value;
 	if (value == null) return "";
@@ -109,6 +115,7 @@ export class TerminalPanel {
 	private cwd: string | null = null;
 	private running = false;
 	private onRequestClose: (() => void) | null = null;
+	private onCommandComplete: ((event: TerminalCommandCompleteEvent) => void | Promise<void>) | null = null;
 
 	private xterm: Terminal | null = null;
 	private fitAddon: FitAddon | null = null;
@@ -133,6 +140,10 @@ export class TerminalPanel {
 
 	setOnRequestClose(cb: () => void): void {
 		this.onRequestClose = cb;
+	}
+
+	setOnCommandComplete(cb: (event: TerminalCommandCompleteEvent) => void | Promise<void>): void {
+		this.onCommandComplete = cb;
 	}
 
 	setProjectPath(path: string | null): void {
@@ -186,6 +197,8 @@ export class TerminalPanel {
 			this.fitAddon = new FitAddon();
 			this.xterm = new Terminal({
 				cursorBlink: true,
+				cursorStyle: "bar",
+				cursorWidth: 2,
 				convertEol: true,
 				scrollback: 6000,
 				fontSize: 12,
@@ -208,9 +221,94 @@ export class TerminalPanel {
 		}
 	}
 
+	private isMacPlatform(): boolean {
+		return navigator.platform.toLowerCase().includes("mac");
+	}
+
+	private isCopyShortcut(event: KeyboardEvent): boolean {
+		const key = event.key.toLowerCase();
+		if (this.isMacPlatform()) {
+			return event.metaKey && !event.ctrlKey && !event.altKey && key === "c";
+		}
+		return event.ctrlKey && event.shiftKey && !event.metaKey && key === "c";
+	}
+
+	private isPasteShortcut(event: KeyboardEvent): boolean {
+		const key = event.key.toLowerCase();
+		if (this.isMacPlatform()) {
+			return event.metaKey && !event.ctrlKey && !event.altKey && key === "v";
+		}
+		if (event.ctrlKey && event.shiftKey && !event.metaKey && key === "v") return true;
+		return event.shiftKey && key === "insert";
+	}
+
+	private isSelectAllShortcut(event: KeyboardEvent): boolean {
+		const key = event.key.toLowerCase();
+		if (this.isMacPlatform()) {
+			return event.metaKey && !event.ctrlKey && !event.altKey && key === "a";
+		}
+		return event.ctrlKey && event.shiftKey && !event.metaKey && key === "a";
+	}
+
+	private async copySelectionToClipboard(): Promise<void> {
+		const selection = this.xterm?.getSelection() ?? "";
+		if (!selection) return;
+		try {
+			await navigator.clipboard.writeText(selection);
+		} catch {
+			// Ignore clipboard failures in restricted environments.
+		}
+	}
+
+	private handlePastedText(rawText: string): void {
+		if (!rawText) return;
+		const normalized = rawText.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+		if (!normalized) return;
+
+		if (this.running) {
+			if (this.runningInteractive && this.runningChild) {
+				this.writeToRunningChild(normalized.replace(/\n/g, "\r"));
+			}
+			return;
+		}
+
+		const inline = normalized.replace(/\n+/g, " ");
+		if (!inline) return;
+		this.inputBuffer += inline;
+		this.xterm?.write(inline);
+		this.scrollTerminalToBottom();
+	}
+
+	private async pasteFromClipboard(): Promise<void> {
+		try {
+			const text = await navigator.clipboard.readText();
+			this.handlePastedText(text);
+		} catch {
+			// Ignore clipboard failures in restricted environments.
+		}
+	}
+
 	private installKeyboardBindings(): void {
 		if (!this.xterm) return;
 		this.xterm.onKey(({ key, domEvent }) => {
+			if (this.isCopyShortcut(domEvent)) {
+				domEvent.preventDefault();
+				void this.copySelectionToClipboard();
+				return;
+			}
+
+			if (this.isPasteShortcut(domEvent)) {
+				domEvent.preventDefault();
+				void this.pasteFromClipboard();
+				return;
+			}
+
+			if (this.isSelectAllShortcut(domEvent)) {
+				domEvent.preventDefault();
+				this.xterm?.selectAll();
+				return;
+			}
+
 			if (domEvent.ctrlKey && !domEvent.metaKey && domEvent.key.toLowerCase() === "c") {
 				domEvent.preventDefault();
 				if (this.running) {
@@ -803,6 +901,7 @@ export class TerminalPanel {
 		this.running = true;
 		this.runningInteractive = resolved.interactive;
 		this.render();
+		let completedResult: TerminalExecResult | null = null;
 		try {
 			if (this.isCdCommand(command)) {
 				await this.executeCdCommand(command);
@@ -815,6 +914,7 @@ export class TerminalPanel {
 					rawOutput: resolved.interactive,
 					allowExecuteFallback: !resolved.interactive,
 				});
+				completedResult = result;
 				if (typeof result.code === "number" && result.code !== 0 && !result.stderr.trim()) {
 					this.writeStdErr(`exit ${result.code}`);
 				}
@@ -829,6 +929,17 @@ export class TerminalPanel {
 			this.suppressPromptOnce = false;
 			if (!suppressPrompt) {
 				this.printPrompt();
+			}
+			if (!this.isCdCommand(command) && this.onCommandComplete) {
+				void Promise.resolve(
+					this.onCommandComplete({
+						command,
+						interactive: resolved.interactive,
+						result: completedResult,
+					}),
+				).catch(() => {
+					// Ignore command completion callback failures.
+				});
 			}
 			const next = this.queuedCommands.shift();
 			if (next) {

--- a/src/components/terminal-panel.ts
+++ b/src/components/terminal-panel.ts
@@ -163,13 +163,17 @@ export class TerminalPanel {
 	private applyTheme(): void {
 		if (!this.xterm) return;
 		const styles = getComputedStyle(document.documentElement);
-		const background = styles.getPropertyValue("--bg").trim() || "#0f1115";
+		const panelRoot = this.container.querySelector<HTMLElement>(".terminal-panel-root");
+		const panelStyles = panelRoot ? getComputedStyle(panelRoot) : styles;
+		const background = panelStyles.getPropertyValue("--terminal-panel-bg").trim() || styles.getPropertyValue("--bg").trim() || "#0f1115";
 		const foreground = styles.getPropertyValue("--text").trim() || "#d7dce2";
 		const muted = styles.getPropertyValue("--muted").trim() || "#95a1b2";
+		const accent = styles.getPropertyValue("--accent").trim() || foreground;
 		this.xterm.options.theme = {
 			background,
 			foreground,
-			cursor: foreground,
+			cursor: accent,
+			cursorAccent: background,
 			selectionBackground: muted,
 		};
 	}
@@ -453,18 +457,27 @@ export class TerminalPanel {
 		}
 	}
 
-	private buildPiInteractiveBridgeCommand(): string | null {
+	private getCurrentTerminalDimensions(): { cols: number; rows: number } {
+		const cols = Math.max(60, Math.floor(this.xterm?.cols ?? 120));
+		const rows = Math.max(18, Math.floor(this.xterm?.rows ?? 36));
+		return { cols, rows };
+	}
+
+	private buildPiInteractiveBridgeCommand(dimensions?: { cols: number; rows: number }): string | null {
 		const platform = navigator.platform.toLowerCase();
 		if (platform.includes("win")) return null;
+		const cols = Math.max(60, Math.floor(dimensions?.cols ?? 120));
+		const rows = Math.max(18, Math.floor(dimensions?.rows ?? 36));
+		const boot = `stty cols ${cols} rows ${rows} 2>/dev/null; exec pi`;
 		if (platform.includes("mac")) {
-			return "script -q /dev/null pi";
+			return `script -q /dev/null /bin/sh -lc ${shellSingleQuote(boot)}`;
 		}
-		return `script -q -c ${shellSingleQuote("pi")} /dev/null`;
+		return `script -q -c ${shellSingleQuote(boot)} /dev/null`;
 	}
 
 	private resolveSpecialShellCommand(command: string): TerminalCommandResolution {
 		const trimmed = command.trim();
-		const piCommand = this.buildPiInteractiveBridgeCommand();
+		const piCommand = this.buildPiInteractiveBridgeCommand(this.getCurrentTerminalDimensions());
 		if (piCommand) {
 			if (/^pi$/i.test(trimmed)) {
 				return {
@@ -781,6 +794,7 @@ export class TerminalPanel {
 			return;
 		}
 
+		this.fitAddon?.fit();
 		const resolved = this.resolveSpecialShellCommand(command);
 		if (resolved.infoText) {
 			this.writeInfo(resolved.infoText);

--- a/src/components/terminal-panel.ts
+++ b/src/components/terminal-panel.ts
@@ -81,6 +81,14 @@ function shellSingleQuote(value: string): string {
 	return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
+const BUILTIN_OAUTH_PROVIDER_ORDER = [
+	"anthropic",
+	"github-copilot",
+	"google-gemini-cli",
+	"google-antigravity",
+	"openai-codex",
+] as const;
+
 export class TerminalPanel {
 	private container: HTMLElement;
 	private cwd: string | null = null;
@@ -99,6 +107,7 @@ export class TerminalPanel {
 	private shellProfile: ShellProfile | null = null;
 	private resolvingShellProfile: Promise<ShellProfile> | null = null;
 	private runningChild: Child | null = null;
+	private runningInteractive = false;
 	private queuedCommands: string[] = [];
 
 	constructor(container: HTMLElement) {
@@ -196,6 +205,39 @@ export class TerminalPanel {
 
 			if (this.running) {
 				domEvent.preventDefault();
+				if (this.runningInteractive && this.runningChild) {
+					if (domEvent.key === "Enter") {
+						this.writeToRunningChild("\n");
+						return;
+					}
+					if (domEvent.key === "Backspace") {
+						this.writeToRunningChild("\x7f");
+						return;
+					}
+					if (domEvent.key === "ArrowUp") {
+						this.writeToRunningChild("\x1b[A");
+						return;
+					}
+					if (domEvent.key === "ArrowDown") {
+						this.writeToRunningChild("\x1b[B");
+						return;
+					}
+					if (domEvent.key === "ArrowLeft") {
+						this.writeToRunningChild("\x1b[D");
+						return;
+					}
+					if (domEvent.key === "ArrowRight") {
+						this.writeToRunningChild("\x1b[C");
+						return;
+					}
+					if (domEvent.key === "Tab") {
+						this.writeToRunningChild("\t");
+						return;
+					}
+					if (isPrintableKey(domEvent, key)) {
+						this.writeToRunningChild(key);
+					}
+				}
 				return;
 			}
 
@@ -293,6 +335,14 @@ export class TerminalPanel {
 		this.replaceCurrentInput("");
 	}
 
+	private writeToRunningChild(value: string): void {
+		const child = this.runningChild;
+		if (!child || !value) return;
+		void child.write(value).catch(() => {
+			// Ignore transient stdin write failures while process is exiting.
+		});
+	}
+
 	private scrollTerminalToBottom(): void {
 		requestAnimationFrame(() => {
 			this.xterm?.scrollToBottom();
@@ -369,30 +419,59 @@ export class TerminalPanel {
 		}
 	}
 
-	private buildPiLoginBridgeCommand(rawProviderArg: string): string | null {
-		const provider = rawProviderArg.trim().toLowerCase();
-		const slashCommand = provider ? `/login ${provider}` : "/login";
-		const scriptedInput = shellSingleQuote(`${slashCommand}\n\n`);
+	private buildPiInteractiveBridgeCommand(): string | null {
 		const platform = navigator.platform.toLowerCase();
 		if (platform.includes("win")) return null;
 		if (platform.includes("mac")) {
-			return `printf %s ${scriptedInput} | script -q /dev/null pi`;
+			return "script -q /dev/null pi";
 		}
-		return `printf %s ${scriptedInput} | script -q -c ${shellSingleQuote("pi")} /dev/null`;
+		return `script -q -c ${shellSingleQuote("pi")} /dev/null`;
 	}
 
-	private resolveSpecialShellCommand(command: string): { shellCommand: string; infoText: string | null } {
-		const loginMatch = command.match(/^pi\s+login(?:\s+([a-z0-9._-]+))?$/i);
-		if (loginMatch) {
-			const bridgeCommand = this.buildPiLoginBridgeCommand(loginMatch[1] ?? "");
-			if (bridgeCommand) {
+	private resolveSpecialShellCommand(command: string): {
+		shellCommand: string;
+		infoText: string | null;
+		interactive: boolean;
+		initialInput: string[];
+	} {
+		const trimmed = command.trim();
+		const piCommand = this.buildPiInteractiveBridgeCommand();
+		if (piCommand) {
+			if (/^pi$/i.test(trimmed)) {
 				return {
-					shellCommand: bridgeCommand,
-					infoText: "Running Pi OAuth helper (pi + /login) in pseudo-terminal mode…",
+					shellCommand: piCommand,
+					infoText: "Running pi in interactive terminal mode.",
+					interactive: true,
+					initialInput: [],
+				};
+			}
+			const loginMatch = trimmed.match(/^pi\s+login(?:\s+([a-z0-9._-]+))?$/i);
+			if (loginMatch) {
+				const requestedProvider = (loginMatch[1] ?? "").trim().toLowerCase();
+				const infoText = requestedProvider
+					? `Running Pi OAuth helper. Select ${requestedProvider} in the /login provider picker.`
+					: "Running Pi OAuth helper. Use /login in the terminal picker.";
+				const initialInput: string[] = ["/login\n"];
+				const providerIndex = BUILTIN_OAUTH_PROVIDER_ORDER.indexOf(requestedProvider as (typeof BUILTIN_OAUTH_PROVIDER_ORDER)[number]);
+				if (providerIndex >= 0) {
+					const down = "\x1b[B".repeat(providerIndex);
+					if (down) initialInput.push(down);
+					initialInput.push("\n");
+				}
+				return {
+					shellCommand: piCommand,
+					infoText,
+					interactive: true,
+					initialInput,
 				};
 			}
 		}
-		return { shellCommand: command, infoText: null };
+		return {
+			shellCommand: command,
+			infoText: null,
+			interactive: false,
+			initialInput: [],
+		};
 	}
 
 	private async ensureShellProfile(): Promise<ShellProfile> {
@@ -451,9 +530,13 @@ export class TerminalPanel {
 		};
 	}
 
-	private async executeShell(command: string, options: { streamOutput?: boolean } = {}): Promise<TerminalExecResult> {
+	private async executeShell(
+		command: string,
+		options: { streamOutput?: boolean; initialInput?: string[] } = {},
+	): Promise<TerminalExecResult> {
 		const profile = await this.ensureShellProfile();
 		const streamOutput = options.streamOutput !== false;
+		const initialInput = Array.isArray(options.initialInput) ? options.initialInput : [];
 		const shellCommand = Command.create(profile.name, this.buildShellArgs(profile, command), {
 			cwd: this.cwd || undefined,
 		});
@@ -496,6 +579,23 @@ export class TerminalPanel {
 				void this.executeShellViaExecute(profile, command, streamOutput).then(settleWithResult).catch(settleWithError);
 			};
 
+			const sendInitialInput = async (child: Child): Promise<void> => {
+				if (initialInput.length === 0) return;
+				for (let i = 0; i < initialInput.length; i += 1) {
+					const chunk = initialInput[i] ?? "";
+					if (!chunk) continue;
+					try {
+						await child.write(chunk);
+					} catch (err) {
+						this.writeStdErr(err instanceof Error ? err.message : String(err));
+						return;
+					}
+					if (i < initialInput.length - 1) {
+						await new Promise((resolve) => setTimeout(resolve, 140));
+					}
+				}
+			};
+
 			const onStdout = (payload: string) => {
 				const text = normalizeText(payload);
 				if (!text) return;
@@ -534,6 +634,7 @@ export class TerminalPanel {
 				.then((child) => {
 					spawnedChild = child;
 					this.runningChild = child;
+					void sendInitialInput(child);
 				})
 				.catch((error) => {
 					if (this.isSpawnScopeError(error)) {
@@ -597,12 +698,16 @@ export class TerminalPanel {
 		}
 
 		this.running = true;
+		this.runningInteractive = resolved.interactive;
 		this.render();
 		try {
 			if (this.isCdCommand(command)) {
 				await this.executeCdCommand(command);
 			} else {
-				const result = await this.executeShell(resolved.shellCommand, { streamOutput: true });
+				const result = await this.executeShell(resolved.shellCommand, {
+					streamOutput: true,
+					initialInput: resolved.initialInput,
+				});
 				if (typeof result.code === "number" && result.code !== 0 && !result.stderr.trim()) {
 					this.writeStdErr(`exit ${result.code}`);
 				}
@@ -611,6 +716,7 @@ export class TerminalPanel {
 			this.writeStdErr(err instanceof Error ? err.message : String(err));
 		} finally {
 			this.running = false;
+			this.runningInteractive = false;
 			this.render();
 			this.printPrompt();
 			const next = this.queuedCommands.shift();

--- a/src/components/terminal-panel.ts
+++ b/src/components/terminal-panel.ts
@@ -22,6 +22,15 @@ interface TerminalExecResult {
 	stderr: string;
 }
 
+interface TerminalCommandResolution {
+	shellCommand: string;
+	infoText: string | null;
+	interactive: boolean;
+	initialInput: string[];
+	initialInputStartDelayMs: number;
+	initialInputInterChunkDelayMs: number;
+}
+
 function normalizeText(value: unknown): string {
 	if (typeof value === "string") return value;
 	if (value == null) return "";
@@ -81,14 +90,6 @@ function shellSingleQuote(value: string): string {
 	return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
-const BUILTIN_OAUTH_PROVIDER_ORDER = [
-	"anthropic",
-	"github-copilot",
-	"google-gemini-cli",
-	"google-antigravity",
-	"openai-codex",
-] as const;
-
 export class TerminalPanel {
 	private container: HTMLElement;
 	private cwd: string | null = null;
@@ -108,6 +109,7 @@ export class TerminalPanel {
 	private resolvingShellProfile: Promise<ShellProfile> | null = null;
 	private runningChild: Child | null = null;
 	private runningInteractive = false;
+	private suppressPromptOnce = false;
 	private queuedCommands: string[] = [];
 
 	constructor(container: HTMLElement) {
@@ -166,7 +168,7 @@ export class TerminalPanel {
 			this.fitAddon = new FitAddon();
 			this.xterm = new Terminal({
 				cursorBlink: true,
-				convertEol: true,
+				convertEol: false,
 				scrollback: 6000,
 				fontSize: 12,
 				lineHeight: 1.35,
@@ -374,6 +376,21 @@ export class TerminalPanel {
 		this.scrollTerminalToBottom();
 	}
 
+	private writeRawOutput(text: string): void {
+		if (!this.xterm || !text) return;
+		this.xterm.write(text);
+		this.scrollTerminalToBottom();
+	}
+
+	private decodeOutputChunk(payload: string | Uint8Array, decoder: TextDecoder | null): string {
+		if (typeof payload === "string") return payload;
+		if (!(payload instanceof Uint8Array)) return normalizeText(payload);
+		if (!decoder) {
+			return new TextDecoder().decode(payload);
+		}
+		return decoder.decode(payload, { stream: true });
+	}
+
 	private writeStdOut(text: string): void {
 		if (!this.xterm) return;
 		if (!text) return;
@@ -428,12 +445,7 @@ export class TerminalPanel {
 		return `script -q -c ${shellSingleQuote("pi")} /dev/null`;
 	}
 
-	private resolveSpecialShellCommand(command: string): {
-		shellCommand: string;
-		infoText: string | null;
-		interactive: boolean;
-		initialInput: string[];
-	} {
+	private resolveSpecialShellCommand(command: string): TerminalCommandResolution {
 		const trimmed = command.trim();
 		const piCommand = this.buildPiInteractiveBridgeCommand();
 		if (piCommand) {
@@ -443,26 +455,23 @@ export class TerminalPanel {
 					infoText: "Running pi in interactive terminal mode.",
 					interactive: true,
 					initialInput: [],
+					initialInputStartDelayMs: 0,
+					initialInputInterChunkDelayMs: 0,
 				};
 			}
 			const loginMatch = trimmed.match(/^pi\s+login(?:\s+([a-z0-9._-]+))?$/i);
 			if (loginMatch) {
 				const requestedProvider = (loginMatch[1] ?? "").trim().toLowerCase();
 				const infoText = requestedProvider
-					? `Running Pi OAuth helper. Select ${requestedProvider} in the /login provider picker.`
+					? `Running Pi OAuth helper. Use /login and select ${requestedProvider} in the provider picker.`
 					: "Running Pi OAuth helper. Use /login in the terminal picker.";
-				const initialInput: string[] = ["/login\n"];
-				const providerIndex = BUILTIN_OAUTH_PROVIDER_ORDER.indexOf(requestedProvider as (typeof BUILTIN_OAUTH_PROVIDER_ORDER)[number]);
-				if (providerIndex >= 0) {
-					const down = "\x1b[B".repeat(providerIndex);
-					if (down) initialInput.push(down);
-					initialInput.push("\n");
-				}
 				return {
 					shellCommand: piCommand,
 					infoText,
 					interactive: true,
-					initialInput,
+					initialInput: ["/login\n"],
+					initialInputStartDelayMs: 1000,
+					initialInputInterChunkDelayMs: 220,
 				};
 			}
 		}
@@ -471,6 +480,8 @@ export class TerminalPanel {
 			infoText: null,
 			interactive: false,
 			initialInput: [],
+			initialInputStartDelayMs: 0,
+			initialInputInterChunkDelayMs: 0,
 		};
 	}
 
@@ -532,14 +543,31 @@ export class TerminalPanel {
 
 	private async executeShell(
 		command: string,
-		options: { streamOutput?: boolean; initialInput?: string[] } = {},
+		options: {
+			streamOutput?: boolean;
+			initialInput?: string[];
+			initialInputStartDelayMs?: number;
+			initialInputInterChunkDelayMs?: number;
+			rawOutput?: boolean;
+			allowExecuteFallback?: boolean;
+		} = {},
 	): Promise<TerminalExecResult> {
 		const profile = await this.ensureShellProfile();
 		const streamOutput = options.streamOutput !== false;
 		const initialInput = Array.isArray(options.initialInput) ? options.initialInput : [];
-		const shellCommand = Command.create(profile.name, this.buildShellArgs(profile, command), {
-			cwd: this.cwd || undefined,
-		});
+		const outputRaw = options.rawOutput === true;
+		const allowExecuteFallback = options.allowExecuteFallback ?? !outputRaw;
+		const initialInputStartDelayMs = Math.max(0, Number(options.initialInputStartDelayMs ?? 0));
+		const initialInputInterChunkDelayMs = Math.max(0, Number(options.initialInputInterChunkDelayMs ?? 140));
+		const shellArgs = this.buildShellArgs(profile, command);
+		const shellCommand = outputRaw
+			? Command.create(profile.name, shellArgs, {
+					cwd: this.cwd || undefined,
+					encoding: "raw",
+				})
+			: Command.create(profile.name, shellArgs, {
+					cwd: this.cwd || undefined,
+				});
 
 		return await new Promise<TerminalExecResult>((resolve, reject) => {
 			let stdout = "";
@@ -575,12 +603,19 @@ export class TerminalPanel {
 			const attemptExecuteFallback = () => {
 				if (fallbackStarted) return;
 				fallbackStarted = true;
+				if (!allowExecuteFallback) {
+					settleWithError(new Error("Spawn unavailable for interactive terminal command. Restart app and verify shell capabilities."));
+					return;
+				}
 				this.writeInfo("Spawn unavailable; falling back to execute mode.");
 				void this.executeShellViaExecute(profile, command, streamOutput).then(settleWithResult).catch(settleWithError);
 			};
 
 			const sendInitialInput = async (child: Child): Promise<void> => {
 				if (initialInput.length === 0) return;
+				if (initialInputStartDelayMs > 0) {
+					await new Promise((resolve) => setTimeout(resolve, initialInputStartDelayMs));
+				}
 				for (let i = 0; i < initialInput.length; i += 1) {
 					const chunk = initialInput[i] ?? "";
 					if (!chunk) continue;
@@ -590,25 +625,46 @@ export class TerminalPanel {
 						this.writeStdErr(err instanceof Error ? err.message : String(err));
 						return;
 					}
-					if (i < initialInput.length - 1) {
-						await new Promise((resolve) => setTimeout(resolve, 140));
+					if (i < initialInput.length - 1 && initialInputInterChunkDelayMs > 0) {
+						await new Promise((resolve) => setTimeout(resolve, initialInputInterChunkDelayMs));
 					}
 				}
 			};
 
-			const onStdout = (payload: string) => {
-				const text = normalizeText(payload);
+			const stdoutDecoder = outputRaw ? new TextDecoder() : null;
+			const stderrDecoder = outputRaw ? new TextDecoder() : null;
+
+			const onStdout = (payload: string | Uint8Array) => {
+				const text = outputRaw ? this.decodeOutputChunk(payload, stdoutDecoder) : normalizeText(payload);
 				if (!text) return;
 				stdout += text;
-				if (streamOutput) this.writeStdOut(text);
+				if (streamOutput) {
+					if (outputRaw) this.writeRawOutput(text);
+					else this.writeStdOut(text);
+				}
 			};
-			const onStderr = (payload: string) => {
-				const text = normalizeText(payload);
+			const onStderr = (payload: string | Uint8Array) => {
+				const text = outputRaw ? this.decodeOutputChunk(payload, stderrDecoder) : normalizeText(payload);
 				if (!text) return;
 				stderr += text;
-				if (streamOutput) this.writeStdErr(text);
+				if (streamOutput) {
+					if (outputRaw) this.writeRawOutput(text);
+					else this.writeStdErr(text);
+				}
 			};
 			const onClose = (payload: { code: number | null; signal: number | null }) => {
+				if (outputRaw) {
+					const flushStdout = stdoutDecoder?.decode() ?? "";
+					if (flushStdout) {
+						stdout += flushStdout;
+						if (streamOutput) this.writeRawOutput(flushStdout);
+					}
+					const flushStderr = stderrDecoder?.decode() ?? "";
+					if (flushStderr) {
+						stderr += flushStderr;
+						if (streamOutput) this.writeRawOutput(flushStderr);
+					}
+				}
 				settleWithResult({
 					code: payload.code,
 					signal: payload.signal,
@@ -707,6 +763,10 @@ export class TerminalPanel {
 				const result = await this.executeShell(resolved.shellCommand, {
 					streamOutput: true,
 					initialInput: resolved.initialInput,
+					initialInputStartDelayMs: resolved.initialInputStartDelayMs,
+					initialInputInterChunkDelayMs: resolved.initialInputInterChunkDelayMs,
+					rawOutput: resolved.interactive,
+					allowExecuteFallback: !resolved.interactive,
 				});
 				if (typeof result.code === "number" && result.code !== 0 && !result.stderr.trim()) {
 					this.writeStdErr(`exit ${result.code}`);
@@ -718,7 +778,11 @@ export class TerminalPanel {
 			this.running = false;
 			this.runningInteractive = false;
 			this.render();
-			this.printPrompt();
+			const suppressPrompt = this.suppressPromptOnce;
+			this.suppressPromptOnce = false;
+			if (!suppressPrompt) {
+				this.printPrompt();
+			}
 			const next = this.queuedCommands.shift();
 			if (next) {
 				this.xterm?.write(`${next}\r\n`);
@@ -743,6 +807,7 @@ export class TerminalPanel {
 
 	private async handleClearAction(): Promise<void> {
 		if (this.running) {
+			this.suppressPromptOnce = true;
 			await this.abortRunningCommand();
 		}
 		this.clearScreen();

--- a/src/components/terminal-panel.ts
+++ b/src/components/terminal-panel.ts
@@ -2,7 +2,7 @@
  * TerminalPanel - docked terminal experience (xterm surface + local shell execution)
  */
 
-import { Command } from "@tauri-apps/plugin-shell";
+import { Command, type Child } from "@tauri-apps/plugin-shell";
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal } from "@xterm/xterm";
 import { html, render } from "lit";
@@ -77,6 +77,10 @@ function isPrintableKey(event: KeyboardEvent, key: string): boolean {
 	return key.length === 1;
 }
 
+function shellSingleQuote(value: string): string {
+	return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
 export class TerminalPanel {
 	private container: HTMLElement;
 	private cwd: string | null = null;
@@ -94,6 +98,8 @@ export class TerminalPanel {
 
 	private shellProfile: ShellProfile | null = null;
 	private resolvingShellProfile: Promise<ShellProfile> | null = null;
+	private runningChild: Child | null = null;
+	private queuedCommands: string[] = [];
 
 	constructor(container: HTMLElement) {
 		this.container = container;
@@ -113,6 +119,20 @@ export class TerminalPanel {
 
 	focusInput(): void {
 		this.xterm?.focus();
+	}
+
+	async runCommand(commandText: string): Promise<void> {
+		const command = commandText.trim();
+		if (!command) return;
+		this.ensureTerminal();
+		this.focusInput();
+		if (this.running) {
+			this.queuedCommands.push(command);
+			this.writeInfo(`Queued: ${command}`);
+			return;
+		}
+		this.xterm?.write(`${command}\r\n`);
+		await this.executeCommand(command);
 	}
 
 	private applyTheme(): void {
@@ -349,6 +369,32 @@ export class TerminalPanel {
 		}
 	}
 
+	private buildPiLoginBridgeCommand(rawProviderArg: string): string | null {
+		const provider = rawProviderArg.trim().toLowerCase();
+		const slashCommand = provider ? `/login ${provider}` : "/login";
+		const scriptedInput = shellSingleQuote(`${slashCommand}\n\n`);
+		const platform = navigator.platform.toLowerCase();
+		if (platform.includes("win")) return null;
+		if (platform.includes("mac")) {
+			return `printf %s ${scriptedInput} | script -q /dev/null pi`;
+		}
+		return `printf %s ${scriptedInput} | script -q -c ${shellSingleQuote("pi")} /dev/null`;
+	}
+
+	private resolveSpecialShellCommand(command: string): { shellCommand: string; infoText: string | null } {
+		const loginMatch = command.match(/^pi\s+login(?:\s+([a-z0-9._-]+))?$/i);
+		if (loginMatch) {
+			const bridgeCommand = this.buildPiLoginBridgeCommand(loginMatch[1] ?? "");
+			if (bridgeCommand) {
+				return {
+					shellCommand: bridgeCommand,
+					infoText: "Running Pi OAuth helper (pi + /login) in pseudo-terminal mode…",
+				};
+			}
+		}
+		return { shellCommand: command, infoText: null };
+	}
+
 	private async ensureShellProfile(): Promise<ShellProfile> {
 		if (this.shellProfile) return this.shellProfile;
 		if (this.resolvingShellProfile) return this.resolvingShellProfile;
@@ -382,23 +428,88 @@ export class TerminalPanel {
 		}
 	}
 
-	private async executeShell(command: string): Promise<TerminalExecResult> {
+	private async executeShell(command: string, options: { streamOutput?: boolean } = {}): Promise<TerminalExecResult> {
 		const profile = await this.ensureShellProfile();
-		const output = await Command.create(profile.name, this.buildShellArgs(profile, command), {
+		const streamOutput = options.streamOutput !== false;
+		const shellCommand = Command.create(profile.name, this.buildShellArgs(profile, command), {
 			cwd: this.cwd || undefined,
-		}).execute();
-		return {
-			code: output.code,
-			signal: output.signal,
-			stdout: normalizeText(output.stdout),
-			stderr: normalizeText(output.stderr),
-		};
+		});
+
+		return await new Promise<TerminalExecResult>((resolve, reject) => {
+			let stdout = "";
+			let stderr = "";
+			let settled = false;
+			let spawnedChild: Child | null = null;
+
+			const cleanup = () => {
+				shellCommand.stdout.off("data", onStdout);
+				shellCommand.stderr.off("data", onStderr);
+				shellCommand.off("close", onClose);
+				shellCommand.off("error", onError);
+				if (this.runningChild && spawnedChild && this.runningChild.pid === spawnedChild.pid) {
+					this.runningChild = null;
+				}
+			};
+
+			const settleWithResult = (result: TerminalExecResult) => {
+				if (settled) return;
+				settled = true;
+				cleanup();
+				resolve(result);
+			};
+
+			const settleWithError = (error: unknown) => {
+				if (settled) return;
+				settled = true;
+				cleanup();
+				reject(error instanceof Error ? error : new Error(normalizeText(error)));
+			};
+
+			const onStdout = (payload: string) => {
+				const text = normalizeText(payload);
+				if (!text) return;
+				stdout += text;
+				if (streamOutput) this.writeStdOut(text);
+			};
+			const onStderr = (payload: string) => {
+				const text = normalizeText(payload);
+				if (!text) return;
+				stderr += text;
+				if (streamOutput) this.writeStdErr(text);
+			};
+			const onClose = (payload: { code: number | null; signal: number | null }) => {
+				settleWithResult({
+					code: payload.code,
+					signal: payload.signal,
+					stdout,
+					stderr,
+				});
+			};
+			const onError = (message: string) => {
+				settleWithError(new Error(message || "Shell command failed"));
+			};
+
+			shellCommand.stdout.on("data", onStdout);
+			shellCommand.stderr.on("data", onStderr);
+			shellCommand.on("close", onClose);
+			shellCommand.on("error", onError);
+
+			shellCommand
+				.spawn()
+				.then((child) => {
+					spawnedChild = child;
+					this.runningChild = child;
+				})
+				.catch((error) => {
+					settleWithError(error);
+				});
+		});
 	}
 
 	private async executeCdCommand(command: string): Promise<void> {
 		const profile = await this.ensureShellProfile();
 		const probeCommand = this.buildCdProbeCommand(profile, command);
-		const result = await this.executeShell(probeCommand);
+		const result = await this.executeShell(probeCommand, { streamOutput: false });
 		if (result.stderr.trim()) {
 			this.writeStdErr(result.stderr.trimEnd());
 		}
@@ -441,15 +552,18 @@ export class TerminalPanel {
 			return;
 		}
 
+		const resolved = this.resolveSpecialShellCommand(command);
+		if (resolved.infoText) {
+			this.writeInfo(resolved.infoText);
+		}
+
 		this.running = true;
 		this.render();
 		try {
 			if (this.isCdCommand(command)) {
 				await this.executeCdCommand(command);
 			} else {
-				const result = await this.executeShell(command);
-				if (result.stdout.length > 0) this.writeStdOut(result.stdout);
-				if (result.stderr.length > 0) this.writeStdErr(result.stderr);
+				const result = await this.executeShell(resolved.shellCommand, { streamOutput: true });
 				if (typeof result.code === "number" && result.code !== 0 && !result.stderr.trim()) {
 					this.writeStdErr(`exit ${result.code}`);
 				}
@@ -460,16 +574,38 @@ export class TerminalPanel {
 			this.running = false;
 			this.render();
 			this.printPrompt();
+			const next = this.queuedCommands.shift();
+			if (next) {
+				this.xterm?.write(`${next}\r\n`);
+				void this.executeCommand(next);
+			}
 		}
 	}
 
 	private async abortRunningCommand(): Promise<void> {
 		if (!this.running) return;
-		this.writeInfo("Abort is not available for this shell command path yet.");
+		const child = this.runningChild;
+		if (!child) {
+			this.writeInfo("No running child process to abort.");
+			return;
+		}
+		try {
+			await child.kill();
+		} catch (err) {
+			this.writeStdErr(err instanceof Error ? err.message : String(err));
+		}
+	}
+
+	private async handleClearAction(): Promise<void> {
+		if (this.running) {
+			await this.abortRunningCommand();
+		}
+		this.clearScreen();
 	}
 
 	private clearScreen(): void {
 		this.inputBuffer = "";
+		this.queuedCommands = [];
 		this.xterm?.write("\x1b[2J\x1b[3J\x1b[H");
 		this.printPrompt();
 		this.scrollTerminalToBottom();
@@ -493,7 +629,7 @@ export class TerminalPanel {
 					<div class="terminal-panel-title">${headerTitle}</div>
 					<div class="terminal-panel-cwd" title=${this.cwd || ""}>${cwdLabel}</div>
 					<div class="terminal-panel-actions">
-						<button class="ghost-btn" title="Clear terminal" @click=${() => this.clearScreen()}>Clear</button>
+						<button class="ghost-btn" title="Clear terminal" @click=${() => void this.handleClearAction()}>Clear</button>
 						<button class="ghost-btn terminal-close-btn" title="Close terminal" @click=${() => this.onRequestClose?.()}>✕</button>
 					</div>
 				</div>

--- a/src/components/terminal-panel.ts
+++ b/src/components/terminal-panel.ts
@@ -41,6 +41,20 @@ function normalizeText(value: unknown): string {
 	}
 }
 
+function toUint8Array(value: unknown): Uint8Array | null {
+	if (value instanceof Uint8Array) return value;
+	if (Array.isArray(value) && value.every((item) => typeof item === "number")) {
+		return Uint8Array.from(value);
+	}
+	if (value && typeof value === "object") {
+		const candidate = (value as { data?: unknown }).data;
+		if (Array.isArray(candidate) && candidate.every((item) => typeof item === "number")) {
+			return Uint8Array.from(candidate);
+		}
+	}
+	return null;
+}
+
 function shellProfilesForPlatform(): ShellProfile[] {
 	const platform = navigator.platform.toLowerCase();
 	if (platform.includes("win")) {
@@ -168,7 +182,7 @@ export class TerminalPanel {
 			this.fitAddon = new FitAddon();
 			this.xterm = new Terminal({
 				cursorBlink: true,
-				convertEol: false,
+				convertEol: true,
 				scrollback: 6000,
 				fontSize: 12,
 				lineHeight: 1.35,
@@ -382,13 +396,16 @@ export class TerminalPanel {
 		this.scrollTerminalToBottom();
 	}
 
-	private decodeOutputChunk(payload: string | Uint8Array, decoder: TextDecoder | null): string {
+	private decodeOutputChunk(payload: unknown, decoder: TextDecoder | null): string {
 		if (typeof payload === "string") return payload;
-		if (!(payload instanceof Uint8Array)) return normalizeText(payload);
-		if (!decoder) {
-			return new TextDecoder().decode(payload);
+		const bytes = toUint8Array(payload);
+		if (bytes) {
+			if (!decoder) {
+				return new TextDecoder().decode(bytes);
+			}
+			return decoder.decode(bytes, { stream: true });
 		}
-		return decoder.decode(payload, { stream: true });
+		return normalizeText(payload);
 	}
 
 	private writeStdOut(text: string): void {
@@ -634,7 +651,7 @@ export class TerminalPanel {
 			const stdoutDecoder = outputRaw ? new TextDecoder() : null;
 			const stderrDecoder = outputRaw ? new TextDecoder() : null;
 
-			const onStdout = (payload: string | Uint8Array) => {
+			const onStdout = (payload: unknown) => {
 				const text = outputRaw ? this.decodeOutputChunk(payload, stdoutDecoder) : normalizeText(payload);
 				if (!text) return;
 				stdout += text;
@@ -643,7 +660,7 @@ export class TerminalPanel {
 					else this.writeStdOut(text);
 				}
 			};
-			const onStderr = (payload: string | Uint8Array) => {
+			const onStderr = (payload: unknown) => {
 				const text = outputRaw ? this.decodeOutputChunk(payload, stderrDecoder) : normalizeText(payload);
 				if (!text) return;
 				stderr += text;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2892,8 +2892,17 @@ async function initialize(): Promise<void> {
 				scheduleSidebarSessionsRefresh();
 			}
 		});
-		chatView.setOnOpenTerminal(() => {
+		chatView.setOnOpenTerminal(async (commandText) => {
+			const command = (commandText ?? "").trim();
+			if (command) {
+				toggleTerminalDock(true);
+				requestAnimationFrame(() => {
+					void terminalPanel?.runCommand(command);
+				});
+				return;
+			}
 			toggleTerminalDock();
+			terminalPanel?.focusInput();
 		});
 		chatView.setOnAddProject(() => {
 			void sidebar?.openFolder();

--- a/src/main.ts
+++ b/src/main.ts
@@ -2924,6 +2924,14 @@ async function initialize(): Promise<void> {
 			await packagesView.refreshPackages(false);
 			return await packagesView.openExtensionConfigByCommand(normalizedName, args);
 		});
+		chatView.setOnOpenProviderConfig(async (provider) => {
+			const normalizedProvider = provider.trim().toLowerCase().replace(/^\/+/, "");
+			if (!normalizedProvider) return false;
+			openPackagesPane();
+			if (!packagesView) return false;
+			await packagesView.refreshPackages(false);
+			return await packagesView.openExtensionConfigByProvider(normalizedProvider);
+		});
 		chatView.setOnBeginRenameCurrentSession(() => {
 			const workspace = getActiveWorkspace();
 			if (!workspace) return false;

--- a/src/main.ts
+++ b/src/main.ts
@@ -146,6 +146,7 @@ let projectSwitchTask: Promise<void> = Promise.resolve();
 let projectSwitchVersion = 0;
 let workspacePaneApplyVersion = 0;
 let settingsPaneRecoveryTimer: ReturnType<typeof setTimeout> | null = null;
+let terminalCommandRefreshTimer: ReturnType<typeof setTimeout> | null = null;
 
 class StaleProjectTaskError extends Error {
 	constructor() {
@@ -1631,6 +1632,33 @@ function scheduleSidebarSessionsRefresh(delayMs = 180): void {
 	sidebarSessionsRefreshTimer = setTimeout(() => {
 		sidebarSessionsRefreshTimer = null;
 		sidebar?.refreshActiveProjectSessions();
+	}, delayMs);
+}
+
+function scheduleTerminalCommandRefresh(delayMs = 260): void {
+	if (terminalCommandRefreshTimer) {
+		clearTimeout(terminalCommandRefreshTimer);
+	}
+	terminalCommandRefreshTimer = setTimeout(() => {
+		terminalCommandRefreshTimer = null;
+		void (async () => {
+			try {
+				await chatView?.refreshModels();
+			} catch {
+				// ignore refresh model failures from terminal-triggered updates
+			}
+			try {
+				await chatView?.refreshFromBackend();
+			} catch {
+				// ignore refresh failures from terminal-triggered updates
+			}
+			if (packagesView) {
+				void packagesView.refreshPackages(false).catch(() => {
+					// ignore package refresh failures here
+				});
+			}
+			scheduleSidebarSessionsRefresh(0);
+		})();
 	}, delayMs);
 }
 
@@ -3912,6 +3940,12 @@ function renderApp(): void {
 		setupTerminalDockResize(terminalPane);
 		terminalPanel = new TerminalPanel(terminalPane);
 		terminalPanel.setProjectPath(null);
+		terminalPanel.setOnCommandComplete(({ command, result }) => {
+			const normalized = command.trim().toLowerCase();
+			if (!/^pi(?:\s|$)/.test(normalized)) return;
+			if (result && typeof result.code === "number" && result.code !== 0) return;
+			scheduleTerminalCommandRefresh();
+		});
 		terminalPanel.setOnRequestClose(() => {
 			const workspace = getActiveWorkspace();
 			if (!workspace) return;

--- a/src/recommended-packages.ts
+++ b/src/recommended-packages.ts
@@ -48,6 +48,30 @@ export const RECOMMENDED_PACKAGES: RecommendedPackageDefinition[] = [
 		installSourceHint: "npm:@byteowlz/pi-auto-rename",
 		aliases: ["@byteowlz/pi-auto-rename", "pi-session-auto-rename"],
 	},
+	{
+		id: "pi-cursor-provider",
+		name: "Cursor Provider",
+		description: "Connect Pi to Cursor-authenticated models through the Cursor local proxy/provider extension.",
+		installScopeHint: "global",
+		source: "npm:pi-cursor-provider",
+		sourceKind: "npm",
+		publisher: "community",
+		resourcesLabel: "1 provider extension",
+		installSourceHint: "npm:pi-cursor-provider",
+		aliases: ["pi-cursor-provider", "cursor-provider", "cursor"],
+	},
+	{
+		id: "pi-kilocode",
+		name: "Kilo Code Provider",
+		description: "Adds Kilo Code as a Pi provider with capability-friendly integration for Desktop.",
+		installScopeHint: "global",
+		source: "npm:pi-kilocode",
+		sourceKind: "npm",
+		publisher: "community",
+		resourcesLabel: "1 provider extension",
+		installSourceHint: "npm:pi-kilocode",
+		aliases: ["pi-kilocode", "kilo", "kilocode"],
+	},
 ];
 
 function normalizeNpmSource(value: string): string {

--- a/src/rpc/bridge.ts
+++ b/src/rpc/bridge.ts
@@ -63,6 +63,12 @@ export interface PiAuthStatus {
 	configured_providers: PiAuthProviderStatus[];
 }
 
+export interface PiProviderAuthClearResult {
+	provider: string;
+	removed: boolean;
+	source: "auth_file" | "environment" | "missing";
+}
+
 export interface CliUpdateStatus {
 	discovery: string;
 	current_version: string | null;
@@ -505,6 +511,10 @@ export class RpcBridge {
 
 	async getPiAuthStatus(): Promise<PiAuthStatus> {
 		return invoke<PiAuthStatus>("get_pi_auth_status");
+	}
+
+	async clearPiProviderAuth(provider: string): Promise<PiProviderAuthClearResult> {
+		return invoke<PiProviderAuthClearResult>("clear_pi_provider_auth", { provider });
 	}
 
 	async getCliUpdateStatus(): Promise<CliUpdateStatus> {
@@ -968,6 +978,10 @@ class ActiveRpcBridgeProxy {
 
 	async getPiAuthStatus(): Promise<PiAuthStatus> {
 		return this.activeBridge.getPiAuthStatus();
+	}
+
+	async clearPiProviderAuth(provider: string): Promise<PiProviderAuthClearResult> {
+		return this.activeBridge.clearPiProviderAuth(provider);
 	}
 
 	async getCliUpdateStatus(): Promise<CliUpdateStatus> {

--- a/src/rpc/bridge.ts
+++ b/src/rpc/bridge.ts
@@ -69,6 +69,12 @@ export interface PiProviderAuthClearResult {
 	source: "auth_file" | "environment" | "missing";
 }
 
+export interface PiOAuthProviderInfo {
+	id: string;
+	name: string;
+	source: "built_in" | "package";
+}
+
 export interface CliUpdateStatus {
 	discovery: string;
 	current_version: string | null;
@@ -515,6 +521,10 @@ export class RpcBridge {
 
 	async clearPiProviderAuth(provider: string): Promise<PiProviderAuthClearResult> {
 		return invoke<PiProviderAuthClearResult>("clear_pi_provider_auth", { provider });
+	}
+
+	async getPiOAuthProviders(): Promise<PiOAuthProviderInfo[]> {
+		return invoke<PiOAuthProviderInfo[]>("get_pi_oauth_providers");
 	}
 
 	async getCliUpdateStatus(): Promise<CliUpdateStatus> {
@@ -982,6 +992,10 @@ class ActiveRpcBridgeProxy {
 
 	async clearPiProviderAuth(provider: string): Promise<PiProviderAuthClearResult> {
 		return this.activeBridge.clearPiProviderAuth(provider);
+	}
+
+	async getPiOAuthProviders(): Promise<PiOAuthProviderInfo[]> {
+		return this.activeBridge.getPiOAuthProviders();
 	}
 
 	async getCliUpdateStatus(): Promise<CliUpdateStatus> {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1826,7 +1826,8 @@ body.file-split-resizing #file-split-resize-handle::after {
 .packages-view-body {
 	flex: 1;
 	min-height: 0;
-	overflow: auto;
+	overflow-y: auto;
+	overflow-x: hidden;
 	padding: 22px 22px 18px;
 	display: grid;
 	gap: 16px;
@@ -1869,6 +1870,9 @@ body.file-split-resizing #file-split-resize-handle::after {
 	color: var(--muted);
 	background: color-mix(in srgb, var(--bg-soft) 56%, transparent);
 	border: 1px solid color-mix(in srgb, var(--border) 76%, transparent);
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+	word-break: break-word;
 }
 
 .packages-banner.success {
@@ -2304,6 +2308,10 @@ body.file-split-resizing #file-split-resize-handle::after {
 .packages-command-log {
 	max-height: 220px;
 	margin: 0;
+	overflow: auto;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+	word-break: break-word;
 }
 
 .packages-empty {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5912,13 +5912,11 @@ body.file-split-resizing #file-split-resize-handle::after {
 }
 
 .model-picker-provider-row {
-	display: grid;
-	grid-template-columns: 1fr auto;
-	gap: 4px;
-	align-items: center;
+	position: relative;
 }
 
 .model-picker-provider {
+	width: 100%;
 	height: 28px;
 	border: none;
 	border-radius: 8px;
@@ -5928,7 +5926,7 @@ body.file-split-resizing #file-split-resize-handle::after {
 	align-items: center;
 	justify-content: space-between;
 	gap: 6px;
-	padding: 0 8px;
+	padding: 0 46px 0 8px;
 	font-size: 12px;
 	cursor: pointer;
 	min-width: 0;
@@ -5941,14 +5939,6 @@ body.file-split-resizing #file-split-resize-handle::after {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	text-align: left;
-}
-
-.model-picker-provider-state {
-	flex-shrink: 0;
-	font-size: 10px;
-	color: var(--muted-2);
-	text-transform: lowercase;
-	letter-spacing: 0.02em;
 }
 
 .model-picker-provider-caret {
@@ -5966,7 +5956,12 @@ body.file-split-resizing #file-split-resize-handle::after {
 }
 
 .model-picker-provider-auth {
-	height: 24px;
+	position: absolute;
+	right: 6px;
+	top: 50%;
+	transform: translateY(-50%);
+	height: 22px;
+	min-width: 44px;
 	border-radius: 999px;
 	border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
 	background: color-mix(in srgb, var(--bg-soft) 78%, transparent);
@@ -5976,6 +5971,16 @@ body.file-split-resizing #file-split-resize-handle::after {
 	font-weight: 600;
 	letter-spacing: 0.01em;
 	cursor: pointer;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 120ms ease;
+}
+
+.model-picker-provider-row:hover .model-picker-provider-auth,
+.model-picker-provider-row:focus-within .model-picker-provider-auth,
+.model-picker-provider-auth.busy {
+	opacity: 1;
+	pointer-events: auto;
 }
 
 .model-picker-provider-auth:hover {
@@ -5989,8 +5994,13 @@ body.file-split-resizing #file-split-resize-handle::after {
 }
 
 .model-picker-provider-auth:disabled {
-	opacity: 0.55;
 	cursor: default;
+}
+
+.model-picker-provider-row:hover .model-picker-provider-auth:disabled,
+.model-picker-provider-row:focus-within .model-picker-provider-auth:disabled,
+.model-picker-provider-auth.busy:disabled {
+	opacity: 0.55;
 }
 
 .model-picker-models {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1745,11 +1745,13 @@ body.file-split-resizing #file-split-resize-handle::after {
 .terminal-panel-viewport {
 	flex: 1;
 	min-height: 0;
-	padding: 8px 10px 16px;
+	padding: 0;
+	overflow: hidden;
 	scrollbar-gutter: stable;
 }
 
 .terminal-panel-viewport .xterm {
+	width: 100%;
 	height: 100%;
 }
 
@@ -5958,7 +5960,7 @@ body.file-split-resizing #file-split-resize-handle::after {
 
 .model-picker-provider-auth {
 	position: absolute;
-	right: 24px;
+	right: 3px; /*comment about do not edit   */
 	top: 50%;
 	transform: translateY(-50%);
 	height: 22px;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5907,6 +5907,7 @@ body.file-split-resizing #file-split-resize-handle::after {
 	padding: 6px 4px;
 	grid-auto-rows: min-content;
 	align-content: start;
+	overflow-x: hidden;
 	border-right: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
 	background: color-mix(in srgb, var(--bg-soft) 42%, transparent);
 }
@@ -5918,6 +5919,7 @@ body.file-split-resizing #file-split-resize-handle::after {
 .model-picker-provider {
 	width: 100%;
 	height: 28px;
+	box-sizing: border-box;
 	border: none;
 	border-radius: 8px;
 	background: transparent;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5903,16 +5903,23 @@ body.file-split-resizing #file-split-resize-handle::after {
 
 .model-picker-providers {
 	display: grid;
-	gap: 1px;
-	padding: 4px;
+	gap: 4px;
+	padding: 6px 4px;
 	grid-auto-rows: min-content;
 	align-content: start;
 	border-right: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
 	background: color-mix(in srgb, var(--bg-soft) 42%, transparent);
 }
 
+.model-picker-provider-row {
+	display: grid;
+	grid-template-columns: 1fr auto;
+	gap: 4px;
+	align-items: center;
+}
+
 .model-picker-provider {
-	height: 27px;
+	height: 28px;
 	border: none;
 	border-radius: 8px;
 	background: transparent;
@@ -5920,10 +5927,11 @@ body.file-split-resizing #file-split-resize-handle::after {
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
-	gap: 8px;
+	gap: 6px;
 	padding: 0 8px;
 	font-size: 12px;
 	cursor: pointer;
+	min-width: 0;
 }
 
 .model-picker-provider-label {
@@ -5933,6 +5941,14 @@ body.file-split-resizing #file-split-resize-handle::after {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	text-align: left;
+}
+
+.model-picker-provider-state {
+	flex-shrink: 0;
+	font-size: 10px;
+	color: var(--muted-2);
+	text-transform: lowercase;
+	letter-spacing: 0.02em;
 }
 
 .model-picker-provider-caret {
@@ -5945,14 +5961,56 @@ body.file-split-resizing #file-split-resize-handle::after {
 	color: var(--text);
 }
 
+.model-picker-provider.unauth {
+	color: color-mix(in srgb, var(--muted) 72%, var(--bg));
+}
+
+.model-picker-provider-auth {
+	height: 24px;
+	border-radius: 999px;
+	border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
+	background: color-mix(in srgb, var(--bg-soft) 78%, transparent);
+	color: var(--muted);
+	padding: 0 8px;
+	font-size: 10px;
+	font-weight: 600;
+	letter-spacing: 0.01em;
+	cursor: pointer;
+}
+
+.model-picker-provider-auth:hover {
+	color: var(--text);
+	border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+}
+
+.model-picker-provider-auth.connected {
+	border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
+	color: color-mix(in srgb, var(--text) 82%, var(--accent));
+}
+
+.model-picker-provider-auth:disabled {
+	opacity: 0.55;
+	cursor: default;
+}
+
 .model-picker-models {
 	display: grid;
-	gap: 1px;
-	padding: 4px;
+	gap: 4px;
+	padding: 6px 4px;
 	grid-auto-rows: min-content;
 	align-content: start;
-	max-height: 224px;
+	max-height: 236px;
 	overflow-y: auto;
+}
+
+.model-picker-auth-hint {
+	margin: 2px 4px 4px;
+	padding: 6px 8px;
+	border-radius: 8px;
+	font-size: 11px;
+	line-height: 1.35;
+	color: var(--muted-2);
+	background: color-mix(in srgb, var(--bg-soft) 74%, transparent);
 }
 
 .model-picker-model {
@@ -5974,6 +6032,18 @@ body.file-split-resizing #file-split-resize-handle::after {
 .model-picker-model.active {
 	background: color-mix(in srgb, var(--bg-soft) 82%, transparent);
 	color: var(--text);
+}
+
+.model-picker-model.disabled,
+.model-picker-model:disabled {
+	color: color-mix(in srgb, var(--muted) 70%, var(--bg));
+	cursor: not-allowed;
+}
+
+.model-picker-model.disabled:hover,
+.model-picker-model:disabled:hover {
+	background: transparent;
+	color: color-mix(in srgb, var(--muted) 70%, var(--bg));
 }
 
 .model-picker-empty {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5928,7 +5928,7 @@ body.file-split-resizing #file-split-resize-handle::after {
 	align-items: center;
 	justify-content: space-between;
 	gap: 6px;
-	padding: 0 46px 0 8px;
+	padding: 0 74px 0 8px;
 	font-size: 12px;
 	cursor: pointer;
 	min-width: 0;
@@ -5943,10 +5943,6 @@ body.file-split-resizing #file-split-resize-handle::after {
 	text-align: left;
 }
 
-.model-picker-provider-caret {
-	flex-shrink: 0;
-}
-
 .model-picker-provider:hover,
 .model-picker-provider.active {
 	background: color-mix(in srgb, var(--bg-soft) 84%, transparent);
@@ -5959,14 +5955,14 @@ body.file-split-resizing #file-split-resize-handle::after {
 
 .model-picker-provider-auth {
 	position: absolute;
-	right: 6px;
+	right: 18px;
 	top: 50%;
 	transform: translateY(-50%);
 	height: 22px;
 	min-width: 44px;
-	border-radius: 999px;
-	border: 1px solid color-mix(in srgb, var(--border) 78%, transparent);
-	background: color-mix(in srgb, var(--bg-soft) 78%, transparent);
+	border-radius: 8px;
+	border: none;
+	background: var(--bg-muted);
 	color: var(--muted);
 	padding: 0 8px;
 	font-size: 10px;
@@ -5975,7 +5971,7 @@ body.file-split-resizing #file-split-resize-handle::after {
 	cursor: pointer;
 	opacity: 0;
 	pointer-events: none;
-	transition: opacity 120ms ease;
+	transition: opacity 120ms ease, background 120ms ease, color 120ms ease;
 }
 
 .model-picker-provider-row:hover .model-picker-provider-auth,
@@ -5986,13 +5982,12 @@ body.file-split-resizing #file-split-resize-handle::after {
 }
 
 .model-picker-provider-auth:hover {
+	background: var(--bg-soft);
 	color: var(--text);
-	border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
 }
 
 .model-picker-provider-auth.connected {
-	border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
-	color: color-mix(in srgb, var(--text) 82%, var(--accent));
+	color: var(--text);
 }
 
 .model-picker-provider-auth:disabled {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5894,6 +5894,7 @@ body.file-split-resizing #file-split-resize-handle::after {
 	grid-template-columns: minmax(132px, 176px) minmax(188px, 270px);
 	min-width: 340px;
 	max-width: min(92vw, 470px);
+	height: 244px;
 	border-radius: 12px;
 	border: 1px solid color-mix(in srgb, var(--border) 90%, transparent);
 	background: color-mix(in srgb, var(--bg-elev) 94%, var(--bg));
@@ -5907,7 +5908,9 @@ body.file-split-resizing #file-split-resize-handle::after {
 	padding: 6px 4px;
 	grid-auto-rows: min-content;
 	align-content: start;
+	height: 100%;
 	overflow-x: hidden;
+	overflow-y: auto;
 	border-right: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
 	background: color-mix(in srgb, var(--bg-soft) 42%, transparent);
 }
@@ -6006,7 +6009,8 @@ body.file-split-resizing #file-split-resize-handle::after {
 	padding: 6px 4px;
 	grid-auto-rows: min-content;
 	align-content: start;
-	max-height: 236px;
+	height: 100%;
+	max-height: none;
 	overflow-y: auto;
 }
 

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1685,7 +1685,8 @@ body.file-split-resizing #file-split-resize-handle::after {
 	flex-direction: column;
 	height: 100%;
 	width: 100%;
-	background: var(--bg);
+	--terminal-panel-bg: color-mix(in srgb, var(--bg-elev) 70%, var(--bg));
+	background: var(--terminal-panel-bg);
 }
 
 .terminal-resize-handle {
@@ -1714,7 +1715,7 @@ body.file-split-resizing #file-split-resize-handle::after {
 	align-items: center;
 	gap: 10px;
 	padding: 0 10px;
-	background: color-mix(in srgb, var(--bg-elev) 70%, var(--bg));
+	background: var(--terminal-panel-bg);
 }
 
 .terminal-panel-title {
@@ -1745,18 +1746,21 @@ body.file-split-resizing #file-split-resize-handle::after {
 .terminal-panel-viewport {
 	flex: 1;
 	min-height: 0;
-	padding: 0;
+	padding: 0 10px;
 	overflow: hidden;
+	background: var(--terminal-panel-bg);
 	scrollbar-gutter: stable;
 }
 
 .terminal-panel-viewport .xterm {
 	width: 100%;
 	height: 100%;
+	background: var(--terminal-panel-bg);
 }
 
 .terminal-panel-viewport .xterm .xterm-viewport {
 	overflow-y: auto;
+	background: var(--terminal-panel-bg);
 }
 
 .packages-view-root {

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5955,7 +5955,7 @@ body.file-split-resizing #file-split-resize-handle::after {
 
 .model-picker-provider-auth {
 	position: absolute;
-	right: 34px;
+	right: 24px;
 	top: 50%;
 	transform: translateY(-50%);
 	height: 22px;

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -5928,7 +5928,7 @@ body.file-split-resizing #file-split-resize-handle::after {
 	align-items: center;
 	justify-content: space-between;
 	gap: 6px;
-	padding: 0 74px 0 8px;
+	padding: 0 8px;
 	font-size: 12px;
 	cursor: pointer;
 	min-width: 0;
@@ -5955,7 +5955,7 @@ body.file-split-resizing #file-split-resize-handle::after {
 
 .model-picker-provider-auth {
 	position: absolute;
-	right: 18px;
+	right: 34px;
 	top: 50%;
 	transform: translateY(-50%);
 	height: 22px;


### PR DESCRIPTION
## Summary
Implements the next #48 auth/model-picker flow pass:

- **Model picker now includes provider auth context**
  - Shows providers even when unauthenticated (not just currently-available models)
  - Unauthenticated providers are visually subdued/greyed out
  - Models for unauthenticated providers are shown but disabled

- **Inline provider auth actions in flyout**
  - Provider rows now include `Login` / `Logout` action pills
  - `Logout` clears provider credentials from `~/.pi/agent/auth.json` via new desktop command
  - Environment-based auth shows `Env` state (informational, not removable in-app)

- **Provider setup routing for extension providers**
  - Added provider-based package settings opener flow
  - Model picker can route provider setup to Packages config UI via provider matching heuristics

- **Built-in slash auth UX updated**
  - `/login` and `/logout` descriptions updated
  - `/login <provider>` and `/logout <provider>` now route through model-picker auth flow
  - `/login` or `/logout` with no args opens picker for inline auth actions

- **Backend + bridge additions**
  - New Tauri command: `clear_pi_provider_auth(provider)`
  - New RPC bridge API: `clearPiProviderAuth(provider)`

## Files
- `src/components/chat-view.ts`
- `src/styles/app.css`
- `src/components/packages-view.ts`
- `src/main.ts`
- `src/rpc/bridge.ts`
- `src-tauri/src/lib.rs`
- `CHANGELOG.md`

## Validation
- `npm run check`
- `npm run build:frontend`
- `cargo check --manifest-path src-tauri/Cargo.toml`
