### PR TITLE
fix(ui): remove unknown provider placeholder and harden bundled theme preinstall state

### DIFF
--- a/src/components/chat-view.ts
+++ b/src/components/chat-view.ts
@@ -952,6 +952,21 @@ export class ChatView {
 		return normalizeProviderKeyValue(provider);
 	}
 
+	private isUnknownRuntimeModel(provider: string, modelId: string): boolean {
+		const providerKey = this.providerKey(provider);
+		const modelKey = normalizeText(modelId).toLowerCase();
+		return providerKey === "unknown" && (modelKey.length === 0 || modelKey === "unknown");
+	}
+
+	private currentModelSelection(state: RpcSessionState | null | undefined = this.state): { provider: string; modelId: string } {
+		const provider = normalizeText(state?.model?.provider);
+		const modelId = normalizeText(state?.model?.id);
+		if (this.isUnknownRuntimeModel(provider, modelId)) {
+			return { provider: "", modelId: "" };
+		}
+		return { provider, modelId };
+	}
+
 	private isOAuthProviderId(provider: string): boolean {
 		return isOAuthProviderIdInCatalog(provider, this.oauthProviderCatalog);
 	}
@@ -1337,7 +1352,7 @@ export class ChatView {
 			this.modelPickerActiveProvider = preferred;
 		}
 		if (!this.modelPickerActiveProvider) {
-			const currentProvider = normalizeText(this.state?.model?.provider);
+			const currentProvider = this.currentModelSelection().provider;
 			if (currentProvider) {
 				this.modelPickerActiveProvider = currentProvider;
 			}
@@ -1786,8 +1801,7 @@ export class ChatView {
 	}
 
 	private thinkingLevelModelKey(state: RpcSessionState | null | undefined = this.state): string {
-		const provider = state?.model?.provider?.trim() ?? "";
-		const modelId = state?.model?.id?.trim() ?? "";
+		const { provider, modelId } = this.currentModelSelection(state);
 		if (!provider || !modelId) return "";
 		return `${provider}::${modelId}`;
 	}
@@ -1883,8 +1897,7 @@ export class ChatView {
 				: null;
 		if (stateWindow && stateWindow > 0) return stateWindow;
 
-		const provider = this.state?.model?.provider ?? "";
-		const modelId = this.state?.model?.id ?? "";
+		const { provider, modelId } = this.currentModelSelection();
 		if (provider && modelId) {
 			const fromCatalog = this.availableModels.find((m) => m.provider === provider && m.id === modelId)?.contextWindow;
 			if (typeof fromCatalog === "number" && Number.isFinite(fromCatalog) && fromCatalog > 0) {
@@ -4347,8 +4360,7 @@ export class ChatView {
 	}
 
 	private renderComposerControls(canSend: boolean, isStreaming: boolean, interactionLocked: boolean): TemplateResult {
-		const currentProvider = normalizeText(this.state?.model?.provider);
-		const currentModelId = normalizeText(this.state?.model?.id);
+		const { provider: currentProvider, modelId: currentModelId } = this.currentModelSelection();
 		const currentModelValue = currentProvider && currentModelId ? `${currentProvider}::${currentModelId}` : "";
 		const currentModelDisplay = currentModelId ? formatModelDisplayName(currentModelId) : "Select model";
 		const currentProviderDisplay = currentProvider ? this.displayProviderLabel(currentProvider) : "";

--- a/src/components/packages-view.ts
+++ b/src/components/packages-view.ts
@@ -745,6 +745,21 @@ export class PackagesView {
 		}
 	}
 
+	private updateBundledThemeInstallStateFromResources(resources: DiscoveredThemeItem[]): void {
+		const bundledResources = resources.filter((item) => isBundledThemeId(item.id));
+		if (bundledResources.length === 0) return;
+		this.desktopThemesInstalledCount = Math.max(this.desktopThemesInstalledCount, bundledResources.length);
+		if (!this.desktopThemesRootPath) {
+			const samplePath = bundledResources[0]?.path ?? "";
+			if (samplePath) {
+				this.desktopThemesRootPath = pathDirName(samplePath);
+			}
+		}
+		if (bundledResources.length >= this.desktopThemesTotal) {
+			this.desktopThemesInstalled = true;
+		}
+	}
+
 	private async openExternal(url: string): Promise<void> {
 		try {
 			const { open } = await import("@tauri-apps/plugin-shell");
@@ -1327,6 +1342,7 @@ export class PackagesView {
 				globalThemes,
 				(item) => `${item.id}:${normalizeFsPath(item.path)}`,
 			).sort((a, b) => a.name.localeCompare(b.name));
+			this.updateBundledThemeInstallStateFromResources(this.themeResources);
 		} catch (err) {
 			this.promptTemplateResources = [];
 			this.skillResources = [];


### PR DESCRIPTION
## Summary
- Hide backend placeholder model `unknown/unknown` in desktop model picker/composer controls.
- Treat runtime placeholder model as "no selected model" in ChatView model selection logic.
- Harden bundled theme install-state detection in Packages by deriving state from discovered theme resources when status probing fails.

## Why
New-user sessions can start with RPC state model `unknown/unknown` (from backend placeholder), which surfaced as an extra **Unknown** provider/model in the picker UI.

Also, Pi Desktop Themes should appear preinstalled by default; this patch adds a resource-derived fallback so the UI still marks bundled themes installed when file-level discovery proves they are present.

## Validation
- npm run check
- npm run build:frontend
