### PR TITLE
hotfix: manual Pi binary override + Linux discovery fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ The format is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0
 ## [Unreleased]
 
 ### Changed
-- _No changes yet._
+- Added a Settings → Updates advanced control for manual Pi binary override (`pi_path`) with browse/save/clear actions, so users can pin an explicit `pi` executable path across all OSes.
+- RPC/CLI command bridge now carries a preferred manual Pi binary override for runtime start and non-runtime CLI actions (status/list/install/update flows).
 
 ### Fixed
-- _No changes yet._
+- Improved Linux/macOS fallback discovery for global npm installs by checking additional common user-prefix locations (including `~/.npm-global/bin/pi`) and npm prefix environment hints.
+- Explicit Pi path resolution now supports `~`-prefixed paths in manual settings/env override flows.
 
 ## [1.0.0] - 2026-04-13
 

--- a/README.md
+++ b/README.md
@@ -60,23 +60,55 @@ Pi Desktop gives you a stable desktop UX for Pi without hardcoding product logic
 
 ## Features
 
-- Workspace + project sidebar with pin/reorder semantics
-- Session-first tabs (chat-centered), with right-side file split panel
-- Docked xterm terminal panel in chat
-- Streaming chat UI with compact workflow/tool/thinking timeline
-- Composer slash palette with deterministic slash execution
-- Message actions (copy/resend, hover-revealed)
-- Context usage ring + session stats
-- Command palette + shortcuts panel
-- Package manager pane (`pi install/remove/update/list`)
-- Recommended package catalog
-- **Package settings modal** with Save/Apply UX driven by discovered package capabilities
-- Settings panel with simplified IA and no-project-safe behavior
-- Inline runtime/provider error visibility in chat timeline (CLI-like error surfacing)
-- Session context action to **Mark unread**
-- First-run CLI onboarding when `pi` is missing
-- In-app CLI update checks + update action
-- Native notifications via extension UI boundary (`ctx.ui.notify`)
+### Feature snapshot (short)
+
+- Multi-workspace, project-aware desktop shell for Pi
+- Session-first chat workflow with streaming, tools, and thinking timeline
+- Docked terminal, right-side file split, and command palette
+- Deterministic slash commands + runtime-discovered extension/skill/prompt commands
+- Package/resource management (`pi install/remove/update/list`) in-app
+- Model/provider picker with auth actions and diagnostics
+- Robust settings, updates, and no-project-safe UX
+
+### Built-in features (technical)
+
+- **Workspace/session architecture**
+  - Workspace + project sidebar with pin/reorder semantics
+  - Session-first tabs (chat-centered), session browser/history/fork flows
+  - Session context actions (including **Mark unread**)
+
+- **Chat + composer**
+  - Streaming chat UI with compact workflow/tool/thinking timeline
+  - Composer slash palette with deterministic slash execution
+  - Full input history (`ArrowUp` / `ArrowDown`), queued follow-ups, and message actions
+
+- **Commands + shortcuts**
+  - Built-in slash commands for settings/model/import/export/share/tree/fork/resume/compact/reload/quit
+  - Command palette + shortcuts panel
+
+- **Model/provider/auth**
+  - Model picker with provider grouping + login/logout actions
+  - Account diagnostics + auth status visibility
+  - Auto-refresh of auth state when `~/.pi/agent/auth.json` changes
+
+- **Terminal + files**
+  - Docked xterm terminal panel in chat
+  - Right-side file split panel with resize
+  - Drag/drop attachments and file reference pills in composer
+
+- **Packages/resources/themes**
+  - Package manager pane (`pi install/remove/update/list`)
+  - Recommended package + skill catalogs
+  - Package settings modal with capability-driven Save/Apply UX
+  - Bundled desktop themes + CLI-schema-compatible theme handling
+
+- **Settings + updates + reliability**
+  - Simplified Settings IA with no-project-safe behavior
+  - **Manual CLI binary path override** in Settings (all OS) for environments where PATH discovery is unreliable
+  - First-run CLI onboarding when `pi` is missing
+  - In-app desktop + CLI update checks/actions
+  - Inline runtime/provider error visibility in chat timeline
+  - Native notifications via extension UI boundary (`ctx.ui.notify`)
 
 Detailed capability map: [`FEATURE_MAPPING.md`](./FEATURE_MAPPING.md)
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -71,6 +71,9 @@ struct RpcStartOptions {
     /// Dev-mode only: path to the CLI JS file (e.g. "../coding-agent/dist/cli.js").
     /// When null/empty, the backend discovers the pi binary automatically.
     cli_path: Option<String>,
+    /// Optional explicit pi binary path override from Desktop settings.
+    /// When set, this takes precedence over sidecar/PATH/common-location discovery.
+    pi_path: Option<String>,
     cwd: String,
     provider: Option<String>,
     model: Option<String>,
@@ -164,6 +167,44 @@ fn resolve_home_dir() -> Option<PathBuf> {
     None
 }
 
+fn expand_tilde_path(raw: &str) -> PathBuf {
+    let trimmed = raw.trim();
+    if trimmed == "~" {
+        if let Some(home) = resolve_home_dir() {
+            return home;
+        }
+    }
+    if let Some(rest) = trimmed.strip_prefix("~/") {
+        if let Some(home) = resolve_home_dir() {
+            return home.join(rest);
+        }
+    }
+    if let Some(rest) = trimmed.strip_prefix("~\\") {
+        if let Some(home) = resolve_home_dir() {
+            return home.join(rest);
+        }
+    }
+    PathBuf::from(trimmed)
+}
+
+fn resolve_explicit_pi_path(raw: &str) -> Option<PathBuf> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let expanded = expand_tilde_path(trimmed);
+    if expanded.is_file() {
+        return Some(expanded);
+    }
+
+    if let Ok(which_path) = which::which(trimmed) {
+        return Some(which_path);
+    }
+
+    None
+}
+
 fn discover_pi_from_common_locations() -> Option<PathBuf> {
     let mut candidates: Vec<PathBuf> = Vec::new();
 
@@ -251,6 +292,19 @@ fn discover_pi_from_common_locations() -> Option<PathBuf> {
         candidates.push(home_dir.join(".pi/agent/bin/pi"));
         candidates.push(home_dir.join(".volta/bin/pi"));
         candidates.push(home_dir.join(".local/bin/pi"));
+        candidates.push(home_dir.join(".npm-global/bin/pi"));
+        candidates.push(home_dir.join(".npm/bin/pi"));
+    }
+
+    // npm custom prefix installs (common on Linux/macOS desktop launches)
+    for key in ["NPM_CONFIG_PREFIX", "PREFIX"] {
+        if let Ok(prefix) = std::env::var(key) {
+            let trimmed = prefix.trim();
+            if !trimmed.is_empty() {
+                candidates.push(PathBuf::from(trimmed).join("bin/pi"));
+                candidates.push(PathBuf::from(trimmed).join("pi"));
+            }
+        }
     }
 
     // Common system install locations
@@ -431,16 +485,8 @@ fn resolve_pi_changelog_candidates(pi: &PiProcess) -> Vec<PathBuf> {
 fn discover_pi_from_env_override() -> Option<PathBuf> {
     for key in ["PI_DESKTOP_PI_PATH", "PI_CLI_PATH"] {
         if let Ok(raw) = std::env::var(key) {
-            let value = raw.trim();
-            if value.is_empty() {
-                continue;
-            }
-            let candidate = PathBuf::from(value);
-            if candidate.is_file() {
-                return Some(candidate);
-            }
-            if let Ok(which_path) = which::which(value) {
-                return Some(which_path);
+            if let Some(path) = resolve_explicit_pi_path(&raw) {
+                return Some(path);
             }
         }
     }
@@ -462,13 +508,28 @@ fn missing_pi_cli_error(additional: Option<String>) -> String {
 }
 
 /// Discover the pi binary. Strategy:
-/// 1. If cli_path is provided (dev mode), use node + script
-/// 2. Try explicit env override (PI_DESKTOP_PI_PATH / PI_CLI_PATH)
-/// 3. Try sidecar discovery (packaged app)
-/// 4. Try finding `pi` on PATH (globally installed CLI or standalone binary)
-/// 5. Try common install locations (for GUI app launches without shell PATH)
-/// 6. Fail with actionable error
+/// 1. If pi_path is provided (Desktop manual override), use it
+/// 2. If cli_path is provided (dev mode), use node + script or explicit binary
+/// 3. Try explicit env override (PI_DESKTOP_PI_PATH / PI_CLI_PATH)
+/// 4. Try sidecar discovery (packaged app)
+/// 5. Try finding `pi` on PATH (globally installed CLI or standalone binary)
+/// 6. Try common install locations (for GUI app launches without shell PATH)
+/// 7. Fail with actionable error
 fn discover_pi(app: &AppHandle, options: &RpcStartOptions) -> Result<PiProcess, String> {
+    // Desktop manual override from settings
+    if let Some(ref pi_path) = options.pi_path {
+        let trimmed = pi_path.trim();
+        if !trimmed.is_empty() {
+            if let Some(path) = resolve_explicit_pi_path(trimmed) {
+                return Ok(PiProcess::PathBinary { path });
+            }
+            return Err(missing_pi_cli_error(Some(format!(
+                "Configured pi binary path was not found: {}",
+                trimmed
+            ))));
+        }
+    }
+
     // Dev mode: cli_path explicitly provided
     if let Some(ref cli_path) = options.cli_path {
         let trimmed = cli_path.trim();
@@ -478,12 +539,8 @@ fn discover_pi(app: &AppHandle, options: &RpcStartOptions) -> Result<PiProcess, 
                     script: trimmed.to_string(),
                 });
             }
-            let direct = PathBuf::from(trimmed);
-            if direct.is_file() {
-                return Ok(PiProcess::PathBinary { path: direct });
-            }
-            if let Ok(which_path) = which::which(trimmed) {
-                return Ok(PiProcess::PathBinary { path: which_path });
+            if let Some(path) = resolve_explicit_pi_path(trimmed) {
+                return Ok(PiProcess::PathBinary { path });
             }
         }
     }
@@ -575,7 +632,7 @@ fn write_rpc_line(stdin: &mut std::process::ChildStdin, line: &str) -> Result<()
 }
 
 /// Start the pi coding agent in RPC mode as a child process.
-/// Discovery order: dev cli_path -> sidecar -> PATH -> error.
+/// Discovery order: manual pi_path -> dev cli_path -> env override -> sidecar -> PATH/common locations -> error.
 #[tauri::command]
 async fn rpc_start(
     app: AppHandle,
@@ -1460,6 +1517,7 @@ async fn get_pi_oauth_providers(app: AppHandle) -> Result<Vec<PiOAuthProviderInf
 
     let discovery_opts = RpcStartOptions {
         cli_path: None,
+        pi_path: None,
         cwd: ".".to_string(),
         provider: None,
         model: None,
@@ -1475,6 +1533,7 @@ async fn get_pi_oauth_providers(app: AppHandle) -> Result<Vec<PiOAuthProviderInf
         cwd: Some(".".to_string()),
         env: None,
         cli_path: None,
+        pi_path: None,
     };
 
     let output = match build_plain_command(&pi, &list_opts).output() {
@@ -1523,6 +1582,7 @@ pub struct AppSettings {
     pub follow_up_mode: String,
     pub model_provider: Option<String>,
     pub model_id: Option<String>,
+    pub pi_path: Option<String>,
 }
 
 impl Default for AppSettings {
@@ -1536,6 +1596,7 @@ impl Default for AppSettings {
             follow_up_mode: "one-at-a-time".to_string(),
             model_provider: None,
             model_id: None,
+            pi_path: None,
         }
     }
 }
@@ -1591,6 +1652,7 @@ struct PiCliCommandOptions {
     cwd: Option<String>,
     env: Option<std::collections::HashMap<String, String>>,
     cli_path: Option<String>,
+    pi_path: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1604,6 +1666,7 @@ struct PiCliCommandResult {
 #[derive(Debug, Deserialize)]
 struct CliStatusOptions {
     cli_path: Option<String>,
+    pi_path: Option<String>,
     cwd: Option<String>,
     env: Option<std::collections::HashMap<String, String>>,
 }
@@ -1803,6 +1866,7 @@ fn get_current_pi_version(pi: &PiProcess, options: &CliStatusOptions) -> Option<
         cwd: options.cwd.clone(),
         env: options.env.clone(),
         cli_path: options.cli_path.clone(),
+        pi_path: options.pi_path.clone(),
     };
 
     let output = build_plain_command(pi, &version_opts).output().ok()?;
@@ -1939,6 +2003,7 @@ async fn run_pi_cli_command(
 
     let discovery_opts = RpcStartOptions {
         cli_path: options.cli_path.clone(),
+        pi_path: options.pi_path.clone(),
         cwd: resolved_cwd,
         provider: None,
         model: None,
@@ -1968,12 +2033,14 @@ async fn get_cli_update_status(
 ) -> Result<CliUpdateStatus, String> {
     let opts = options.unwrap_or(CliStatusOptions {
         cli_path: None,
+        pi_path: None,
         cwd: Some(".".to_string()),
         env: None,
     });
 
     let discovery_opts = RpcStartOptions {
         cli_path: opts.cli_path.clone(),
+        pi_path: opts.pi_path.clone(),
         cwd: opts.cwd.clone().unwrap_or_else(|| ".".to_string()),
         provider: None,
         model: None,
@@ -2027,12 +2094,14 @@ async fn get_pi_changelog(
 ) -> Result<PiChangelogResult, String> {
     let opts = options.unwrap_or(CliStatusOptions {
         cli_path: None,
+        pi_path: None,
         cwd: Some(".".to_string()),
         env: None,
     });
 
     let discovery_opts = RpcStartOptions {
         cli_path: opts.cli_path.clone(),
+        pi_path: opts.pi_path.clone(),
         cwd: opts.cwd.clone().unwrap_or_else(|| ".".to_string()),
         provider: None,
         model: None,

--- a/src/components/settings-panel.ts
+++ b/src/components/settings-panel.ts
@@ -49,6 +49,7 @@ interface SettingsState {
 	autoRetryEnabled: boolean;
 	steeringMode: QueueMode;
 	followUpMode: QueueMode;
+	piBinaryPath: string;
 }
 
 interface ScopedModelOption {
@@ -85,6 +86,7 @@ export class SettingsPanel {
 		autoRetryEnabled: true,
 		steeringMode: "one-at-a-time",
 		followUpMode: "one-at-a-time",
+		piBinaryPath: "",
 	};
 	private onClose: (() => void) | null = null;
 	private onRequestAddProject: (() => void) | null = null;
@@ -100,7 +102,9 @@ export class SettingsPanel {
 	private cliLoading = false;
 	private cliUpdating = false;
 	private cliActionMessage = "";
+	private piPathActionMessage = "";
 	private onCliStatusChange: ((status: CliUpdateStatus | null) => void) | null = null;
+	private onPiBinaryPathChange: ((path: string | null) => void) | null = null;
 	private onNavigationStateChange: ((state: SettingsNavigationState) => void) | null = null;
 	private compatibilityReport: RpcCompatibilityReport | null = null;
 	private compatibilityLoading = false;
@@ -162,6 +166,10 @@ export class SettingsPanel {
 
 	setOnCliStatusChange(callback: (status: CliUpdateStatus | null) => void): void {
 		this.onCliStatusChange = callback;
+	}
+
+	setOnPiBinaryPathChange(callback: ((path: string | null) => void) | null): void {
+		this.onPiBinaryPathChange = callback;
 	}
 
 	setOnNavigationStateChange(callback: ((state: SettingsNavigationState) => void) | null): void {
@@ -855,6 +863,59 @@ export class SettingsPanel {
 		this.themeCatalogMessage = `Created theme ${fileStem}.json in ~/.pi/agent/themes`;
 	}
 
+	private normalizePiBinaryPath(value: string | null | undefined): string | null {
+		const normalized = typeof value === "string" ? value.trim() : "";
+		return normalized.length > 0 ? normalized : null;
+	}
+
+	private setPiBinaryPathDraft(value: string): void {
+		this.state.piBinaryPath = value;
+		this.piPathActionMessage = "";
+		this.render();
+	}
+
+	private async choosePiBinaryPathFromDialog(): Promise<void> {
+		try {
+			const { open } = await import("@tauri-apps/plugin-dialog");
+			const selected = await open({
+				multiple: false,
+				directory: false,
+				title: "Select pi binary",
+			});
+			if (typeof selected !== "string" || selected.trim().length === 0) return;
+			this.state.piBinaryPath = selected;
+			this.piPathActionMessage = "";
+			this.render();
+		} catch (err) {
+			this.piPathActionMessage = err instanceof Error ? err.message : "Could not open file picker.";
+			this.render();
+		}
+	}
+
+	private async savePiBinaryPathOverride(): Promise<void> {
+		const normalized = this.normalizePiBinaryPath(this.state.piBinaryPath);
+		this.state.piBinaryPath = normalized ?? "";
+		try {
+			await this.saveSettings();
+			this.onPiBinaryPathChange?.(normalized);
+			this.piPathActionMessage = normalized
+				? "Saved CLI binary override. Use /reload to reconnect active runtimes."
+				: "Cleared CLI binary override.";
+			await this.refreshCliStatus();
+			if (this.isRuntimeControlsEnabled()) {
+				await this.refreshCompatibilityStatus();
+			}
+		} catch (err) {
+			this.piPathActionMessage = err instanceof Error ? err.message : "Failed to save CLI binary override.";
+		}
+		this.render();
+	}
+
+	private async clearPiBinaryPathOverride(): Promise<void> {
+		this.state.piBinaryPath = "";
+		await this.savePiBinaryPathOverride();
+	}
+
 	private async loadState(): Promise<void> {
 		const runtimeReady = Boolean(this.runtimeProjectPath) && rpcBridge.isConnected;
 		if (runtimeReady) {
@@ -889,6 +950,7 @@ export class SettingsPanel {
 			const saved = (await invoke("load_settings")) as {
 				theme?: string;
 				auto_retry?: boolean;
+				pi_path?: string | null;
 			};
 			if (saved.theme === "dark" || saved.theme === "light" || saved.theme === "system") {
 				this.state.theme = saved.theme;
@@ -897,6 +959,9 @@ export class SettingsPanel {
 			if (typeof saved.auto_retry === "boolean") {
 				this.state.autoRetryEnabled = saved.auto_retry;
 			}
+			const normalizedPiPath = this.normalizePiBinaryPath(saved.pi_path);
+			this.state.piBinaryPath = normalizedPiPath ?? "";
+			this.onPiBinaryPathChange?.(normalizedPiPath);
 		} catch {
 			// ignore missing persisted settings
 		}
@@ -1527,6 +1592,7 @@ export class SettingsPanel {
 					follow_up_mode: this.state.followUpMode,
 					model_provider: null,
 					model_id: null,
+					pi_path: this.normalizePiBinaryPath(this.state.piBinaryPath),
 				},
 			});
 		} catch (err) {
@@ -1985,6 +2051,30 @@ export class SettingsPanel {
 									: html`<div class="settings-desc">CLI status unavailable. Install or reconnect CLI, then refresh.</div>`}
 								${this.cliStatus?.note ? html`<div class="settings-desc">${this.cliStatus.note}</div>` : null}
 							`}
+						<div class="settings-row settings-row-top">
+							<div>
+								<div class="settings-label">CLI binary path override (optional)</div>
+								<div class="settings-desc">Set an absolute path to your <code>pi</code> binary if Desktop cannot discover it automatically.</div>
+								<div class="settings-desc">Examples: <code>~/.npm-global/bin/pi</code>, <code>/usr/local/bin/pi</code>, <code>C:\\Users\\you\\AppData\\Roaming\\npm\\pi.cmd</code></div>
+							</div>
+						</div>
+						<input
+							type="text"
+							class="settings-path-input"
+							placeholder="/absolute/path/to/pi"
+							.value=${this.state.piBinaryPath}
+							@input=${(e: Event) => this.setPiBinaryPathDraft((e.target as HTMLInputElement).value)}
+						/>
+						<div class="settings-actions" style="margin-top:8px;">
+							<button class="ghost-btn" @click=${() => this.choosePiBinaryPathFromDialog()}>Browse…</button>
+							<button class="ghost-btn" ?disabled=${this.saving} @click=${() => this.savePiBinaryPathOverride()}>
+								${this.saving ? "Saving…" : "Save path override"}
+							</button>
+							<button class="ghost-btn" ?disabled=${this.saving || this.state.piBinaryPath.trim().length === 0} @click=${() => this.clearPiBinaryPathOverride()}>
+								Clear override
+							</button>
+						</div>
+						${this.piPathActionMessage ? html`<div class="settings-desc">${this.piPathActionMessage}</div>` : null}
 						<div class="settings-actions">
 							<button class="ghost-btn" ?disabled=${this.cliLoading} @click=${() => this.refreshCliStatus()}>Refresh CLI status</button>
 							<button

--- a/src/main.ts
+++ b/src/main.ts
@@ -143,6 +143,7 @@ let extensionUiHandler: ExtensionUiHandler | null = null;
 
 let cliUpdateStatus: CliUpdateStatus | null = null;
 let desktopUpdateStatus: DesktopUpdateStatus | null = null;
+let preferredPiBinaryPath: string | null = null;
 let cliUpdatePollingTimer: ReturnType<typeof setInterval> | null = null;
 let desktopUpdatePollingTimer: ReturnType<typeof setInterval> | null = null;
 let cliUpdateChecking = false;
@@ -529,10 +530,12 @@ function getOrCreateRuntimeForTab(workspaceId: string, tabId: string, projectPat
 		return existing;
 	}
 	const instanceId = sessionRuntimeInstanceId(key);
+	const bridge = new RpcBridge(instanceId);
+	bridge.setPreferredPiPath(preferredPiBinaryPath);
 	const runtime: SessionRuntime = {
 		key,
 		instanceId,
-		bridge: new RpcBridge(instanceId),
+		bridge,
 		workspaceId,
 		tabId,
 		projectPath,
@@ -1591,8 +1594,9 @@ async function renameSessionFromWorkspace(projectId: string, sessionPath: string
 				}
 			} else {
 				const maintenanceBridge = new RpcBridge(uid("rename_rpc"));
+				maintenanceBridge.setPreferredPiPath(findPiBinaryPath());
 				try {
-					await maintenanceBridge.start({ cliPath: findCliPath(), cwd: project.path });
+					await maintenanceBridge.start({ cliPath: findCliPath(), piPath: findPiBinaryPath(), cwd: project.path });
 					const switched = await maintenanceBridge.switchSession(sessionPath);
 					if (switched.cancelled) return;
 					await maintenanceBridge.setSessionName(trimmedName);
@@ -1937,12 +1941,40 @@ function setupSidebarResize(): void {
 	};
 }
 
+function normalizePiBinaryPath(value: unknown): string | null {
+	if (typeof value !== "string") return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+function applyPreferredPiBinaryPath(path: string | null): void {
+	preferredPiBinaryPath = normalizePiBinaryPath(path);
+	rpcBridge.setPreferredPiPath(preferredPiBinaryPath);
+	for (const runtime of sessionRuntimes.values()) {
+		runtime.bridge.setPreferredPiPath(preferredPiBinaryPath);
+	}
+}
+
+async function loadPreferredPiBinaryPathFromSettings(): Promise<void> {
+	try {
+		const { invoke } = await import("@tauri-apps/api/core");
+		const saved = (await invoke("load_settings")) as { pi_path?: string | null };
+		applyPreferredPiBinaryPath(normalizePiBinaryPath(saved?.pi_path ?? null));
+	} catch {
+		applyPreferredPiBinaryPath(null);
+	}
+}
+
 function findCliPath(): string | null {
 	if (import.meta.env.DEV) {
 		// Optional local dev path (if running next to pi-mono)
 		return null;
 	}
 	return null;
+}
+
+function findPiBinaryPath(): string | null {
+	return preferredPiBinaryPath;
 }
 
 function getCwd(): string {
@@ -2677,7 +2709,7 @@ async function ensureRuntimeForSessionTab(
 		if (!bridge.isConnected) {
 			runtime.phase = "starting";
 			recordDebugTrace(`ensureRuntime:start-bridge instance=${runtime.instanceId}`);
-			await bridge.start({ cliPath: findCliPath(), cwd: projectPath });
+			await bridge.start({ cliPath: findCliPath(), piPath: findPiBinaryPath(), cwd: projectPath });
 			recordDebugTrace(`ensureRuntime:bridge-started instance=${runtime.instanceId} discovery=${bridge.discoveryInfo ?? "-"}`);
 			if (typeof taskVersion === "number") {
 				assertProjectTaskCurrent(taskVersion);
@@ -3035,6 +3067,7 @@ async function initialize(): Promise<void> {
 
 	initializeComponents();
 	loadWorkspaces();
+	await loadPreferredPiBinaryPathFromSettings();
 	loadSidebarWidth();
 	applySidebarWidth();
 	await ensureBundledThemesInstalled();
@@ -3329,6 +3362,14 @@ function mountSettingsPanel(): SettingsPanel {
 	panel.setOnCliStatusChange((status) => {
 		cliUpdateStatus = status;
 		syncCliUpdateUiHint();
+	});
+	panel.setOnPiBinaryPathChange((path) => {
+		const previous = preferredPiBinaryPath;
+		applyPreferredPiBinaryPath(path);
+		recordDebugTrace(`pi-path-override updated path=${path ?? "-"}`);
+		if (previous !== preferredPiBinaryPath && preferredPiBinaryPath) {
+			chatView?.notify("Saved CLI binary path override. Use /reload to reconnect active runtimes.", "info");
+		}
 	});
 	panel.setOnClose(() => {
 		const workspace = getActiveWorkspace();

--- a/src/rpc/bridge.ts
+++ b/src/rpc/bridge.ts
@@ -11,6 +11,7 @@ export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhi
 
 export interface RpcStartOptions {
 	cliPath: string | null;
+	piPath?: string | null;
 	cwd: string;
 	provider?: string;
 	model?: string;
@@ -251,6 +252,7 @@ export class RpcBridge {
 	private pendingGeneration: number | null = null;
 	private lastStartOptions: RpcStartOptions | null = null;
 	private lastDiscoveryInfo: string | null = null;
+	private preferredPiPath: string | null = null;
 	private parseFailureCount = 0;
 
 	constructor(instanceId = "default") {
@@ -269,19 +271,41 @@ export class RpcBridge {
 		return this.lastDiscoveryInfo;
 	}
 
+	setPreferredPiPath(path: string | null): void {
+		this.preferredPiPath = this.normalizePathOverride(path);
+	}
+
+	getPreferredPiPath(): string | null {
+		return this.preferredPiPath;
+	}
+
+	private normalizePathOverride(value: string | null | undefined): string | null {
+		const trimmed = typeof value === "string" ? value.trim() : "";
+		return trimmed.length > 0 ? trimmed : null;
+	}
+
 	async start(options: RpcStartOptions): Promise<string> {
 		await this.ensureListeners();
 		this.pendingGeneration = (this.currentGeneration ?? 0) + 1;
 
+		const effectiveCliPath = this.normalizePathOverride(options.cliPath);
+		const effectivePiPath = this.normalizePathOverride(options.piPath) ?? this.preferredPiPath;
+		const startOptions: RpcStartOptions = {
+			...options,
+			cliPath: effectiveCliPath,
+			piPath: effectivePiPath,
+		};
+
 		try {
-			traceBridge(`start instance=${this.instanceId} cwd=${options.cwd}`);
+			traceBridge(`start instance=${this.instanceId} cwd=${startOptions.cwd}`);
 			const result = await invoke<RpcStartResult>("rpc_start", {
 				options: {
-					cli_path: options.cliPath ?? null,
-					cwd: options.cwd,
-					provider: options.provider || null,
-					model: options.model || null,
-					env: options.env || null,
+					cli_path: startOptions.cliPath ?? null,
+					pi_path: startOptions.piPath ?? null,
+					cwd: startOptions.cwd,
+					provider: startOptions.provider || null,
+					model: startOptions.model || null,
+					env: startOptions.env || null,
 				},
 				instanceId: this.instanceId,
 			});
@@ -291,7 +315,7 @@ export class RpcBridge {
 				? result.generation
 				: this.pendingGeneration;
 			this.pendingGeneration = null;
-			this.lastStartOptions = { ...options };
+			this.lastStartOptions = { ...startOptions };
 			this.lastDiscoveryInfo = result.discovery;
 			traceBridge(`started instance=${this.instanceId} generation=${this.currentGeneration ?? -1} discovery=${result.discovery}`);
 			this.emitToListeners({ type: "rpc_connected", discovery: result.discovery });
@@ -484,9 +508,16 @@ export class RpcBridge {
 
 	async runPiCliCommand(
 		args: string[],
-		options: { cwd?: string; env?: Record<string, string>; cliPath?: string | null } = {},
+		options: { cwd?: string; env?: Record<string, string>; cliPath?: string | null; piPath?: string | null } = {},
 	): Promise<PiCliCommandResult> {
-		const cliPath = typeof options.cliPath !== "undefined" ? options.cliPath : (this.lastStartOptions?.cliPath ?? null);
+		const cliPath = this.normalizePathOverride(
+			typeof options.cliPath !== "undefined" ? options.cliPath : (this.lastStartOptions?.cliPath ?? null),
+		);
+		const piPath = this.normalizePathOverride(
+			typeof options.piPath !== "undefined"
+				? options.piPath
+				: (this.preferredPiPath ?? this.lastStartOptions?.piPath ?? null),
+		);
 
 		return invoke<PiCliCommandResult>("run_pi_cli_command", {
 			options: {
@@ -494,6 +525,7 @@ export class RpcBridge {
 				cwd: options.cwd ?? null,
 				env: options.env ?? null,
 				cli_path: cliPath,
+				pi_path: piPath,
 			},
 		});
 	}
@@ -530,7 +562,8 @@ export class RpcBridge {
 	async getCliUpdateStatus(): Promise<CliUpdateStatus> {
 		return invoke<CliUpdateStatus>("get_cli_update_status", {
 			options: {
-				cli_path: this.lastStartOptions?.cliPath ?? null,
+				cli_path: this.normalizePathOverride(this.lastStartOptions?.cliPath ?? null),
+				pi_path: this.normalizePathOverride(this.preferredPiPath ?? this.lastStartOptions?.piPath ?? null),
 				cwd: this.lastStartOptions?.cwd ?? null,
 				env: this.lastStartOptions?.env ?? null,
 			},
@@ -540,7 +573,8 @@ export class RpcBridge {
 	async getPiChangelog(): Promise<PiChangelogResult> {
 		return invoke<PiChangelogResult>("get_pi_changelog", {
 			options: {
-				cli_path: this.lastStartOptions?.cliPath ?? null,
+				cli_path: this.normalizePathOverride(this.lastStartOptions?.cliPath ?? null),
+				pi_path: this.normalizePathOverride(this.preferredPiPath ?? this.lastStartOptions?.piPath ?? null),
 				cwd: this.lastStartOptions?.cwd ?? null,
 				env: this.lastStartOptions?.env ?? null,
 			},
@@ -797,12 +831,14 @@ class ActiveRpcBridgeProxy {
 
 	setActiveBridge(bridge: RpcBridge): void {
 		if (this.activeBridge === bridge) return;
+		const preferredPiPath = this.activeBridge.getPreferredPiPath();
 		const listeners = [...this.listenerUnsubscribers.keys()];
 		for (const unlisten of this.listenerUnsubscribers.values()) {
 			unlisten();
 		}
 		this.listenerUnsubscribers.clear();
 		this.activeBridge = bridge;
+		this.activeBridge.setPreferredPiPath(preferredPiPath);
 		for (const listener of listeners) {
 			this.listenerUnsubscribers.set(listener, this.activeBridge.onEvent(listener));
 		}
@@ -818,6 +854,14 @@ class ActiveRpcBridgeProxy {
 
 	get discoveryInfo(): string | null {
 		return this.activeBridge.discoveryInfo;
+	}
+
+	setPreferredPiPath(path: string | null): void {
+		this.activeBridge.setPreferredPiPath(path);
+	}
+
+	getPreferredPiPath(): string | null {
+		return this.activeBridge.getPreferredPiPath();
 	}
 
 	getInstanceId(): string {
@@ -973,7 +1017,7 @@ class ActiveRpcBridgeProxy {
 
 	async runPiCliCommand(
 		args: string[],
-		options: { cwd?: string; env?: Record<string, string>; cliPath?: string | null } = {},
+		options: { cwd?: string; env?: Record<string, string>; cliPath?: string | null; piPath?: string | null } = {},
 	): Promise<PiCliCommandResult> {
 		return this.activeBridge.runPiCliCommand(args, options);
 	}

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -8129,6 +8129,10 @@ body.file-split-resizing #file-split-resize-handle::after {
 	margin-bottom: 0;
 }
 
+.settings-row-top {
+	align-items: flex-start;
+}
+
 .settings-label {
 	font-size: 13px;
 	font-weight: 600;
@@ -8171,6 +8175,17 @@ body.file-split-resizing #file-split-resize-handle::after {
 .settings-select {
 	height: 32px;
 	padding: 0 8px;
+	border-radius: 9px;
+	border: 1px solid var(--border);
+	background: var(--bg-muted);
+	color: var(--text);
+	font-size: 12px;
+}
+
+.settings-path-input {
+	width: 100%;
+	height: 34px;
+	padding: 0 10px;
 	border-radius: 9px;
 	border: 1px solid var(--border);
 	background: var(--bg-muted);


### PR DESCRIPTION
## Summary

This hotfix addresses CLI discovery failures on desktop launches (especially Linux/npm custom prefix setups) and adds a user-facing manual override path.

## Changes

- Added **Settings → Updates → CLI binary path override** (browse/save/clear).
- Persisted `pi_path` in desktop app settings.
- Wired runtime + CLI command bridge to honor manual `pi_path` override.
- Added `~` expansion for explicit manual/env override paths.
- Improved Linux/macOS fallback discovery with extra npm-prefix candidates:
  - `~/.npm-global/bin/pi`
  - `~/.npm/bin/pi`
  - `NPM_CONFIG_PREFIX` / `PREFIX` based paths.
- Updated README features section (short + technical list).
- Added changelog entries under Unreleased.

## Validation

- `npm run check` ✅
- `cargo check --manifest-path src-tauri/Cargo.toml` ✅
- `npm run build:frontend` ✅
- `npm run tauri dev` launched successfully (manual override visible in Settings).

## Notes

This is designed as a fast hotfix branch targeting `main`.
