### PR TITLE
fix(settings): no-project CLI updates + version sync to 0.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-desktop",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-desktop",
-			"version": "0.1.8",
+			"version": "0.1.9",
 			"license": "MIT",
 			"dependencies": {
 				"@mariozechner/mini-lit": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-desktop",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"private": true,
 	"type": "module",
 	"description": "Pi Desktop - A minimalist coding agent desktop app",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-desktop"
-version = "0.1.8"
+version = "0.1.9"
 description = "Pi Desktop - A minimal coding agent desktop app"
 authors = ["Pi Desktop contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
 	"$schema": "https://raw.githubusercontent.com/nicegui/nicegui/refs/heads/main/nicegui/static/tauri_v2_schema.json",
 	"productName": "Pi Desktop",
 	"identifier": "com.pi.desktop",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"build": {
 		"beforeDevCommand": "npx vite --port 1420",
 		"devUrl": "http://localhost:1420",

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -871,14 +871,6 @@ export class SettingsPanel {
 			this.compatibilityReport = null;
 			this.authLoading = false;
 			this.compatibilityLoading = false;
-			this.desktopStatus = null;
-			this.cliStatus = null;
-			this.desktopLoading = false;
-			this.cliLoading = false;
-			this.themeCatalogLoading = false;
-			this.themeCatalogError = "";
-			this.themeCatalogMessage = "";
-			this.availableThemes = [];
 			this.scopedModelsLoading = false;
 			this.scopedModelsSaving = false;
 			this.scopedModelsError = "";
@@ -909,19 +901,20 @@ export class SettingsPanel {
 			// ignore missing persisted settings
 		}
 
-		if (!runtimeReady) {
-			this.applyAppearanceProfileForCurrentResolvedTheme(false);
-			return;
-		}
-
-		await Promise.all([
+		const refreshTasks: Promise<void>[] = [
 			this.refreshDesktopStatus(),
 			this.refreshCliStatus(),
 			this.refreshThemeCatalog(),
-			this.refreshAccountStatus(),
-			this.refreshCompatibilityStatus(),
-			this.refreshScopedModels(),
-		]);
+		];
+		if (runtimeReady) {
+			refreshTasks.push(
+				this.refreshAccountStatus(),
+				this.refreshCompatibilityStatus(),
+				this.refreshScopedModels(),
+			);
+		}
+
+		await Promise.all(refreshTasks);
 		this.applyAppearanceProfileForCurrentResolvedTheme(false);
 	}
 
@@ -1993,12 +1986,11 @@ export class SettingsPanel {
 								${this.cliStatus?.note ? html`<div class="settings-desc">${this.cliStatus.note}</div>` : null}
 							`}
 						<div class="settings-actions">
-							<button class="ghost-btn" ?disabled=${this.cliLoading || !runtimeControlsEnabled} @click=${() => this.refreshCliStatus()}>Refresh CLI status</button>
+							<button class="ghost-btn" ?disabled=${this.cliLoading} @click=${() => this.refreshCliStatus()}>Refresh CLI status</button>
 							<button
 								class="ghost-btn"
 								?disabled=${
 									this.cliUpdating ||
-									!runtimeControlsEnabled ||
 									!this.cliStatus?.can_update_in_app ||
 									!this.cliStatus?.npm_available ||
 									!this.cliStatus?.update_available


### PR DESCRIPTION
## Summary
- decouple Settings -> Updates CLI actions from project requirement
  - Refresh CLI status now works without an open project
  - Update CLI button is no longer blocked by missing project context
- keep advanced CLI diagnostics project/runtime-gated
- load non-runtime settings data even when no project is open
  - desktop update status
  - CLI update status
  - theme catalog
- bump app version from 0.1.8 -> 0.1.9 across desktop metadata to avoid false newer-version prompts against latest release

## Validation
- npm run check
- npm run build:frontend
- cd src-tauri && cargo check
- npm run build -- -b app,dmg